### PR TITLE
Ignore __pycache__ when searching Python source code

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,7 +228,7 @@
 						"type": "string",
 						"title": "IFS directory"
 					},
-					"default": ["node_modules", ".git", "vendor"],
+					"default": ["node_modules", ".git", "vendor", "__pycache__"],
 					"description": "List of directories that will be ignored when searching the IFS."
 				},
 				"code-for-ibmi.logCompileOutput": {


### PR DESCRIPTION
The __pycache__ directory contains bytecode-like files that should be ignored when we run grep over source code.


### Changes

Description of change here.

### Checklist

* [ ] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
