### PR TITLE
Support for IBM i terminals

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -742,6 +742,13 @@ Right click and click 'Search' on IFS directories and source files to search thr
 
 VS Code works in "insert" mode. This can be annoying when editing a fixed mode source, for example DDS. Fortunately there is an [Overtype extension](https://marketplace.visualstudio.com/items?itemName=DrMerfy.overtype) that allows you to toggle between insert and  overtype, and can also display the current mode in the status bar.
 
+### Integrated terminals
+
+It is possible, using the Terminals button in the lower left-hand corner, to select a Terminal to launch:
+
+* PASE: will launch into the pase environment
+* 5250: will launch a 5250 emulator right into the connected system. For this functionality, `tn5250` must be installed on the remote system. This can be installed via yum.
+
 ### Variant Characters/CCSID Issues
 
 Use of variant characters, for example, '£', in your file names or source code may cause files not to open or characters to display incorrectly in Code for IBM i. If you are experiencing such issues, it is likely the IBM i PASE environment locale is not set correctly.

--- a/docs/README.md
+++ b/docs/README.md
@@ -748,6 +748,9 @@ It is possible, using the Terminals button in the lower left-hand corner, to sel
 
 * PASE: will launch into the pase environment
 * 5250: will launch a 5250 emulator right into the connected system. For this functionality, `tn5250` must be installed on the remote system. This can be installed via yum.
+   - **Do the function keys work?** Yes.
+   - **It is possible to do a system request?** Yes. Use Command+C.
+   - **How do I end my session?** Use the Terminal bin in VS Code.
 
 ### Variant Characters/CCSID Issues
 

--- a/package.json
+++ b/package.json
@@ -197,6 +197,12 @@
 								"default": false,
 								"description": "Enables the CL content assist and hover support."
 							},
+							"encodingFor5250": {
+								"type": "string",
+								"default": "37",
+								"enum": ["37", "256", "273", "277", "278", "280", "284", "285", "297", "500", "871", "870", "905", "880", "420", "875", "424", "1026", "290", "win37", "win256", "win273", "win277", "win278", "win280", "win284", "win285", "win297", "win500", "win871", "win870", "win905", "win880", "win420", "win875", "win424", "win1026"],
+								"description": "The encoding for the 5250 emulator. To use the 5250 emulator, tn5250 must be installed on the remote system via yum."
+							},
 							"autoSaveBeforeAction": {
 								"type": "boolean",
 								"default": false,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	},
 	"license": "MIT",
 	"engines": {
-		"vscode": "^1.52.0"
+		"vscode": "^1.60.0"
 	},
 	"categories": [
 		"Other"
@@ -591,6 +591,11 @@
 			{
 				"command": "code-for-ibmi.disconnect",
 				"title": "Disconnect from current connection.",
+				"category": "IBM i"
+			},
+			{
+				"command": "code-for-ibmi.launchTerminalPicker",
+				"title": "Launch Terminal Picker",
 				"category": "IBM i"
 			},
 			{
@@ -1177,7 +1182,7 @@
 		"@types/glob": "^7.1.3",
 		"@types/mocha": "^8.0.4",
 		"@types/node": "^12.11.7",
-		"@types/vscode": "^1.52.0",
+		"@types/vscode": "^1.60.0",
 		"eslint": "^7.19.0",
 		"glob": "^7.1.6",
 		"mocha": "^8.2.1",

--- a/src/Instance.js
+++ b/src/Instance.js
@@ -15,6 +15,9 @@ let connectedBarItem;
 /** @type {vscode.StatusBarItem} */
 let actionsBarItem;
 
+/** @type {vscode.StatusBarItem} */
+let terminalBarItem;
+
 let initialisedBefore = false;
 
 /** @type {vscode.Uri} */
@@ -101,7 +104,6 @@ module.exports = class Instance {
     const ifs = new (require(`./filesystems/ifs`));
 
     const objectBrowser = require(`./views/objectBrowser`);
-    const objectBrowserTwo = require(`./views/objectBrowser`);
     const databaseBrowser = require(`./views/databaseBrowser`);
 
     const actionsUI = require(`./webviews/actions`);
@@ -109,11 +111,13 @@ module.exports = class Instance {
 
     const CLCommands = require(`./languages/clle/clCommands`);
 
+    const Terminal = require(`./api/terminal`);
+
     if (instance.connection) {
       CompileTools.register(context);
 
       if (!connectedBarItem) {
-        connectedBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+        connectedBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 10);
         connectedBarItem.command = {
           command: `code-for-ibmi.showAdditionalSettings`,
           title: `Show Additional Connection Settings`,
@@ -136,6 +140,19 @@ module.exports = class Instance {
       }
 
       actionsBarItem.show();
+
+      if (!terminalBarItem) {
+        terminalBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
+        terminalBarItem.command = {
+          command: `code-for-ibmi.launchTerminalPicker`,
+          title: `Launch Terminal Picker`
+        }
+        context.subscriptions.push(terminalBarItem);
+
+        terminalBarItem.text = `Terminals`;
+      }
+
+      terminalBarItem.show();
 
       //Update the status bar and that's that.
       if (initialisedBefore) {
@@ -392,6 +409,10 @@ module.exports = class Instance {
             }
           }),
 
+          vscode.commands.registerCommand(`code-for-ibmi.launchTerminalPicker`, () => {
+            Terminal.select(this);
+          }),
+
           vscode.commands.registerCommand(`code-for-ibmi.runCommand`, (detail) => {
             if (detail && detail.command) {
               return CompileTools.runCommand(this, detail);
@@ -437,7 +458,7 @@ module.exports = class Instance {
           Configuration.setGlobal(`rpgleContentAssistEnabled`, false);
           Configuration.setGlobal(`rpgleColumnAssistEnabled`, false);
         }
-
+        
         initialisedBefore = true;
       }
     }

--- a/src/api/Configuration.js
+++ b/src/api/Configuration.js
@@ -56,6 +56,9 @@ module.exports = class Configuration {
     /** @type {boolean} */
     this.clContentAssistEnabled = (base.clContentAssistEnabled === true);
 
+    /** @type {string|undefined} */
+    this.encodingFor5250 = base.encodingFor5250 || `37`;
+
     /** @type {boolean} */
     this.autoSaveBeforeAction = (base.autoSaveBeforeAction === true);
   }

--- a/src/api/IBMi.js
+++ b/src/api/IBMi.js
@@ -7,7 +7,7 @@ const Configuration = require(`./Configuration`);
 let remoteApps = [
   {
     path: `/QOpenSys/pkgs/bin/`,
-    names: [`db2util`, `git`, `grep`]
+    names: [`db2util`, `git`, `grep`, `tn5250`]
   },
   {
     path: `/usr/bin/`,
@@ -43,6 +43,7 @@ module.exports = class IBMi {
       db2util: undefined,
       git: undefined,
       grep: undefined,
+      tn5250: undefined,
       setccsid: undefined,
       'GENCMDXML.PGM': undefined
     };

--- a/src/api/terminal.js
+++ b/src/api/terminal.js
@@ -1,0 +1,91 @@
+
+const vscode = require(`vscode`);
+const IBMi = require(`./IBMi`);
+
+module.exports = class Terminal {
+  static select(instance) {
+    /** @type {IBMi} */
+    const connection = instance.getConnection();
+
+    const types = [`PASE`, `5250`];
+    vscode.window.showQuickPick(types, {
+      placeHolder: `Select a terminal type`
+    }).then(type => {
+      if (type) {
+        if (type === `5250` && connection.remoteFeatures.tn5250 === undefined) {
+          vscode.window.showErrorMessage(`5250 terminal is not supported. Please install tn5250 via yum on the remote system.`);
+          return;
+        }
+
+        // @ts-ignore because type is a string
+        Terminal.createTerminal(instance, type);
+      }
+    });
+  }
+
+  /**
+   * 
+   * @param {*} instance 
+   * @param {"PASE"|"5250"} type 
+   */
+  static createTerminal(instance, type) {
+    const writeEmitter = new vscode.EventEmitter();
+
+    /** @type {IBMi} */
+    const connection = instance.getConnection();
+
+    connection.client.requestShell().then(channel => {
+      channel.stdout.on(`data`, (data) => {
+        writeEmitter.fire(String(data))
+      });
+      channel.stderr.on(`data`, (data) => {
+        writeEmitter.fire(String(data))
+      });
+      let emulatorTerminal = vscode.window.createTerminal({
+        name: `IBM i ${type}`,
+        pty: {
+          onDidWrite: writeEmitter.event,
+          open: (dim) => {},
+          close: () => {
+            channel.close();
+          },
+          handleInput: (data) => {
+            channel.stdin.write(data);
+          },
+          setDimensions: (dim) => {
+            //channel.setWindow(dim.rows, dim.columns, 0, 0);
+          },
+        },
+      });
+      channel.on(`close`, () => {
+        channel.destroy();
+        writeEmitter.dispose()
+      });
+      channel.on(`exit`, (code, signal, coreDump, desc) => {
+        writeEmitter.fire(`----------\r\n`);
+        if (code === 0) {
+          writeEmitter.fire(`Completed successfully.\r\n`);
+        }
+        else if (code) {
+          writeEmitter.fire(`Exited with error code ${code}.\r\n`);
+        }
+        else {
+          writeEmitter.fire(`Exited with signal ${signal}.\r\n`);
+        }
+      });
+      channel.on(`error`, (err) => {
+        vscode.window.showErrorMessage(`Connection error: ${err || err.message}`);
+        emulatorTerminal.dispose();
+        channel.destroy();
+      });
+
+      emulatorTerminal.show();
+
+      if (type === `5250`) {
+        channel.stdin.write(`TERM=xterm /QOpenSys/pkgs/bin/tn5250 localhost\n`);
+      } else {
+        channel.stdin.write(`echo "Terminal started. Thanks for using Code for IBM i"\n`);
+      }
+    });
+  }
+}

--- a/src/webviews/settings/index.js
+++ b/src/webviews/settings/index.js
@@ -118,6 +118,22 @@ module.exports = class SettingsUI {
         ui.addField(field);
 
         ui.addField(new Field(`hr`));
+
+        const encodings = ["37", "256", "273", "277", "278", "280", "284", "285", "297", "500", "871", "870", "905", "880", "420", "875", "424", "1026", "290", "win37", "win256", "win273", "win277", "win278", "win280", "win284", "win285", "win297", "win500", "win871", "win870", "win905", "win880", "win420", "win875", "win424", "win1026"];
+        
+        field = new Field(`select`, `encodingFor5250`, `5250 encoding`);
+        field.description = `The encoding for the 5250 emulator. To use the 5250 emulator, tn5250 must be installed on the remote system via yum.`;
+        field.items = encodings.map(encoding => {
+          return {
+            selected: config.encodingFor5250 === encoding,
+            value: encoding,
+            description: encoding,
+            text: encoding,
+          };
+        });
+        ui.addField(field);
+
+        ui.addField(new Field(`hr`));
     
         field = new Field(`submit`, `save`, `Save settings`);
         ui.addField(field);


### PR DESCRIPTION
### Changes

* Adds the ability to launch interactive shells/terminals using the same connection
   * pase
   * 5250 (depends on `/QOpenSys/pkgs/bin/tn5250`, available through yum)
* Upgrades required VS Code version.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [x] **for feature PRs**: PR only includes one feature enhancement.
