### PR TITLE
Fix for downloading IFS content on Windows

### DIFF
--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -274,15 +274,22 @@ module.exports = class ifsBrowserProvider {
 
           } else {
             //Get filename from path on server
-            const filename = node.path.replace(/^.*[\\\/]/, ``);
+            const filename = path.basename(node.path);
 
             const remoteFilepath = path.join(os.homedir(), filename);
 
             let localFilepath = await vscode.window.showSaveDialog({defaultUri: vscode.Uri.file(remoteFilepath)});
 
             if (localFilepath) {
+              let localPath = localFilepath.path;
+              if (process.platform === `win32`) {
+                //Issue with getFile not working propertly on Windows
+                //when there was a / at the start.
+                if (localPath[0] === `/`) localPath = localPath.substr(1);
+              }
+
               try {
-                await client.getFile(localFilepath.path, node.path);
+                await client.getFile(localPath, node.path);
                 vscode.window.showInformationMessage(`File was downloaded.`);
               } catch (e) {
                 vscode.window.showErrorMessage(`Error downloading streamfile! ${e}`);


### PR DESCRIPTION
### Changes

Fixes an issue where downloading content from the IFS would crash due to an invalid path.

### Checklist

* [X] have tested my change
* [ ] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
