### PR TITLE
Add functionality to generate CREATE TABLE SQL's from object browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -565,6 +565,11 @@
 				"category": "IBM i"
 			},
 			{
+				"command": "code-for-ibmi.generateCreateTableSQL",
+				"title": "Generate CREATE TABLE SQL",
+				"category": "IBM i"
+			},
+			{
 				"command": "code-for-ibmi.addToLibraryList",
 				"title": "Add to library list",
 				"category": "IBM i",
@@ -1114,6 +1119,11 @@
 					"command": "code-for-ibmi.runAction",
 					"when": "view == objectBrowser && viewItem == object",
 					"group": "1_workspace@1"
+				},
+				{
+					"command": "code-for-ibmi.generateCreateTableSQL",
+					"when": "view == objectBrowser && viewItem == object",
+					"group": "2_workspace@1"
 				},
 				{
 					"command": "code-for-ibmi.removeSchemaFromDatabaseBrowser",

--- a/src/Instance.js
+++ b/src/Instance.js
@@ -388,6 +388,37 @@ module.exports = class Instance {
           })
         );
 
+        context.subscriptions.push(
+          vscode.commands.registerCommand(`code-for-ibmi.generateCreateTableSQL`, async (node) => {
+            if(!node) return;
+
+            if (node.type != `FILE`) {
+              vscode.window.showErrorMessage(`CREATE TABLE can only be generated for file's.`);
+              return;
+            }
+
+            let lib = node.path.split(`/`)[0];
+            let file = node.path.split(`/`)[1];
+            
+            vscode.window.showInformationMessage(`Generating CREATE TABLE statement...`);
+            let result = await this.getContent().runSQL(`CALL QSYS2.GENERATE_SQL ('${file}', '${lib}', 'TABLE')`);
+
+            let resultString = ``;
+            result.forEach(element => resultString += element.SRCDTA + `\r\n`);
+
+            try {
+              const textDoc = await vscode.workspace.openTextDocument(vscode.Uri.parse(`untitled:` + `Generated SQL`));
+              const editor = await vscode.window.showTextDocument(textDoc);
+              editor.edit(edit => {
+                edit.insert(new vscode.Position(0, 0), resultString);
+              })
+
+            } catch (e) {
+              vscode.window.showErrorMessage(`Error generating CREATE TABLE statement.`);
+            }
+          })
+        );
+
         
 
         initialisedBefore = true;


### PR DESCRIPTION
### Changes

It's now possible to generate CREATE TABLE SQL's from the object browser. This feature was requested in #297.

Things to consider for the future:
1. Any type of object shows the "Generate CREATE TABLE SQL" entry on right clicking. But it will only work for files. Other objects will show an error message.
2. The new tab containing the CREATE TABLE statement cannot be saved by STRG / CMD + S. Don't know the exact reason yet.
3. Maybe it will make sense to add this feature also to the database browser.

### Checklist

* [x] have tested my change
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] have added myself to the contributors' list in the README
* [x] **for feature PRs**: PR only includes one feature enhancement.
