### PR TITLE
Remove use of Searching word twice

### DIFF
--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -310,10 +310,10 @@ module.exports = class ifsBrowserProvider {
             try {
               await vscode.window.withProgress({
                 location: vscode.ProgressLocation.Notification,
-                title: `Searching `,
+                title: `Searching`,
               }, async progress => {
                 progress.report({
-                  message: `Searching '${searchTerm}' in ${path}.`
+                  message: `'${searchTerm}' in ${path}.`
                 });
 
                 const results = await Search.searchIFS(instance, path, searchTerm);

--- a/src/views/memberBrowser.js
+++ b/src/views/memberBrowser.js
@@ -396,7 +396,7 @@ module.exports = class memberBrowserProvider {
 
                 await vscode.window.withProgress({
                   location: vscode.ProgressLocation.Notification,
-                  title: `Searching `,
+                  title: `Searching`,
                 }, async progress => {
                   progress.report({
                     message: `Fetching member list for ${node.path}.`
@@ -410,7 +410,7 @@ module.exports = class memberBrowserProvider {
 
                   if (members.length > 0) {
                     progress.report({
-                      message: `Searching '${searchTerm}' in ${node.path}.`
+                      message: `'${searchTerm}' in ${node.path}.`
                     });
 
                     const results = await Search.searchMembers(instance, path[0], path[1], searchTerm);


### PR DESCRIPTION
### Changes

When using the search, the word 'Searching' appeared twice.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
