### PR TITLE
New command to open errors from EVFEVENT

### DIFF
--- a/package.json
+++ b/package.json
@@ -611,6 +611,11 @@
 				"category": "IBM i"
 			},
 			{
+				"command": "code-for-ibmi.openErrors",
+				"title": "Open errors",
+				"category": "IBM i"
+			},
+			{
 				"command": "code-for-ibmi.launchTerminalPicker",
 				"title": "Launch Terminal Picker",
 				"category": "IBM i"


### PR DESCRIPTION
### Changes

As suggested on IBMiOSS Ryver, you can now open errors from an EVFEVENT file without having to run a compile command.

* Adds `code-for-ibmi.openErrors`

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
