### PR TITLE
Implementation of IFS shortcuts

### DIFF
--- a/package.json
+++ b/package.json
@@ -737,9 +737,15 @@
 			},
 			{
 				"command": "code-for-ibmi.addIFSShortcut",
-				"title": "Add shortcut",
+				"title": "Add IFS shortcut",
 				"category": "IBM i",
 				"icon": "$(add)"
+			},
+			{
+				"command": "code-for-ibmi.removeIFSShortcut",
+				"title": "Remove IFS shortcut",
+				"category": "IBM i",
+				"icon": "$(remove)"
 			},
 			{
 				"command": "code-for-ibmi.refreshObjectList",
@@ -893,6 +899,11 @@
 				},
 				{
 					"command": "code-for-ibmi.addIFSShortcut",
+					"group": "navigation",
+					"when": "view == ifsBrowser"
+				},
+				{
+					"command": "code-for-ibmi.removeIFSShortcut",
 					"group": "navigation",
 					"when": "view == ifsBrowser"
 				},

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"onCommand:code-for-ibmi.openFileByPath",
 		"onView:ifsBrowser",
 		"onCommand:code-for-ibmi.refreshIFSBrowser",
-		"onCommand:code-for-ibmi.changeHomeDirectory",
+		"onCommand:code-for-ibmi.changeWorkingDirectory",
 		"onCommand:code-for-ibmi.createDirectory",
 		"onCommand:code-for-ibmi.createStreamfile",
 		"onCommand:code-for-ibmi.uploadStreamfile",
@@ -68,6 +68,7 @@
 		"onCommand:code-for-ibmi.deleteIFS",
 		"onCommand:code-for-ibmi.searchIFS",
 		"onCommand:code-for-ibmi.downloadStreamfile",
+		"onCommand:code-for-ibmi.addShortcut",
 		"onView:objectBrowser",
 		"onCommand:code-for-ibmi.refreshObjectList",
 		"onCommand:code-for-ibmi.createSourceFile",
@@ -166,6 +167,15 @@
 								},
 								"default": [],
 								"description": "A collection of library lists to easily switch between them on this system."
+							},
+							"ifsShortcuts": {
+								"type": "array",
+								"items": {
+									"type": "string",
+									"title": "Path to directory"
+								},
+								"default": [],
+								"description": "List of directories shown in IFS Browser"
 							},
 							"homeDirectory": {
 								"type": "string",
@@ -680,8 +690,8 @@
 				"icon": "$(refresh)"
 			},
 			{
-				"command": "code-for-ibmi.changeHomeDirectory",
-				"title": "Change directory",
+				"command": "code-for-ibmi.changeWorkingDirectory",
+				"title": "Change working directory",
 				"category": "IBM i",
 				"icon": "$(root-folder)"
 			},
@@ -724,6 +734,12 @@
 				"title": "Upload",
 				"category": "IBM i",
 				"icon": "$(cloud-upload)"
+			},
+			{
+				"command": "code-for-ibmi.addIFSShortcut",
+				"title": "Add shortcut",
+				"category": "IBM i",
+				"icon": "$(add)"
 			},
 			{
 				"command": "code-for-ibmi.refreshObjectList",
@@ -871,27 +887,12 @@
 					"when": "view == memberBrowser"
 				},
 				{
-					"command": "code-for-ibmi.createDirectory",
+					"command": "code-for-ibmi.changeWorkingDirectory",
 					"group": "navigation",
 					"when": "view == ifsBrowser"
 				},
 				{
-					"command": "code-for-ibmi.createStreamfile",
-					"group": "navigation",
-					"when": "view == ifsBrowser"
-				},
-				{
-					"command": "code-for-ibmi.uploadStreamfile",
-					"group": "navigation",
-					"when": "view == ifsBrowser"
-				},
-				{
-					"command": "code-for-ibmi.changeHomeDirectory",
-					"group": "navigation",
-					"when": "view == ifsBrowser"
-				},
-				{
-					"command": "code-for-ibmi.searchIFS",
+					"command": "code-for-ibmi.addIFSShortcut",
 					"group": "navigation",
 					"when": "view == ifsBrowser"
 				},
@@ -1034,6 +1035,16 @@
 					"command": "code-for-ibmi.searchIFS",
 					"when": "view == ifsBrowser && viewItem == directory",
 					"group": "3_ifsStuff@1"
+				},
+				{
+					"command": "code-for-ibmi.addIFSShortcut",
+					"when": "view == ifsBrowser && viewItem == directory",
+					"group": "3_ifsStuff@2"
+				},
+				{
+					"command": "code-for-ibmi.changeWorkingDirectory",
+					"when": "view == ifsBrowser && viewItem == directory",
+					"group": "3_ifsStuff@3"
 				},
 				{
 					"command": "code-for-ibmi.downloadStreamfile",

--- a/src/api/Configuration.js
+++ b/src/api/Configuration.js
@@ -23,6 +23,9 @@ module.exports = class Configuration {
     /** @type {{name: string, list: string[]}[]} */
     this.libraryListProfiles = base.libraryListProfiles || [];
 
+    /** @type {string[]} */
+    this.ifsShortcuts = base.ifsShortcuts || [];
+
     /** @type {string} */
     this.homeDirectory = base.homeDirectory || `.`;
 

--- a/src/api/IBMi.js
+++ b/src/api/IBMi.js
@@ -96,6 +96,16 @@ module.exports = class IBMi {
           }
         }
 
+        //Set a default IFS listing
+        if (this.config.ifsShortcuts.length === 0) {
+          if (homeDirSet) {
+            await this.config.set(`ifsShortcuts`, [this.config.homeDirectory]);
+          } else {
+            await this.config.set(`ifsShortcuts`, [`/`]);
+          }
+        }
+
+
         progress.report({
           message: `Checking library list configuration.`
         });

--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -21,27 +21,61 @@ module.exports = class ifsBrowserProvider {
         this.refresh();
       }),
 
-      vscode.commands.registerCommand(`code-for-ibmi.changeHomeDirectory`, async () => {
-        const connection = instance.getConnection();
+      vscode.commands.registerCommand(`code-for-ibmi.changeWorkingDirectory`, async (node) => {
         const config = instance.getConfig();
         const homeDirectory = config.homeDirectory;
 
-        const newDirectory = await vscode.window.showInputBox({
-          prompt: `Changing home directory`,
-          value: homeDirectory
-        });
+        let newDirectory;
+
+        if (node) {
+          newDirectory = node.path;
+        } else {
+          newDirectory = await vscode.window.showInputBox({
+            prompt: `Changing working directory`,
+            value: homeDirectory
+          });
+        }
 
         try {
           if (newDirectory && newDirectory !== homeDirectory) {
             await config.set(`homeDirectory`, newDirectory);
-            
-            if (Configuration.get(`autoRefresh`)) this.refresh();
+
+            vscode.window.showInformationMessage(`Working directory changed to ${newDirectory}.`);
           }
         } catch (e) {
           console.log(e);
         }
       }),
 
+      vscode.commands.registerCommand(`code-for-ibmi.addIFSShortcut`, async (node) => {
+        const config = instance.getConfig();
+
+        let newDirectory;
+
+        let shortcuts = config.ifsShortcuts;
+
+        if (node) {
+          newDirectory = node.path;
+        } else {
+          newDirectory = await vscode.window.showInputBox({
+            prompt: `Path to IFS directory`,
+          });
+        }
+
+        try {
+          if (newDirectory) {
+            newDirectory = newDirectory.trim();
+            
+            if (!shortcuts.includes(newDirectory)) {
+              shortcuts.push(newDirectory);
+              await config.set(`ifsShortcuts`, shortcuts);
+              if (Configuration.get(`autoRefresh`)) this.refresh();
+            }
+          }
+        } catch (e) {
+          console.log(e);
+        }
+      }),
 
       vscode.commands.registerCommand(`code-for-ibmi.createDirectory`, async (node) => {
         const connection = instance.getConnection();
@@ -295,7 +329,7 @@ module.exports = class ifsBrowserProvider {
     if (connection) {
       const config = instance.getConfig();
       
-      if (element) { //Chosen SPF
+      if (element) { //Chosen directory
         //Fetch members
         console.log(element.path);
 
@@ -314,11 +348,12 @@ module.exports = class ifsBrowserProvider {
         }
 
       } else {
-        const objects = await content.getFileList(config.homeDirectory);
+        items = config.ifsShortcuts.map(directory => new Object(`directory`, directory, directory));
+        // const objects = await content.getFileList(config.homeDirectory);
 
-        for (let object of objects) {
-          items.push(new Object(object.type, object.name, object.path));
-        }
+        // for (let object of objects) {
+        //   items.push(new Object(object.type, object.name, object.path));
+        // }
       }
     }
 

--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -77,6 +77,38 @@ module.exports = class ifsBrowserProvider {
         }
       }),
 
+      vscode.commands.registerCommand(`code-for-ibmi.removeIFSShortcut`, async (node) => {
+        const config = instance.getConfig();
+
+        let removeDir;
+
+        let shortcuts = config.ifsShortcuts;
+
+        if (node) {
+          removeDir = node.path;
+        } else {
+          removeDir = await vscode.window.showQuickPick(shortcuts, {
+            placeHolder: `Select IFS directory to remove`,
+          });
+        }
+
+        try {
+          if (removeDir) {
+            removeDir = removeDir.trim();
+
+            const inx = shortcuts.indexOf(removeDir);
+            
+            if (inx >= 0) {
+              shortcuts.splice(inx, 1);
+              await config.set(`ifsShortcuts`, shortcuts);
+              if (Configuration.get(`autoRefresh`)) this.refresh();
+            }
+          }
+        } catch (e) {
+          console.log(e);
+        }
+      }),
+
       vscode.commands.registerCommand(`code-for-ibmi.createDirectory`, async (node) => {
         const connection = instance.getConnection();
         const config = instance.getConfig();


### PR DESCRIPTION
### Changes

Implements the ability to have access to many IFS directories at the same time - these are called Shortcuts.

To do:

* [x] Ability to right-click and remove a shortcut
* [x] Update docs (docs don't currently have anything on the IFS browser?)
* [x] Walkthrough updated (has to be done in a separate repo)

### Checklist

* [X] have tested my change
* [ ] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [X] **for feature PRs**: PR only includes one feature enhancement.
