### PR TITLE
Support *ALL as source file name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
 	"name": "code-for-ibmi",
-	"version": "0.5.3",
+	"version": "0.6.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "0.5.3",
+			"name": "code-for-ibmi",
+			"version": "0.6.7",
 			"license": "MIT",
 			"dependencies": {
 				"@bendera/vscode-webview-elements": "^0.3.0",
@@ -713,7 +714,6 @@
 			"dependencies": {
 				"anymatch": "~3.1.1",
 				"braces": "~3.0.2",
-				"fsevents": "~2.3.1",
 				"glob-parent": "~5.1.0",
 				"is-binary-path": "~2.1.0",
 				"is-glob": "~4.0.1",

--- a/src/api/IBMiContent.js
+++ b/src/api/IBMiContent.js
@@ -230,6 +230,7 @@ module.exports = class IBMiContent {
         SELECT
           (b.avgrowsize - 12) as MBMXRL,
           a.iasp_number as MBASP,
+          a.table_name AS MBFILE,
           b.system_table_member as MBNAME,
           b.source_type as MBSEU2,
           b.partition_text as MBMTXT
@@ -238,8 +239,8 @@ module.exports = class IBMiContent {
             ON b.table_schema = a.table_schema AND
               b.table_name = a.table_name
         WHERE
-          a.table_schema = '${lib}' And
-          a.table_name = '${spf}'
+          a.table_schema = '${lib}' 
+          ${spf !== `*ALL` ? `AND a.table_name = '${spf}'` : ``}
       `)
 
     } else {
@@ -263,11 +264,11 @@ module.exports = class IBMiContent {
     return results.map(result => ({
       asp: asp,
       library: lib,
-      file: spf,
+      file: result.MBFILE,
       name: result.MBNAME,
       extension: result.MBSEU2,
       recordLength: Number(result.MBMXRL),
-      text: result.MBMTXT
+      text: `${result.MBMTXT || ``}${spf === `*ALL` ? ` (${result.MBFILE})` : ``}`.trim()
     })).sort((a, b) => {
       if (a.name < b.name) { return -1; }
       if (a.name > b.name) { return 1; }


### PR DESCRIPTION
### Changes

Allow the user of `*ALL` for the source file name in the source file shortcuts.

![image](https://user-images.githubusercontent.com/3708366/132063499-aee548be-d3f9-4485-a5b5-48341e5f0f7b.png)

Closes #269.

### Checklist

* [X] have tested my change
* [ ] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [X] **for feature PRs**: PR only includes one feature enhancement.
