### PR TITLE
New functionality to automatically save before an action is run (#365)

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,6 +179,11 @@
 								"default": false,
 								"description": "Enables the CL content assist and hover support."
 							},
+							"autoSaveBeforeAction": {
+								"type": "boolean",
+								"default": false,
+								"description": "Automatically save before running action if editor is dirty"
+							},
 							"customVariables": {
 								"type": "array",
 								"description": "Custom variables for Actions",

--- a/src/Instance.js
+++ b/src/Instance.js
@@ -366,13 +366,26 @@ module.exports = class Instance {
 
               if (editor) {
                 willRun = true;
-                if (editor.document.isDirty) {
-                  let result = await vscode.window.showWarningMessage(`The file must be saved to run Actions.`, `Save`, `Cancel`);
-
-                  if (result === `Save`) {
-                    await editor.document.save();
-                  } else {
-                    willRun = false;
+                if (config.autoSaveBeforeAction) {
+                  await editor.document.save();
+                } else {
+                  if (editor.document.isDirty) {
+                    let result = await vscode.window.showWarningMessage(`The file must be saved to run Actions.`, `Save`, `Save automatically`, `Cancel`);
+                    
+                    switch (result) {
+                    case `Save`: 
+                      await editor.document.save();
+                      willRun = true;
+                      break;
+                    case `Save automatically`:
+                      config.set(`autoSaveBeforeAction`, true);
+                      await editor.document.save();
+                      willRun = true;
+                      break;
+                    default:
+                      willRun = false;
+                      break;
+                    }
                   }
                 }
               }

--- a/src/api/Configuration.js
+++ b/src/api/Configuration.js
@@ -58,6 +58,9 @@ module.exports = class Configuration {
 
     /** @type {boolean} */
     this.clContentAssistEnabled = (base.clContentAssistEnabled === true);
+
+    /** @type {boolean} */
+    this.autoSaveBeforeAction = (base.autoSaveBeforeAction === true);
   }
 
   /**

--- a/src/webviews/settings/index.js
+++ b/src/webviews/settings/index.js
@@ -73,6 +73,11 @@ module.exports = class SettingsUI {
         field.default = config.hideCompileErrors.join(`, `);
         field.description = `A comma delimited list of errors to be hidden from the result of an Action in the EVFEVENT file. Useful for codes like <code>RNF5409</code>.`;
         ui.addField(field);
+    
+        field = new Field(`checkbox`, `autoSaveBeforeAction`, `Auto Save for Actions`);
+        field.default = (config.autoSaveBeforeAction ? `checked` : ``);
+        field.description = `When current editor has unsaved changes, automatically save it before running an action.`;
+        ui.addField(field);
 
         ui.addField(new Field(`hr`));
     


### PR DESCRIPTION
### Changes

* Adds new config to auto save before an action is run
* Popup to save file before executing an action now has a `Save automatically` button which will update the config.

Closes #365 

### Checklist

* [X] have tested my change
* [ ] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [X] **for feature PRs**: PR only includes one feature enhancement.
