### PR TITLE
logCompileOutput enabled by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
 				},
 				"code-for-ibmi.logCompileOutput": {
 					"type": "boolean",
-					"default": false,
+					"default": true,
 					"description": "If enabled, will log spool files from command executed. You can find it under Output for 'IBM i Compile Log'."
 				},
 				"code-for-ibmi.rpgleLinterSupportEnabled": {


### PR DESCRIPTION
### Changes

`logCompileOutput` enabled by default

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
