### PR TITLE
Added functionality to upload and download source members.

### DIFF
--- a/package.json
+++ b/package.json
@@ -663,6 +663,16 @@
 				"icon": "$(files)"
 			},
 			{
+				"command": "code-for-ibmi.downloadMemberAsFile",
+				"title": "Download",
+				"category": "IBM i"
+			},
+			{
+				"command": "code-for-ibmi.uploadAndReplaceMemberAsFile",
+				"title": "Upload and replace",
+				"category": "IBM i"
+			},
+			{
 				"command": "code-for-ibmi.refreshIFSBrowser",
 				"title": "Refresh IFS List",
 				"category": "IBM i",
@@ -972,6 +982,16 @@
 					"command": "code-for-ibmi.renameMember",
 					"when": "view == memberBrowser && viewItem == member",
 					"group": "2_memberStuff@3"
+				},
+				{
+					"command": "code-for-ibmi.downloadMemberAsFile",
+					"when": "view == memberBrowser && viewItem == member",
+					"group": "3_memberTransfer@1"
+				},
+				{
+					"command": "code-for-ibmi.uploadAndReplaceMemberAsFile",
+					"when": "view == memberBrowser && viewItem == member",
+					"group": "3_memberTransfer@2"
 				},
 				{
 					"command": "code-for-ibmi.runActionFromView",

--- a/src/views/memberBrowser.js
+++ b/src/views/memberBrowser.js
@@ -309,7 +309,7 @@ module.exports = class memberBrowserProvider {
             contentApi.uploadMemberContent(asp, lib, file, name, data);
             vscode.window.showInformationMessage(`Member was uploaded.`);
           } catch (e) {
-            vscode.window.showErrorMessage(`Error reading file! ${e}`);
+            vscode.window.showErrorMessage(`Error uploading content to member! ${e}`);
           }
         }
   
@@ -350,7 +350,7 @@ module.exports = class memberBrowserProvider {
               await writeFileAsync(localPath, memberContent, `utf8`);
               vscode.window.showInformationMessage(`Member was downloaded.`);
             } catch (e) {
-              vscode.window.showErrorMessage(`Error downloading streamfile! ${e}`);
+              vscode.window.showErrorMessage(`Error downloading member! ${e}`);
             }
           }
 

--- a/src/views/memberBrowser.js
+++ b/src/views/memberBrowser.js
@@ -1,9 +1,14 @@
 
 const vscode = require(`vscode`);
+const os = require(`os`);
+let fs = require(`fs`);
+const util = require(`util`);
 
 let instance = require(`../Instance`);
 const Configuration = require(`../api/Configuration`);
 const Search = require(`../api/Search`);
+
+const writeFileAsync = util.promisify(fs.writeFile);
 
 module.exports = class memberBrowserProvider {
   /**
@@ -271,6 +276,84 @@ module.exports = class memberBrowserProvider {
           }
 
           
+        } else {
+          //Running from command.
+        }
+      }),
+
+      vscode.commands.registerCommand(`code-for-ibmi.uploadAndReplaceMemberAsFile`, async (node) => {
+        const contentApi = instance.getContent();
+
+        let originPath = await vscode.window.showOpenDialog({ defaultUri: vscode.Uri.file(os.homedir()) });
+ 
+        if (originPath) {
+          const path = node.path.split(`/`);
+          let asp, lib, file, fullName;
+      
+          if (path.length === 3) {
+            lib = path[0];
+            file = path[1];
+            fullName = path[2];
+          } else {
+            asp = path[0];
+            lib = path[1];
+            file = path[2];
+            fullName = path[3];
+          }
+
+          const name = fullName.substring(0, fullName.lastIndexOf(`.`));
+
+          const data = fs.readFileSync(originPath[0].fsPath, `utf8`);
+          
+          try {
+            contentApi.uploadMemberContent(asp, lib, file, name, data);
+            vscode.window.showInformationMessage(`Member was uploaded.`);
+          } catch (e) {
+            vscode.window.showErrorMessage(`Error reading file! ${e}`);
+          }
+        }
+  
+      }),
+
+      vscode.commands.registerCommand(`code-for-ibmi.downloadMemberAsFile`, async (node) => {
+        const contentApi = instance.getContent();
+
+        const path = node.path.split(`/`);
+        let asp, lib, file, fullName;
+    
+        if (path.length === 3) {
+          lib = path[0];
+          file = path[1];
+          fullName = path[2];
+        } else {
+          asp = path[0];
+          lib = path[1];
+          file = path[2];
+          fullName = path[3];
+        }
+    
+        const name = fullName.substring(0, fullName.lastIndexOf(`.`));
+        const memberContent = await contentApi.downloadMemberContent(asp, lib, file, name);
+
+        if (node) {
+          let localFilepath = await vscode.window.showSaveDialog({ defaultUri: vscode.Uri.file(os.homedir() + `/` + fullName) });
+
+          if (localFilepath) {
+            let localPath = localFilepath.path;
+            if (process.platform === `win32`) {
+              //Issue with getFile not working propertly on Windows
+              //when there was a / at the start.
+              if (localPath[0] === `/`) localPath = localPath.substr(1);
+            }
+
+            try {
+              await writeFileAsync(localPath, memberContent, `utf8`);
+              vscode.window.showInformationMessage(`Member was downloaded.`);
+            } catch (e) {
+              vscode.window.showErrorMessage(`Error downloading streamfile! ${e}`);
+            }
+          }
+
         } else {
           //Running from command.
         }


### PR DESCRIPTION
### Changes

Added functionality to upload and download source members. (See issue #46)

It's now possible to up- and download source members by right-clicking the member name in the member browser.

Something to consider: The path routines in code-for-ibmi.uploadAndReplaceMemberAsFile and code-for-ibmi.downloadMemberAsFile are pretty similar to the routines in qsysFs.readFile. Maybe it make more sense to exclude it into an own util class. As far as I can tell, it makes more sense from my point of view to get the qsysFs stuff into the api. 

### Checklist

* [x] have tested my change
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] have added myself to the contributors' list in the README
* [x] **for feature PRs**: PR only includes one feature enhancement.
