### PR TITLE
Added 2 COBOL compile options

### DIFF
--- a/package.json
+++ b/package.json
@@ -314,7 +314,7 @@
 							"CBLLE",
 							"CBL"
 						    ],
-						    "name": "Create ALL-in-one PGM CBLLE (CRTBNDCBL)",
+						    "name": "Create Bound COBOL Program (CRTBNDCBL)",
 						    "command": "CRTBNDCBL (&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*SOURCE) DBGVIEW(*SOURCE)"
 						},
 						{

--- a/package.json
+++ b/package.json
@@ -309,6 +309,24 @@
 					},
 					"default": [
 						{
+						    "type": "member",
+						    "extensions": [
+							"CBLLE",
+							"CBL"
+						    ],
+						    "name": "Create ALL-in-one PGM CBLLE (CRTBNDCBL)",
+						    "command": "CRTBNDCBL (&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*SOURCE) DBGVIEW(*SOURCE)"
+						},
+						{
+						    "type": "member",
+						    "extensions": [
+							"CBLLE",
+							"CBL"
+						    ],
+						    "name": "Create Module CBLLE (CRTCBLMOD)",
+						    "command": "CRTCBLMOD MODULE(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*SOURCE) DBGVIEW(*SOURCE)"
+						},
+						{
 							"type": "member",
 							"extensions": [
 								"RPGLE",


### PR DESCRIPTION
Created a compiled COBOL module option
Created a compiled COBOL bundle(Module and Program) option


### Changes

Added 2 compile option for COBOL:
{
            "type": "member",
            "extensions": [
                "CBLLE",
                "CBL"
            ],
            "name": "Create ALL-in-one PGM CBLLE (CRTBNDCBL)",
            "command": "CRTBNDCBL (&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*SOURCE) DBGVIEW(*SOURCE)"
        },
        {
            "type": "member",
            "extensions": [
                "CBLLE",
                "CBL"
            ],
            "name": "Create Module CBLLE (CRTCBLMOD)",
            "command": "CRTCBLMOD MODULE(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*SOURCE) DBGVIEW(*SOURCE)"
        },

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
