### PR TITLE
Search in ASP when defined

### DIFF
--- a/src/api/Search.js
+++ b/src/api/Search.js
@@ -12,11 +12,14 @@ module.exports = class Search {
   static async searchMembers(instance, lib, spf, term) {
     /** @type {IBMi} */
     const connection = instance.getConnection();
+    const config = instance.getConfig();
     
     term = term.replace(/'/g, `\\'`);
     term = term.replace(/\\/g, `\\\\"`);
 
-    const result = await connection.qshCommand(`/usr/bin/grep -in '${term}' /QSYS.LIB/${lib}.LIB/${spf}.FILE/*`, undefined, 1);
+    const asp = ((config.sourceASP && config.sourceASP.length > 0) ? `/${config.sourceASP}` : ``);
+
+    const result = await connection.qshCommand(`/usr/bin/grep -in '${term}' ${asp}/QSYS.LIB/${lib}.LIB/${spf}.FILE/*`, undefined, 1);
 
     //@ts-ignore stderr does exist.
     if (result.stderr) throw new Error(result.stderr);

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -368,13 +368,16 @@ module.exports = class objectBrowserTwoProvider {
 
       vscode.commands.registerCommand(`code-for-ibmi.searchSourceFile`, async (node) => {
         if (node) {
+          const config = instance.getConfig();
           const content = instance.getContent();
 
           const path = node.path.split(`/`);
 
           if (path[1] !== `*ALL`) {
+            const aspText = ((config.sourceASP && config.sourceASP.length > 0) ? `(in ASP ${config.sourceASP}` : ``);
+
             let searchTerm = await vscode.window.showInputBox({
-              prompt: `Search ${node.path}.`
+              prompt: `Search ${node.path}. ${aspText}`
             });
 
             if (searchTerm) {


### PR DESCRIPTION
### Changes

Previously the member search was not accounting for ASP defined in the settings. Now, not only will it use the ASP in the search, but it will also show the ASP in the search box.

Fixes #398 

### Checklist

* [ ] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
