### PR TITLE
Feature/member by path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
 	"name": "code-for-ibmi",
-	"version": "0.5.1",
+	"version": "0.5.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "0.5.1",
+			"version": "0.5.3",
 			"license": "MIT",
 			"dependencies": {
 				"@bendera/vscode-webview-elements": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -567,7 +567,7 @@
 			},
 			{
 				"command": "code-for-ibmi.openMemberByPath",
-				"title": "Open Source File",
+				"title": "Open Source Member",
 				"category": "IBM i",
 				"icon": "$(files)"
 			},

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"onCommand:code-for-ibmi.updateMemberText",
 		"onCommand:code-for-ibmi.renameMember",
 		"onCommand:code-for-ibmi.searchSourceFile",
+		"onCommand:code-for-ibmi.openMemberByPath",
 		"onView:ifsBrowser",
 		"onCommand:code-for-ibmi.refreshIFSBrowser",
 		"onCommand:code-for-ibmi.changeHomeDirectory",
@@ -563,6 +564,12 @@
 				"command": "code-for-ibmi.searchSourceFile",
 				"title": "Search Source File",
 				"category": "IBM i"
+			},
+			{
+				"command": "code-for-ibmi.openMemberByPath",
+				"title": "Open Source File",
+				"category": "IBM i",
+				"icon": "$(files)"
 			},
 			{
 				"command": "code-for-ibmi.addSourceFile",

--- a/src/views/memberBrowser.js
+++ b/src/views/memberBrowser.js
@@ -343,11 +343,6 @@ module.exports = class memberBrowserProvider {
       }),
 
       vscode.commands.registerCommand(`code-for-ibmi.openMemberByPath`, async () => {
-        const connection = instance.getConnection();
-        const config = instance.getConfig();
-
-        let sourceFiles = config.sourceFileList;
-
         const searchFor = await vscode.window.showInputBox({
           prompt: `Enter source path (Format: LIB/SPF/NAME.ext)`
         });
@@ -356,11 +351,7 @@ module.exports = class memberBrowserProvider {
           const [path] = searchFor.match(/\w+\/\w+\/\w+\.\w+/);
           if (path) {
 
-            vscode.command = {
-              command: `code-for-ibmi.openEditable`,
-              title: `Open Member`,
-              arguments: [path]
-            };
+            vscode.commands.executeCommand(`code-for-ibmi.openEditable`, path);
           } else {
             vscode.window.showErrorMessage(`Format incorrect. Use LIB/SPF/NAME.ext`);
           }

--- a/src/views/memberBrowser.js
+++ b/src/views/memberBrowser.js
@@ -340,6 +340,31 @@ module.exports = class memberBrowserProvider {
         } else {
           //Running from command.
         }
+      }),
+
+      vscode.commands.registerCommand(`code-for-ibmi.openMemberByPath`, async () => {
+        const connection = instance.getConnection();
+        const config = instance.getConfig();
+
+        let sourceFiles = config.sourceFileList;
+
+        const searchFor = await vscode.window.showInputBox({
+          prompt: `Enter source path (Format: LIB/SPF/NAME.ext)`
+        });
+
+        if (searchFor) {
+          const [path] = searchFor.match(/\w+\/\w+\/\w+\.\w+/);
+          if (path) {
+
+            vscode.command = {
+              command: `code-for-ibmi.openEditable`,
+              title: `Open Member`,
+              arguments: [path]
+            };
+          } else {
+            vscode.window.showErrorMessage(`Format incorrect. Use LIB/SPF/NAME.ext`);
+          }
+        }
       })
     )
   }

--- a/src/views/memberBrowser.js
+++ b/src/views/memberBrowser.js
@@ -348,11 +348,12 @@ module.exports = class memberBrowserProvider {
         });
 
         if (searchFor) {
-          const [path] = searchFor.match(/\w+\/\w+\/\w+\.\w+/);
-          if (path) {
-
-            vscode.commands.executeCommand(`code-for-ibmi.openEditable`, path);
-          } else {
+          try { //The reason for the try is because match throws an error.
+            const [path] = searchFor.match(/\w+\/\w+\/\w+\.\w+/);
+            if (path) {
+              vscode.commands.executeCommand(`code-for-ibmi.openEditable`, path);
+            }
+          } catch (e) {
             vscode.window.showErrorMessage(`Format incorrect. Use LIB/SPF/NAME.ext`);
           }
         }


### PR DESCRIPTION
### Changes

Adds a new command to open a source member by path.

### Checklist

* [x] have tested my change
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] have added myself to the contributors' list in the README
* [x] **for feature PRs**: PR only includes one feature enhancement.

### Next Steps
- Extend this to also work for the IFS.
- Add a section to the README for custom keyboard shortcuts.

Closes #170
