### PR TITLE
Show IFS listing, even if standard out is printed too (#168)

### DIFF
--- a/src/api/IBMi.js
+++ b/src/api/IBMi.js
@@ -222,6 +222,7 @@ module.exports = class IBMi {
    * @param {string} command 
    * @param {null|string} [directory] If null/not passed, will default to home directory
    * @param {number} [returnType] If not passed, will default to 0. Accepts 0 or 1
+   * @returns {Promise<string|{code: number, stdout: string, stderr: string}>}
    */
   async paseCommand(command, directory = this.config.homeDirectory, returnType = 0) {
     command = command.replace(/\$/g, `\\$`);

--- a/src/api/IBMiContent.js
+++ b/src/api/IBMiContent.js
@@ -279,10 +279,13 @@ module.exports = class IBMiContent {
    * @return {Promise<{type: "directory"|"streamfile", name: string, path: string}[]>} Resulting list
    */
   async getFileList(remotePath) {
-    let results = await this.ibmi.paseCommand(`ls -a -p ` + remotePath);
+    const result = await this.ibmi.paseCommand(`ls -a -p ` + remotePath, undefined, 1);
 
-    if (typeof results === `string` && results !== ``) {
-      let list = results.split(`\n`);
+    //@ts-ignore
+    const fileList = result.stdout;
+
+    if (typeof fileList === `string` && fileList !== ``) {
+      let list = fileList.split(`\n`);
 
       //Remove current and dir up.
       list = list.filter(item => item !== `../` && item !== `./`);


### PR DESCRIPTION
### Changes

An issue was reported where `ls` was writing to standard out, even if files existed but a single file had a badly encoded name. This solves that by always printing the file listing, even if there is an error.

### Checklist

* [X] have tested my change
* [ ] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
