### PR TITLE
Credential saving

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -250,8 +250,7 @@ Here is a snippet of what the connection details look like:
     "name": "My IBMi Connection",
     "host": "DEV400",
     "port": 22,
-    "username": "OTTEB",
-    "privateKey": null
+    "username": "OTTEB"
   }
 ],
 ```

--- a/package.json
+++ b/package.json
@@ -524,6 +524,11 @@
 				"category": "IBM i"
 			},
 			{
+				"command": "code-for-ibmi.showLoginSettings",
+				"title": "Login settings",
+				"category": "IBM i"
+			},
+			{
 				"command": "code-for-ibmi.deleteConnection",
 				"title": "Delete connection",
 				"category": "IBM i"
@@ -958,11 +963,18 @@
 			"view/item/context": [
 				{
 					"command": "code-for-ibmi.deleteConnection",
-					"when": "view == connectionBrowser && viewItem == server"
+					"when": "view == connectionBrowser && viewItem == server",
+					"group": "2_delete@1"
 				},
 				{
 					"command": "code-for-ibmi.showAdditionalSettings",
-					"when": "view == connectionBrowser && viewItem == server"
+					"when": "view == connectionBrowser && viewItem == server",
+					"group": "1_manage@1"
+				},
+				{
+					"command": "code-for-ibmi.showLoginSettings",
+					"when": "view == connectionBrowser && viewItem == server",
+					"group": "1_manage@2"
 				},
 				{
 					"command": "code-for-ibmi.connectPrevious",

--- a/src/extension.js
+++ b/src/extension.js
@@ -22,6 +22,24 @@ function activate(context) {
   //We setup the event emitter.
   instance.setupEmitter();
 
+  
+  let MigrateConfig =  function(){
+    const configData = vscode.workspace.getConfiguration(`code-for-ibmi`);
+    let connections = configData.get(`connections`);
+
+    // Migrate existing SSH Keys into secure storage
+    for(let connection of connections) {
+      if (connection.privateKey){
+        context.secrets.store(`${connection.name}_privateKey`, `${connection.privateKey}`);
+        delete connection.privateKey;
+      }
+    }
+   
+    configData.update(`connections`,connections,vscode.ConfigurationTarget.Global);
+  };
+  
+  MigrateConfig();
+
   context.subscriptions.push(
     vscode.window.registerTreeDataProvider(
       `connectionBrowser`,

--- a/src/views/connectionBrowser.js
+++ b/src/views/connectionBrowser.js
@@ -51,6 +51,9 @@ module.exports = class objectBrowserProvider {
 
               await Configuration.setGlobal(`connections`, newConnections);
 
+              context.secrets.delete(`${element.label}_password`);
+              context.secrets.delete(`${element.label}_privateKey`);
+            
               this.refresh();
             }
           });

--- a/src/webviews/login/index.js
+++ b/src/webviews/login/index.js
@@ -30,6 +30,7 @@ module.exports = class Login {
     ui.addField(new Field(`paragraph`, `authText`, `Only provide either the password or a private key - not both.`));
     ui.addField(new Field(`password`, `password`, `Password`));
     ui.addField(new Field(`file`, `privateKey`, `Private Key`));
+    ui.addField(new Field(`checkbox`,`savepass`,`Store auth credential`));
     ui.addField(new Field(`submit`, `submitButton`, `Connect`));
 
     const {panel, data} = await ui.loadPage(`IBM i Login`);
@@ -63,9 +64,17 @@ module.exports = class Login {
                   name: data.name,
                   host: data.host,
                   port: data.port,
-                  username: data.username,
-                  privateKey: data.privateKey
+                  username: data.username
                 });
+                
+                if(data.savepass){
+                  if(data.privateKey){
+                    context.secrets.store(`${data.name}_privateKey`, `${data.privateKey}`);
+                  } else if (data.password)
+                  {context.secrets.store(`${data.name}_password`, `${data.password}`);}
+                  
+                };
+
                 await Configuration.setGlobal(`connections`, existingConnections);
               }
     
@@ -99,15 +108,19 @@ module.exports = class Login {
     }
 
     const existingConnections = Configuration.get(`connections`);
-    const connectionConfig = existingConnections.find(item => item.name === name);
- 
+    let connectionConfig = existingConnections.find(item => item.name === name);
+    
     if (connectionConfig) {
+      connectionConfig.privateKey = await context.secrets.get(`${connectionConfig.name}_privateKey`);
       if (!connectionConfig.privateKey) {
-        connectionConfig.password = await vscode.window.showInputBox({
-          prompt: `Password for ${connectionConfig.name}`,
-          password: true
-        });
-        
+        connectionConfig.password = await context.secrets.get(`${connectionConfig.name}_password`);
+        if (!connectionConfig.password){
+          connectionConfig.password = await vscode.window.showInputBox({
+            prompt: `Password for ${connectionConfig.name}`,
+            password: true
+          });
+        };
+
         if (!connectionConfig.password) {
           return;
         }

--- a/src/webviews/settings/index.js
+++ b/src/webviews/settings/index.js
@@ -70,7 +70,9 @@ module.exports = class SettingsUI {
         ui.addField(field);
     
         field = new Field(`input`, `hideCompileErrors`, `Errors to ignore`);
-        field.default = config.hideCompileErrors.join(`, `);
+        if (config.hideCompileErrors) {
+          field.default = config.hideCompileErrors.join(`, `);
+        };
         field.description = `A comma delimited list of errors to be hidden from the result of an Action in the EVFEVENT file. Useful for codes like <code>RNF5409</code>.`;
         ui.addField(field);
 

--- a/src/webviews/settings/index.js
+++ b/src/webviews/settings/index.js
@@ -164,6 +164,55 @@ module.exports = class SettingsUI {
               });
           }
         }
+      }),
+
+      vscode.commands.registerCommand(`code-for-ibmi.showLoginSettings`, async (server) => {
+        if (server) {
+          const connections = Configuration.get(`connections`);
+          const name = server.name;
+
+          const connectionIdx = connections.findIndex(item => item.name === name);
+          let connection = connections[connectionIdx];
+
+          let ui = new CustomUI();
+          let field;
+
+          field = new Field(`input`, `host`, `Host or IP Address`);
+          field.default = connection.host;
+          ui.addField(field);
+
+          field = new Field(`input`, `port`, `Port`);
+          field.default = connection.port;
+          ui.addField(field);
+
+          field = new Field(`input`, `username`, `Username`);
+          field.default = connection.username;
+          ui.addField(field);
+
+          field = new Field(`file`, `privateKey`, `Private Key`);
+          field.description = `Only provide a private key if you want to update from the existing one or set one.`
+          field.default = connection.privateKey;
+          ui.addField(field);
+
+          ui.addField(new Field(`submit`, `submitButton`, `Save`));
+
+          const {panel, data} = await ui.loadPage(`Login Settings: ${name}`);
+
+          if (data) {
+            panel.dispose();
+      
+            data.port = Number(data.port);
+            if (data.privateKey === ``) data.privateKey = connection.privateKey;
+
+            connection = {
+              ...connection,
+              ...data
+            };
+
+            connections[connectionIdx] = connection;
+            await Configuration.setGlobal(`connections`, connections);
+          }
+        }
       })
     )
 

--- a/src/webviews/settings/index.js
+++ b/src/webviews/settings/index.js
@@ -190,10 +190,16 @@ module.exports = class SettingsUI {
           field = new Field(`input`, `username`, `Username`);
           field.default = connection.username;
           ui.addField(field);
+   
+          field = new Field(`paragraph`, `authText`, `Only provide either the password or a private key - not both.`);
+          ui.addField(field);
+
+          field = new Field(`password`, `password`, `Password`);
+          field.description = `Only provide a password if you want to update from the existing one or set one.`
+          ui.addField(field);
 
           field = new Field(`file`, `privateKey`, `Private Key`);
           field.description = `Only provide a private key if you want to update from the existing one or set one.`
-          field.default = connection.privateKey;
           ui.addField(field);
 
           ui.addField(new Field(`submit`, `submitButton`, `Save`));
@@ -204,8 +210,18 @@ module.exports = class SettingsUI {
             panel.dispose();
       
             data.port = Number(data.port);
-            if (data.privateKey === ``) data.privateKey = connection.privateKey;
 
+            if (data.password !== ``){
+              context.secrets.delete(`${data.name}_password`);
+              context.secrets.store(`${data.name}_password`, `${data.password}`)
+            };
+
+            if (data.privateKey !== ``) {
+              context.secrets.delete(`${data.name}_privateKey`);
+              context.secrets.store(`${data.name}_privateKey`, `${data.privateKey}`)
+            };
+
+            // overlay the new data values on existing connection 
             connection = {
               ...connection,
               ...data


### PR DESCRIPTION
### Changes

Implemented credential saving in secret credential storage, credentials will no longer be stored in settings.json for any extention to read. 

This adds a checkbox to the connection creation screen, which when checked will save your password/certificate in secure storage. 

In windows the saved credential can be seen (and edited) in "Control Panel > Credential Manager > Windows Credentials"

When deleting the connection the credential will also be removed.

Also fixed a bug when editing "Connecton Settings"

### Checklist

* [X] have tested my change
* * Tested using password only... I only have access to PUB400 via password login, therefore I cannot test a certificate based login
* [X] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [X] have added myself to the contributors' list in the README
* [X] **for feature PRs**: PR only includes one feature enhancement.

