### PR TITLE
Library creation via object browser added

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
 		"onView:objectBrowser",
 		"onCommand:code-for-ibmi.refreshObjectList",
 		"onCommand:code-for-ibmi.createSourceFile",
+		"onCommand:code-for-ibmi.createLibrary",
 		"onCommand:code-for-ibmi.addLibraryToObjectBrowser",
 		"onCommand:code-for-ibmi.removeLibraryFromObjectBrowser",
 		"onView:databaseBrowser",
@@ -733,6 +734,12 @@
 				"icon": "$(new-folder)"
 			},
 			{
+				"command": "code-for-ibmi.createLibrary",
+				"title": "Create new library",
+				"category": "IBM i",
+				"icon": "$(repo-create)"
+			},
+			{
 				"command": "code-for-ibmi.removeLibraryFromObjectBrowser",
 				"title": "Remove library from view",
 				"category": "IBM i",
@@ -885,6 +892,11 @@
 				},
 				{
 					"command": "code-for-ibmi.addLibraryToObjectBrowser",
+					"group": "navigation",
+					"when": "view == objectBrowser"
+				},
+				{
+					"command": "code-for-ibmi.createLibrary",
 					"group": "navigation",
 					"when": "view == objectBrowser"
 				},

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -68,6 +68,37 @@ module.exports = class objectBrowserProvider {
           if (Configuration.get(`autoRefresh`)) this.refresh();
         }
       }),
+
+      vscode.commands.registerCommand(`code-for-ibmi.createLibrary`, async () => {
+        const config = instance.getConfig();
+        const connection = instance.getConnection();
+
+        const newLibrary = await vscode.window.showInputBox({
+          prompt: `Name of new library`
+        });
+
+        if (!newLibrary) return; 
+
+        let libraries = config.objectBrowserList;
+
+        try {
+          await connection.remoteCommand(
+            `CRTLIB LIB(${newLibrary})`
+          );
+        } catch (e) {
+          vscode.window.showErrorMessage(`Cannot create library "${newLibrary}": ${e}`);
+          return;
+        }
+        
+        if (newLibrary.length <= 10) {
+          libraries.push(newLibrary.toUpperCase());
+          await config.set(`objectBrowserList`, libraries);
+          if (Configuration.get(`autoRefresh`)) this.refresh();
+        } else {
+          vscode.window.showErrorMessage(`Library name too long.`);
+        }
+      }),
+
       vscode.commands.registerCommand(`code-for-ibmi.createSourceFile`, async (node) => {
         if (node) {
           //Running from right click


### PR DESCRIPTION
### Changes

Libraries can now be created via the object browser. You'll find a new + icon on the right of "OBJECT BROWSER". This feature was requested in #194.

Please check the following things before merging:
1. Is it working properly? Unfortunately it's not allowed to create new libraries on PUB400. So I couldn't test it properly.
2. Is the "+" icon good for this use case? In my opinion the icon with the directory and a "+" would fit better but it was already used.

### Checklist

* [x] have tested my change
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] have added myself to the contributors' list in the README
* [x] **for feature PRs**: PR only includes one feature enhancement.
