### PR TITLE
Allow files with poundsigns to be opened (#169)

### DIFF
--- a/src/Instance.js
+++ b/src/Instance.js
@@ -243,9 +243,9 @@ module.exports = class Instance {
             let uri;
             if (path.startsWith(`/`)) {
               //IFS
-              uri = vscode.Uri.parse(path).with({scheme: `streamfile`});
+              uri = vscode.Uri.parse(path).with({scheme: `streamfile`, path});
             } else {
-              uri = vscode.Uri.parse(path).with({scheme: `member`});
+              uri = vscode.Uri.parse(path).with({scheme: `member`, path: `/${path}`});
             }
   
             try {

--- a/src/views/memberBrowser.js
+++ b/src/views/memberBrowser.js
@@ -436,7 +436,7 @@ class Member extends vscode.TreeItem {
     this.contextValue = `member`;
     this.description = member.text;
     this.path = path;
-    this.resourceUri = vscode.Uri.parse(path).with({scheme: `member`});
+    this.resourceUri = vscode.Uri.parse(path).with({scheme: `member`, path: `/${path}`});
     this.command = {
       command: `code-for-ibmi.openEditable`,
       title: `Open Member`,


### PR DESCRIPTION
### Changes

In IBM i land, it is not uncommon for files to include weird characters - in this case, a pound sign, or hash tag, depending on where you're from.

This PR fixes the issue where [VS Code's Uri class](https://code.visualstudio.com/api/references/vscode-api#Uri) was parsing a path such as `BARRY/QRPGLESRC/PGM#01.rpgle` as `BARRY/QRPGLESRC/PGM` and treating `01.rpgle` as the Uri fragment. Same goes for IFS paths.

This will close #169.

### Checklist

* [X] have tested my change
* [ ] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
