### PR TITLE
New 5250 config & resize fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,9 +199,20 @@
 							},
 							"encodingFor5250": {
 								"type": "string",
-								"default": "37",
-								"enum": ["37", "256", "273", "277", "278", "280", "284", "285", "297", "500", "871", "870", "905", "880", "420", "875", "424", "1026", "290", "win37", "win256", "win273", "win277", "win278", "win280", "win284", "win285", "win297", "win500", "win871", "win870", "win905", "win880", "win420", "win875", "win424", "win1026"],
+								"default": "default",
+								"enum": ["default", "37", "256", "273", "277", "278", "280", "284", "285", "297", "500", "871", "870", "905", "880", "420", "875", "424", "1026", "290", "win37", "win256", "win273", "win277", "win278", "win280", "win284", "win285", "win297", "win500", "win871", "win870", "win905", "win880", "win420", "win875", "win424", "win1026"],
 								"description": "The encoding for the 5250 emulator. To use the 5250 emulator, tn5250 must be installed on the remote system via yum."
+							},
+							"terminalFor5250": {
+								"type": "string",
+								"default": "default",
+								"enum": ["default", "IBM-3477-FC", "IBM-3477-FG", "IBM-3180-2 ", "IBM-3179-2 ", "IBM-3196-A1", "IBM-5292-2", "IBM-5291-1", "IBM-5251-11"],
+								"description": "The terminal type for the 5250 emulator. To use the 5250 emulator, tn5250 must be installed on the remote system via yum."
+							},
+							"setDeviceNameFor5250": {
+								"type": "boolean",
+								"default": false,
+								"description": "If enabled, user will be prompted for the terminal device name."
 							},
 							"autoSaveBeforeAction": {
 								"type": "boolean",

--- a/src/api/Configuration.js
+++ b/src/api/Configuration.js
@@ -57,7 +57,13 @@ module.exports = class Configuration {
     this.clContentAssistEnabled = (base.clContentAssistEnabled === true);
 
     /** @type {string|undefined} */
-    this.encodingFor5250 = base.encodingFor5250 || `37`;
+    this.encodingFor5250 = base.encodingFor5250 || `default`;
+
+    /** @type {string|undefined} */
+    this.terminalFor5250 = base.terminalFor5250 || `default`;
+
+    /** @type {boolean} */
+    this.setDeviceNameFor5250 = (base.setDeviceNameFor5250 === true);
 
     /** @type {boolean} */
     this.autoSaveBeforeAction = (base.autoSaveBeforeAction === true);

--- a/src/api/terminal.js
+++ b/src/api/terminal.js
@@ -99,7 +99,7 @@ module.exports = class Terminal {
             }
           },
           setDimensions: (dim) => {
-            //channel.setWindow(dim.rows, dim.columns, 0, 0);
+            channel.setWindow(dim.rows, dim.columns, 0, 0);
           },
         },
       });

--- a/src/api/terminal.js
+++ b/src/api/terminal.js
@@ -14,9 +14,9 @@ module.exports = class Terminal {
     const types = [`PASE`, `5250`];
     vscode.window.showQuickPick(types, {
       placeHolder: `Select a terminal type`
-    }).then(type => {
+    }).then(async type => {
       if (type) {
-        let encodingMap;
+        let encoding, terminal, name;
 
         if (type === `5250`) {
           if (connection.remoteFeatures.tn5250 === undefined) {
@@ -24,14 +24,29 @@ module.exports = class Terminal {
             return;
           }
 
-          encodingMap = configuration.encodingFor5250;
+          encoding = (configuration.encodingFor5250 && configuration.encodingFor5250 !== `default` ? configuration.encodingFor5250 : undefined);
+          terminal = (configuration.terminalFor5250 && configuration.terminalFor5250 !== `default` ? configuration.terminalFor5250 : undefined);
+          
+          if (configuration.setDeviceNameFor5250) {
+            name = await vscode.window.showInputBox({
+              prompt: `Enter a device name for the terminal.`,
+              value: ``,
+              placeHolder: `Blank for default.`
+            });
+
+            if (name === ``) name = undefined;
+          }
 
           // This makes it so the function keys continue to work in the terminal instead of sending them as VS Code commands
           vscode.workspace.getConfiguration().update(`terminal.integrated.sendKeybindingsToShell`, true, true);
         }
 
         // @ts-ignore because type is a string
-        Terminal.createTerminal(instance, type, encodingMap);
+        Terminal.createTerminal(instance, type, {
+          encoding,
+          terminal,
+          name
+        });
       }
     });
   }
@@ -40,9 +55,9 @@ module.exports = class Terminal {
    * 
    * @param {*} instance 
    * @param {"PASE"|"5250"} type 
-   * @param {string} [encodingMap]
+   * @param {{encoding?: string, terminal?: string, name?: string}} [greenScreenSettings]
    */
-  static createTerminal(instance, type, encodingMap) {
+  static createTerminal(instance, type, greenScreenSettings = {}) {
     const writeEmitter = new vscode.EventEmitter();
 
     /** @type {IBMi} */
@@ -113,7 +128,13 @@ module.exports = class Terminal {
       emulatorTerminal.show();
 
       if (type === `5250`) {
-        channel.stdin.write(`TERM=xterm /QOpenSys/pkgs/bin/tn5250 ${encodingMap ? `map=${encodingMap}` : ``} localhost\n`);
+        channel.stdin.write([
+          `TERM=xterm /QOpenSys/pkgs/bin/tn5250`,
+          `${greenScreenSettings.encoding ? `map=${greenScreenSettings.encoding}` : ``}`,
+          `${greenScreenSettings.terminal ? `env.TERM=${greenScreenSettings.terminal}` : ``}`,
+          `${greenScreenSettings.name ? `env.DEVNAME=${greenScreenSettings.name}` : ``}`,
+          `localhost\n`
+        ].join(` `));
       } else {
         channel.stdin.write(`echo "Terminal started. Thanks for using Code for IBM i"\n`);
       }

--- a/src/webviews/settings/index.js
+++ b/src/webviews/settings/index.js
@@ -119,10 +119,10 @@ module.exports = class SettingsUI {
 
         ui.addField(new Field(`hr`));
 
-        const encodings = ["37", "256", "273", "277", "278", "280", "284", "285", "297", "500", "871", "870", "905", "880", "420", "875", "424", "1026", "290", "win37", "win256", "win273", "win277", "win278", "win280", "win284", "win285", "win297", "win500", "win871", "win870", "win905", "win880", "win420", "win875", "win424", "win1026"];
+        const encodings = [`37`, `256`, `273`, `277`, `278`, `280`, `284`, `285`, `297`, `500`, `871`, `870`, `905`, `880`, `420`, `875`, `424`, `1026`, `290`, `win37`, `win256`, `win273`, `win277`, `win278`, `win280`, `win284`, `win285`, `win297`, `win500`, `win871`, `win870`, `win905`, `win880`, `win420`, `win875`, `win424`, `win1026`];
         
         field = new Field(`select`, `encodingFor5250`, `5250 encoding`);
-        field.description = `The encoding for the 5250 emulator. To use the 5250 emulator, tn5250 must be installed on the remote system via yum.`;
+        field.description = `The encoding for the 5250 emulator.`;
         field.items = encodings.map(encoding => {
           return {
             selected: config.encodingFor5250 === encoding,
@@ -131,6 +131,48 @@ module.exports = class SettingsUI {
             text: encoding,
           };
         });
+        field.items.push({
+          selected: config.encodingFor5250 === `default`,
+          value: `default`,
+          description: `Default`,
+          text: `Default`,
+        });
+        ui.addField(field);
+
+        const terminalTypes = [
+          { key: `IBM-3179-2`, text: `IBM-3179-2 (24x80 monochrome)` },
+          { key: `IBM-3180-2`, text: `IBM-3180-2 (27x132 monochrome)` },
+          { key: `IBM-3196-A1`, text: `IBM-3196-A1 (24x80 monochrome)` },
+          { key: `IBM-3477-FC`, text: `IBM-3477-FC (27x132 color)` },
+          { key: `IBM-3477-FG`, text: `IBM-3477-FG (27x132 monochrome)` },
+          { key: `IBM-5251-11`, text: `IBM-5251-11 (24x80 monochrome)` },
+          { key: `IBM-5291-1`, text: `IBM-5291-1 (24x80 monochrome)` },
+          { key: `IBM-5292-2`, text: `IBM-5292-2 (24x80 color)` },
+        ];
+
+        field = new Field(`select`, `terminalFor5250`, `5250 Terminal Type`);
+        field.description = `The terminal type for the 5250 emulator.`;
+        field.items = [
+          {
+            selected: config.terminalFor5250 === `default`,
+            value: `default`,
+            description: `Default`,
+            text: `Default`,
+          },
+          ...terminalTypes.map(terminal => {
+            return {
+              selected: config.terminalFor5250 === terminal.key,
+              value: terminal.key,
+              description: terminal.key,
+              text: terminal.text,
+            };
+          })
+        ]
+        ui.addField(field);
+    
+        field = new Field(`checkbox`, `setDeviceNameFor5250`, `Set Device Name for 5250`);
+        field.default = (config.setDeviceNameFor5250 ? `checked` : ``);
+        field.description = `When enabled, the user will be able to enter a device name before the terminal starts.`;
         ui.addField(field);
 
         ui.addField(new Field(`hr`));


### PR DESCRIPTION
### Changes

* Adds two new config options for 5250
   1. 5250 terminal
   2. Set custom device name
* Fix for resizing issues

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
