### PR TITLE
Allow the user to have many library lists (#204)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -257,11 +257,20 @@ An array for the user library list. Highest item of the library list goes first.
 ]
 ```
 
+##### Library list profiles
+
+It is possible to save a library list's current state, so you can change and revert back to it later. We call that state a 'library list profile'.
+
+You can save the current library list into a profile by using the save button on the Library List view. You can provide it with a unique name, or use an existing one to overwrite an existing profile.
+
+To load a profile, which would set the library list, you can use the list/load button on the Library List view.
+
 #### Current library
 
 The library which will be set as the current library during compilation.
 
 You can change the current library with the 'Change build library' command (F1 -> Change build library).
+
 #### Home Directory
 
 Home directory for user. This directory is also the root for the IFS browser.
@@ -384,7 +393,7 @@ You can now right click and click 'Search' on IFS directories and source files t
 
 ### Overtype
 
-VS Code  works in "insert" mode. This can be annoying when editing a fixed mode source, for example DDS. Fortunately there is an [Overtype extension](https://marketplace.visualstudio.com/items?itemName=DrMerfy.overtype) that allows you to toggle between insert and  overtype, and can also display the current mode in the status bar.
+VS Code works in "insert" mode. This can be annoying when editing a fixed mode source, for example DDS. Fortunately there is an [Overtype extension](https://marketplace.visualstudio.com/items?itemName=DrMerfy.overtype) that allows you to toggle between insert and  overtype, and can also display the current mode in the status bar.
 
 ## Extension Development
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
 		"onCommand:code-for-ibmi.removeFromLibraryList",
 		"onCommand:code-for-ibmi.moveLibraryUp",
 		"onCommand:code-for-ibmi.moveLibraryDown",
+		"onCommand:code-for-ibmi.saveLibraryListProfile",
+		"onCommand:code-for-ibmi.loadLibraryListProfile",
 		"onView:memberBrowser",
 		"onCommand:code-for-ibmi.refreshMemberBrowser",
 		"onCommand:code-for-ibmi.createMember",
@@ -139,6 +141,30 @@
 								},
 								"default": [],
 								"description": "Library list. Used in actions. Highest first."
+							},
+							"libraryListProfiles": {
+								"type": "array",
+								"items": {
+									"type": "object",
+									"title": "Library list profile",
+									"properties": {
+										"name": {
+											"type": "string",
+											"description": "Library list profile name"
+										},
+										"list": {
+											"type": "array",
+											"items": {
+												"type": "string",
+												"title": "Library"
+											},
+											"default": [],
+											"description": "Library list. Highest first."
+										}
+									}
+								},
+								"default": [],
+								"description": "A collection of library lists to easily switch between them on this system."
 							},
 							"homeDirectory": {
 								"type": "string",
@@ -556,6 +582,18 @@
 				"icon": "$(arrow-down)"
 			},
 			{
+				"command": "code-for-ibmi.saveLibraryListProfile",
+				"title": "Save current library list into profile",
+				"category": "IBM i",
+				"icon": "$(save-as)"
+			},
+			{
+				"command": "code-for-ibmi.loadLibraryListProfile",
+				"title": "Set library list to profile",
+				"category": "IBM i",
+				"icon": "$(list-tree)"
+			},
+			{
 				"command": "code-for-ibmi.runActionFromView",
 				"title": "Run Action",
 				"category": "IBM i"
@@ -792,6 +830,16 @@
 				},
 				{
 					"command": "code-for-ibmi.refreshLibraryListView",
+					"group": "navigation",
+					"when": "view == libraryListView"
+				},
+				{
+					"command": "code-for-ibmi.saveLibraryListProfile",
+					"group": "navigation",
+					"when": "view == libraryListView"
+				},
+				{
+					"command": "code-for-ibmi.loadLibraryListProfile",
 					"group": "navigation",
 					"when": "view == libraryListView"
 				},

--- a/src/api/Configuration.js
+++ b/src/api/Configuration.js
@@ -20,6 +20,9 @@ module.exports = class Configuration {
     /** @type {string[]} */
     this.libraryList = base.libraryList || [];
 
+    /** @type {{name: string, list: string[]}[]} */
+    this.libraryListProfiles = base.libraryListProfiles || [];
+
     /** @type {string} */
     this.homeDirectory = base.homeDirectory || `.`;
 

--- a/src/views/libraryListView.js
+++ b/src/views/libraryListView.js
@@ -132,15 +132,20 @@ module.exports = class memberBrowserProvider {
         const currentProfiles = config.libraryListProfiles;
         const availableProfiles = currentProfiles.map(profile => profile.name);
 
-        const chosenProfile = await vscode.window.showQuickPick(availableProfiles);
+        if (availableProfiles.length > 0) {
+          const chosenProfile = await vscode.window.showQuickPick(availableProfiles);
 
-        if (chosenProfile) {
-          const libraryList = currentProfiles.find(profile => profile.name === chosenProfile);
+          if (chosenProfile) {
+            const libraryList = currentProfiles.find(profile => profile.name === chosenProfile);
 
-          if (libraryList) {
-            await config.set(`libraryList`, libraryList.list);
-            this.refresh();
+            if (libraryList) {
+              await config.set(`libraryList`, libraryList.list);
+              this.refresh();
+            }
           }
+
+        } else {
+          vscode.window.showInformationMessage(`No library list profiles exist for this system.`);
         }
       })
     )

--- a/src/views/libraryListView.js
+++ b/src/views/libraryListView.js
@@ -99,6 +99,50 @@ module.exports = class memberBrowserProvider {
 
         }
       }),
+
+      vscode.commands.registerCommand(`code-for-ibmi.saveLibraryListProfile`, async () => {
+        const config = instance.getConfig();
+
+        const libraryList = config.libraryList;
+        let currentProfiles = config.libraryListProfiles;
+
+        const profileName = await vscode.window.showInputBox({
+          prompt: `Name of library list profile`
+        });
+
+        if (profileName) {
+          const existingIndex = currentProfiles.findIndex(profile => profile.name.toUpperCase() === profileName.toUpperCase());
+
+          if (existingIndex >= 0) {
+            currentProfiles[existingIndex].list = libraryList;
+          } else {
+            currentProfiles.push({
+              name: profileName,
+              list: libraryList
+            });
+          }
+
+          await config.set(`libraryListProfiles`, currentProfiles);
+        }
+      }),
+
+      vscode.commands.registerCommand(`code-for-ibmi.loadLibraryListProfile`, async () => {
+        const config = instance.getConfig();
+
+        const currentProfiles = config.libraryListProfiles;
+        const availableProfiles = currentProfiles.map(profile => profile.name);
+
+        const chosenProfile = await vscode.window.showQuickPick(availableProfiles);
+
+        if (chosenProfile) {
+          const libraryList = currentProfiles.find(profile => profile.name === chosenProfile);
+
+          if (libraryList) {
+            await config.set(`libraryList`, libraryList.list);
+            this.refresh();
+          }
+        }
+      })
     )
   }
 


### PR DESCRIPTION
### Changes

This adds two new buttons to the library list view that will allow users to save library lists (namely a Library List Profile) and change between them.

Will close #204.

### Checklist

* [X] have tested my change
* [x] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [X] have added myself to the contributors' list in the README
* [X] **for feature PRs**: PR only includes one feature enhancement.
