### PR TITLE
Save passwords

### DIFF
--- a/src/views/connectionBrowser.js
+++ b/src/views/connectionBrowser.js
@@ -51,6 +51,8 @@ module.exports = class objectBrowserProvider {
 
               await Configuration.setGlobal(`connections`, newConnections);
 
+              context.secrets.delete(`${element.label}_password`);
+
               this.refresh();
             }
           });

--- a/src/webviews/settings/index.js
+++ b/src/webviews/settings/index.js
@@ -216,6 +216,7 @@ module.exports = class SettingsUI {
               context.secrets.store(`${name}_password`, `${data.password}`)
             };
 
+            delete data.password;
 
             connection = {
               ...connection,

--- a/src/webviews/settings/index.js
+++ b/src/webviews/settings/index.js
@@ -189,6 +189,13 @@ module.exports = class SettingsUI {
           field.default = connection.username;
           ui.addField(field);
 
+          field = new Field(`paragraph`, `authText`, `Only provide either the password or a private key - not both.`);
+          ui.addField(field);
+
+          field = new Field(`password`, `password`, `Password`);
+          field.description = `Only provide a password if you want to update an existing one or set a new one.`
+          ui.addField(field);
+
           field = new Field(`file`, `privateKey`, `Private Key`);
           field.description = `Only provide a private key if you want to update from the existing one or set one.`
           field.default = connection.privateKey;
@@ -203,6 +210,12 @@ module.exports = class SettingsUI {
       
             data.port = Number(data.port);
             if (data.privateKey === ``) data.privateKey = connection.privateKey;
+
+            if(data.password && !data.privateKey) {
+              context.secrets.delete(`${name}_password`);
+              context.secrets.store(`${name}_password`, `${data.password}`)
+            };
+
 
             connection = {
               ...connection,


### PR DESCRIPTION
### Changes

Implemented secret password storage. 

There is now the option to save a password for a new connection. 

For existing connections one can be set/changed via the new login settings page. 

Deleting a connection will also delete the saved password

"Save passwords" uses the VS Code secrets API and from windows can be seen/removed/amended in "Control Panel > Credential Manager > Windows Credentials"

### Checklist

* [X] have tested my change
* [X] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [X] have added myself to the contributors' list in the README
* [X] **for feature PRs**: PR only includes one feature enhancement.
