### PR TITLE
Add "Rename" to "Move object" menu command

### DIFF
--- a/package.json
+++ b/package.json
@@ -697,7 +697,7 @@
 			},
 			{
 				"command": "code-for-ibmi.moveIFS",
-				"title": "Move object",
+				"title": "Rename or Move object",
 				"category": "IBM i",
 				"icon": "$(files)"
 			},


### PR DESCRIPTION
The Move function can let the user Rename the IFS file, but that wasn't clear from the label.

If "Rename or Move object" is too long, "Rename/Move object" might also work.


### Changes

Description of change here.

### Checklist

* [ ] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
