### PR TITLE
Remove use of word Searching twice

### DIFF
--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -310,10 +310,10 @@ module.exports = class ifsBrowserProvider {
             try {
               await vscode.window.withProgress({
                 location: vscode.ProgressLocation.Notification,
-                title: `Searching `,
+                title: `Searching`,
               }, async progress => {
                 progress.report({
-                  message: `Searching '${searchTerm}' in ${path}.`
+                  message: `'${searchTerm}' in ${path}.`
                 });
 
                 const results = await Search.searchIFS(instance, path, searchTerm);

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -383,7 +383,7 @@ module.exports = class objectBrowserTwoProvider {
 
                 await vscode.window.withProgress({
                   location: vscode.ProgressLocation.Notification,
-                  title: `Searching `,
+                  title: `Searching`,
                 }, async progress => {
                   progress.report({
                     message: `Fetching member list for ${node.path}.`
@@ -393,7 +393,7 @@ module.exports = class objectBrowserTwoProvider {
 
                   if (members.length > 0) {
                     progress.report({
-                      message: `Searching '${searchTerm}' in ${node.path}.`
+                      message: `'${searchTerm}' in ${node.path}.`
                     });
 
                     const results = await Search.searchMembers(instance, path[0], path[1], searchTerm);


### PR DESCRIPTION
### Changes

Remove the use of the word 'Searching' appearing twice in the prompt.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
