### PR TITLE
Add right click option for RPG to launch column assist (#369)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1015,6 +1015,13 @@
 					"when": "view == databaseBrowser"
 				}
 			],
+			"editor/context": [
+				{
+					"command": "code-for-ibmi.rpgleColumnAssistant",
+					"group": "1_rpgle",
+					"when": "editorLangId == rpgle"
+				}
+			],
 			"view/item/context": [
 				{
 					"command": "code-for-ibmi.deleteConnection",


### PR DESCRIPTION
### Changes

Adds right-click option to the editor to launch the column assist.

### Checklist

* [X] have tested my change
* [ ] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
