### PR TITLE
The ability to specify directories to ignore in the search

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,6 +212,15 @@
 						}
 					}
 				},
+				"code-for-ibmi.grepIgnoreDirs": {
+					"type": "array",
+					"items": {
+						"type": "string",
+						"title": "IFS directory"
+					},
+					"default": ["node_modules", "vendor"],
+					"description": "List of directories that will be ignored when searching the IFS."
+				},
 				"code-for-ibmi.logCompileOutput": {
 					"type": "boolean",
 					"default": false,

--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
 						"type": "string",
 						"title": "IFS directory"
 					},
-					"default": ["node_modules", "vendor"],
+					"default": ["node_modules", ".git", "vendor"],
 					"description": "List of directories that will be ignored when searching the IFS."
 				},
 				"code-for-ibmi.logCompileOutput": {

--- a/src/api/Search.js
+++ b/src/api/Search.js
@@ -85,9 +85,17 @@ module.exports = class Search {
       term = term.replace(/'/g, `\\'`);
       term = term.replace(/\\/g, `\\\\"`);
 
+      /** @type {string[]} */
+      const dirsToIgnore = Configuration.get(`grepIgnoreDirs`);
+      let ignoreString = ``;
+
+      if (dirsToIgnore.length > 0) {
+        ignoreString = `--exclude-dir={${dirsToIgnore.join(`,`)}}`;
+      }
+
       try {
         //@ts-ignore
-        standardOut = await connection.paseCommand(`${grep} -nr "${term}" ${path}`);
+        standardOut = await connection.paseCommand(`${grep} -nr ${ignoreString} "${term}" "${path}"`);
       } catch (e) {
         if (e === ``) standardOut = e //Means no results were found.
         else throw e;

--- a/src/api/Search.js
+++ b/src/api/Search.js
@@ -90,7 +90,7 @@ module.exports = class Search {
       let ignoreString = ``;
 
       if (dirsToIgnore.length > 0) {
-        ignoreString = `--exclude-dir={${dirsToIgnore.join(`,`)}}`;
+        ignoreString = dirsToIgnore.map(dir => `--exclude-dir=${dir}`).join(` `);
       }
 
       try {


### PR DESCRIPTION
### Changes

* Adds new global config `grepIgnoreDirs` which is used when searching the IFS
* IFS search API will use the config when search to keep searches from growing large.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [x] **for feature PRs**: PR only includes one feature enhancement.
