### PR TITLE
Ability to tie a connection to a workspace (#181)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"Other"
 	],
 	"activationEvents": [
+		"onStartupFinished",
 		"onCommand:code-for-ibmi.connect",
 		"onCommand:code-for-ibmi.connectPrevious",
 		"onCommand:code-for-ibmi.disconnect",
@@ -182,6 +183,10 @@
 							}
 						}
 					}
+				},
+				"code-for-ibmi.vscode-ibmi-connection": {
+					"type": "string",
+					"description": "The default connection for this workspace. Not to be used at a global level."
 				},
 				"code-for-ibmi.logCompileOutput": {
 					"type": "boolean",

--- a/src/api/Configuration.js
+++ b/src/api/Configuration.js
@@ -43,7 +43,7 @@ module.exports = class Configuration {
   }
 
   /**
-   * Get a host config prop
+   * Get a config prop for current connection
    * @param {string} key 
    */
   get(key) {
@@ -56,7 +56,7 @@ module.exports = class Configuration {
   }
 
   /**
-   * Update configuration prop
+   * Update configuration prop for current connection
    * @param {string} key 
    * @param {any} value 
    */
@@ -75,7 +75,7 @@ module.exports = class Configuration {
   }
 
   /**
-   * Update many values
+   * Update many values for current connection
    * @param {{[NAME: string]: any}} props 
    */
   async setMany(props) {
@@ -92,16 +92,6 @@ module.exports = class Configuration {
 
       await globalData.update(`connectionSettings`, connections, vscode.ConfigurationTarget.Global);
     }
-  }
-
-  /**
-   * Set global extension config
-   * @param {string} key 
-   * @param {any} value 
-   */
-  static setGlobal(key, value) {
-    const globalData = vscode.workspace.getConfiguration(`code-for-ibmi`);
-    return globalData.update(key, value, vscode.ConfigurationTarget.Global);
   }
 
   /** Reload props from vscode settings */
@@ -144,10 +134,31 @@ module.exports = class Configuration {
 
   /**
    * Returns variable not specific to a host (e.g. a global config)
+   * Checks in workspace config first, and then global config
    * @param {string} prop 
    */
   static get(prop) {
     const globalData = vscode.workspace.getConfiguration(`code-for-ibmi`);
     return globalData.get(prop);
+  }
+
+  /**
+   * Set global extension config
+   * @param {string} key 
+   * @param {any} value 
+   */
+  static setGlobal(key, value) {
+    const globalData = vscode.workspace.getConfiguration(`code-for-ibmi`);
+    return globalData.update(key, value, vscode.ConfigurationTarget.Global);
+  }
+
+  /**
+   * Set workspace extension config
+   * @param {string} key 
+   * @param {any} value 
+   */
+  static setWorkspace(key, value) {
+    const globalData = vscode.workspace.getConfiguration(`code-for-ibmi`);
+    return globalData.update(key, value, vscode.ConfigurationTarget.Workspace);
   }
 }

--- a/src/extension.js
+++ b/src/extension.js
@@ -7,6 +7,7 @@ const vscode = require(`vscode`);
 
 let instance = require(`./Instance`);
 let {CustomUI, Field} = require(`./api/CustomUI`);
+const Configuration = require(`./api/Configuration`);
 
 const LoginPanel = require(`./webviews/login`);
 
@@ -71,6 +72,13 @@ function activate(context) {
       }
     })
   )
+
+  if (vscode.workspace.workspaceFile) {
+    const workspaceConnection = Configuration.get(`vscode-ibmi-connection`);
+    if (workspaceConnection) {
+      LoginPanel.LoginByName(context, workspaceConnection);
+    }
+  }
 
   return {instance, CustomUI, Field, baseContext: context};
 }


### PR DESCRIPTION
### Changes

This feature allows you to tie a connection to a workspace. We did this based on #179, where a user wanted to have different colours for different connections. It would have not been pretty to implement that into the code extension, so instead we make it so you can tie a connection to a workspace to have a better experience.

This adds:

* A new configuration item that is tied to the workspace instead of the global settings.
* A new popup to save the connection (after logging in) the workspace, if the user is in one.
* When you launch VS Code into a workspace, or when you open a workspace, you will automatically be prompted to connect that the workspace connection.

Will close #181 

### Checklist

* [X] have tested my change
* [ ] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [X] **for feature PRs**: PR only includes one feature enhancement.
