### PR TITLE
Workspace deploy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -368,8 +368,9 @@ For all object variables, you can end the variable with `L` for the lowercase of
 
 ## Action Execution
 
-There are three varieties of Actions. They can:
+There are four varieties of Actions. They can:
 
+- if type is `file` and 'deploy first' is enabled, deploy the workspace, then:
 - execute immediately,
 - or they can be displayed for modification,
 - or they can be prompted through the user interface.
@@ -478,6 +479,34 @@ In all the  CRTBNDxxx actions add TGTRLS(&TARGET_RLSE), like this:
 `?CRTBNDCL PGM(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*EVENTF) DBGVIEW(*SOURCE)  TGTRLS(&TARGET_RLSE)`
 
 Now a single change to the TARGET_RLSE custom variable can impact all the CRTBNDxxx actions.
+
+## Workspaces & Deployment
+
+It is possible for the user to deploy a workspace folder directly to the IBM i from VS Code.
+
+If the user opens a Workspace before connecting to an IBM i:
+
+1. a new right-click option will appear on IFS directories to deploy to that directory
+2. a 'Deploy' button will appear on the status bar
+
+### 1. Setting the deploy directory
+
+In the IFS Browser, the user can right-click on any directory and select the 'Deploy Workspace to directory' option. If their workspace has more than one folder opened, the user will be prompted to choose which folder will be deployed to that directory. The user needs to have this folder setup before they can deploy your workspace.
+
+The user can change the deploy directory at any by using the same right-click option on another directory. 
+
+When the user has used the right-click option, they will be asked if they want to run the deploy then.
+
+### 2. The Deploy button / Running the deployment process
+
+Using the 'Deploy' button will start the deployment process. For the deployment process to run, VS Code needs to know which folder to deploy to and will fail if it has not been setup correctly. If the workspace has more than one folder, the user will have to select which folder they want to deploy.
+
+There are two options for deployment:
+
+1. Staged Changes: This only works if the chosen deployment folder is a git repository. Code for IBM i will look at the git status to determine the staged / indexed files and only upload those.
+2. All: Will upload all files in the chosen workspace folder. Will ignore files that are part of the '.gitignore' file if it exists.
+
+The user can also defined Actions that are for the 'file' (local) type to run the deploy before running the Action.
 
 ## Settings: Global
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
 	"name": "code-for-ibmi",
-	"version": "0.7.1",
+	"version": "0.8.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "code-for-ibmi",
-			"version": "0.7.1",
+			"version": "0.8.7",
 			"license": "MIT",
 			"dependencies": {
 				"@bendera/vscode-webview-elements": "^0.3.0",
 				"csv-parse": "^4.15.1",
+				"ignore": "^5.1.9",
 				"node-ssh": "^11.1.1",
 				"tmp": "^0.2.1",
 				"xml2js": "^0.4.23"
@@ -19,7 +20,7 @@
 				"@types/glob": "^7.1.3",
 				"@types/mocha": "^8.0.4",
 				"@types/node": "^12.11.7",
-				"@types/vscode": "^1.52.0",
+				"@types/vscode": "^1.60.0",
 				"eslint": "^7.19.0",
 				"glob": "^7.1.6",
 				"mocha": "^8.2.1",
@@ -29,7 +30,7 @@
 				"webpack-cli": "^4.5.0"
 			},
 			"engines": {
-				"vscode": "^1.52.0"
+				"vscode": "^1.60.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -110,6 +111,15 @@
 				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
+		"node_modules/@eslint/eslintrc/node_modules/ignore": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/@tootallnate/once": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -180,9 +190,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.53.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.53.0.tgz",
-			"integrity": "sha512-XjFWbSPOM0EKIT2XhhYm3D3cx3nn3lshMUcWNy1eqefk+oqRuBq8unVb6BYIZqXy9lQZyeUl7eaBCOZWv+LcXQ==",
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.63.0.tgz",
+			"integrity": "sha512-iePu1axOi5WSThV6l2TYcciBIpAlMarjBC8H0y8L8ocsZLxh7MttzwFU3pjoItF5fRVGxHS0Hsvje9jO3yJsfw==",
 			"dev": true
 		},
 		"node_modules/@ungap/promise-all-settled": {
@@ -1040,6 +1050,15 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/eslint/node_modules/ignore": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/espree": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -1457,10 +1476,9 @@
 			}
 		},
 		"node_modules/ignore": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-			"dev": true,
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+			"integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
 			"engines": {
 				"node": ">= 4"
 			}
@@ -3312,6 +3330,14 @@
 				"lodash": "^4.17.20",
 				"minimatch": "^3.0.4",
 				"strip-json-comments": "^3.1.1"
+			},
+			"dependencies": {
+				"ignore": {
+					"version": "4.0.6",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+					"dev": true
+				}
 			}
 		},
 		"@tootallnate/once": {
@@ -3381,9 +3407,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.53.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.53.0.tgz",
-			"integrity": "sha512-XjFWbSPOM0EKIT2XhhYm3D3cx3nn3lshMUcWNy1eqefk+oqRuBq8unVb6BYIZqXy9lQZyeUl7eaBCOZWv+LcXQ==",
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.63.0.tgz",
+			"integrity": "sha512-iePu1axOi5WSThV6l2TYcciBIpAlMarjBC8H0y8L8ocsZLxh7MttzwFU3pjoItF5fRVGxHS0Hsvje9jO3yJsfw==",
 			"dev": true
 		},
 		"@ungap/promise-all-settled": {
@@ -4084,6 +4110,14 @@
 				"table": "^6.0.4",
 				"text-table": "^0.2.0",
 				"v8-compile-cache": "^2.0.3"
+			},
+			"dependencies": {
+				"ignore": {
+					"version": "4.0.6",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+					"dev": true
+				}
 			}
 		},
 		"eslint-scope": {
@@ -4444,10 +4478,9 @@
 			"dev": true
 		},
 		"ignore": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-			"dev": true
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+			"integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ=="
 		},
 		"import-fresh": {
 			"version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -815,6 +815,12 @@
 				"icon": "$(cloud-upload)"
 			},
 			{
+				"command": "code-for-ibmi.setDeployDirectory",
+				"title": "Deploy Workspace to directory",
+				"category": "IBM i",
+				"icon": "$(cloud-upload)"
+			},
+			{
 				"command": "code-for-ibmi.addIFSShortcut",
 				"title": "Add IFS shortcut",
 				"category": "IBM i",
@@ -1182,6 +1188,11 @@
 					"command": "code-for-ibmi.uploadStreamfile",
 					"when": "view == ifsBrowser && viewItem == directory",
 					"group": "3_ifsTransfer@2"
+				},
+				{
+					"command": "code-for-ibmi.setDeployDirectory",
+					"when": "view == ifsBrowser && viewItem == directory && code-for-ibmi:workspace == true",
+					"group": "3_ifsTransfer@3"
 				},
 				{
 					"command": "code-for-ibmi.createSourceFile",

--- a/package.json
+++ b/package.json
@@ -1248,6 +1248,7 @@
 	},
 	"extensionDependencies": [
 		"barrettotte.ibmi-languages",
-		"HalcyonTechLtd.vscode-ibmi-walkthroughs"
+		"HalcyonTechLtd.vscode-ibmi-walkthroughs",
+		"vscode.git"
 	]
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,13 @@
 								"type": "array",
 								"items": {
 									"type": "object",
-									"required": ["name", "library", "object", "types", "member"],
+									"required": [
+										"name",
+										"library",
+										"object",
+										"types",
+										"member"
+									],
 									"properties": {
 										"name": {
 											"type": "string",
@@ -84,7 +90,9 @@
 												"type": "string",
 												"description": "Object type. Usually starts with an asterisk."
 											},
-											"default": ["*ALL"]
+											"default": [
+												"*ALL"
+											]
 										},
 										"member": {
 											"type": "string",
@@ -189,7 +197,11 @@
 							"sourceDateLocation": {
 								"type": "string",
 								"default": "none",
-								"enum": ["none", "bar", "inline"],
+								"enum": [
+									"none",
+									"bar",
+									"inline"
+								],
 								"description": "The location of the source date of the current line will be displayed."
 							},
 							"clContentAssistEnabled": {
@@ -200,13 +212,62 @@
 							"encodingFor5250": {
 								"type": "string",
 								"default": "default",
-								"enum": ["default", "37", "256", "273", "277", "278", "280", "284", "285", "297", "500", "871", "870", "905", "880", "420", "875", "424", "1026", "290", "win37", "win256", "win273", "win277", "win278", "win280", "win284", "win285", "win297", "win500", "win871", "win870", "win905", "win880", "win420", "win875", "win424", "win1026"],
+								"enum": [
+									"default",
+									"37",
+									"256",
+									"273",
+									"277",
+									"278",
+									"280",
+									"284",
+									"285",
+									"297",
+									"500",
+									"871",
+									"870",
+									"905",
+									"880",
+									"420",
+									"875",
+									"424",
+									"1026",
+									"290",
+									"win37",
+									"win256",
+									"win273",
+									"win277",
+									"win278",
+									"win280",
+									"win284",
+									"win285",
+									"win297",
+									"win500",
+									"win871",
+									"win870",
+									"win905",
+									"win880",
+									"win420",
+									"win875",
+									"win424",
+									"win1026"
+								],
 								"description": "The encoding for the 5250 emulator. To use the 5250 emulator, tn5250 must be installed on the remote system via yum."
 							},
 							"terminalFor5250": {
 								"type": "string",
 								"default": "default",
-								"enum": ["default", "IBM-3477-FC", "IBM-3477-FG", "IBM-3180-2 ", "IBM-3179-2 ", "IBM-3196-A1", "IBM-5292-2", "IBM-5291-1", "IBM-5251-11"],
+								"enum": [
+									"default",
+									"IBM-3477-FC",
+									"IBM-3477-FG",
+									"IBM-3180-2 ",
+									"IBM-3179-2 ",
+									"IBM-3196-A1",
+									"IBM-5292-2",
+									"IBM-5291-1",
+									"IBM-5251-11"
+								],
 								"description": "The terminal type for the 5250 emulator. To use the 5250 emulator, tn5250 must be installed on the remote system via yum."
 							},
 							"setDeviceNameFor5250": {
@@ -247,7 +308,12 @@
 						"type": "string",
 						"title": "IFS directory"
 					},
-					"default": ["node_modules", ".git", "vendor", "__pycache__"],
+					"default": [
+						"node_modules",
+						".git",
+						"vendor",
+						"__pycache__"
+					],
 					"description": "List of directories that will be ignored when searching the IFS."
 				},
 				"code-for-ibmi.logCompileOutput": {
@@ -362,22 +428,22 @@
 					},
 					"default": [
 						{
-						    "type": "member",
-						    "extensions": [
-							"CBLLE",
-							"CBL"
-						    ],
-						    "name": "Create Bound COBOL Program (CRTBNDCBL)",
-						    "command": "CRTBNDCBL (&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*SOURCE) DBGVIEW(*SOURCE)"
+							"type": "member",
+							"extensions": [
+								"CBLLE",
+								"CBL"
+							],
+							"name": "Create Bound COBOL Program (CRTBNDCBL)",
+							"command": "CRTBNDCBL (&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*SOURCE) DBGVIEW(*SOURCE)"
 						},
 						{
-						    "type": "member",
-						    "extensions": [
-							"CBLLE",
-							"CBL"
-						    ],
-						    "name": "Create Module CBLLE (CRTCBLMOD)",
-						    "command": "CRTCBLMOD MODULE(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*SOURCE) DBGVIEW(*SOURCE)"
+							"type": "member",
+							"extensions": [
+								"CBLLE",
+								"CBL"
+							],
+							"name": "Create Module CBLLE (CRTCBLMOD)",
+							"command": "CRTCBLMOD MODULE(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*SOURCE) DBGVIEW(*SOURCE)"
 						},
 						{
 							"type": "member",
@@ -1247,6 +1313,7 @@
 	"dependencies": {
 		"@bendera/vscode-webview-elements": "^0.3.0",
 		"csv-parse": "^4.15.1",
+		"ignore": "^5.1.9",
 		"node-ssh": "^11.1.1",
 		"tmp": "^0.2.1",
 		"xml2js": "^0.4.23"

--- a/package.json
+++ b/package.json
@@ -321,7 +321,8 @@
 								"enum": [
 									"member",
 									"streamfile",
-									"object"
+									"object",
+									"file"
 								]
 							},
 							"environment": {
@@ -352,6 +353,10 @@
 							"command": {
 								"type": "string",
 								"description": "Action command"
+							},
+							"deployFirst": {
+								"type": "boolean",
+								"description": "If enabled and type is local, the deployment process will run before the Action."
 							}
 						}
 					},

--- a/src/Instance.js
+++ b/src/Instance.js
@@ -8,6 +8,9 @@ const CompileTools = require(`./api/CompileTools`);
 const Configuration = require(`./api/Configuration`);
 const Storage = require(`./api/Storage`);
 
+const Terminal = require(`./api/terminal`);
+const Deployment = require(`./api/Deployment`);
+
 const Disposable = require(`./api/Disposable`);
 const { CustomUI, Field } = require(`./api/CustomUI`);
 
@@ -114,8 +117,6 @@ module.exports = class Instance {
 
     const CLCommands = require(`./languages/clle/clCommands`);
 
-    const Terminal = require(`./api/terminal`);
-
     if (instance.connection) {
       instance.storage = new Storage(context, instance.connection.currentConnectionName);
 
@@ -186,6 +187,8 @@ module.exports = class Instance {
 
         actionsUI.init(context);
         variablesUI.init(context);
+
+        const deployment = new Deployment(context, this);
 
         //********* Library list view */
 

--- a/src/Instance.js
+++ b/src/Instance.js
@@ -441,6 +441,7 @@ module.exports = class Instance {
                 switch (scheme) {
                 case `member`:
                 case `streamfile`:
+                case `file`:
                   CompileTools.RunAction(this, uri);
                   break;
                 }

--- a/src/api/CompileTools.js
+++ b/src/api/CompileTools.js
@@ -51,7 +51,7 @@ module.exports = class CompileTools {
   
   /**
    * @param {*} instance
-   * @param {{asp?: string, lib: string, object: string, ext?: string}} evfeventInfo
+   * @param {{asp?: string, lib: string, object: string, ext?: string, translate?: {local: string, remote: string}}} evfeventInfo
    */
   static async refreshDiagnostics(instance, evfeventInfo) {
     const content = instance.getContent();
@@ -104,9 +104,17 @@ module.exports = class CompileTools {
           }
         }
 
-        if (file.startsWith(`/`))
-          ileDiagnostics.set(vscode.Uri.parse(`streamfile:${file}`), diagnostics);
-        else
+        if (file.startsWith(`/`)) {
+          if (evfeventInfo.translate) {
+            if (file.toUpperCase().startsWith(evfeventInfo.translate.remote.toUpperCase())) {
+              const relative = file.substring(evfeventInfo.translate.remote.length);
+              const local = path.join(evfeventInfo.translate.local, relative);
+              ileDiagnostics.set(vscode.Uri.file(local), diagnostics);
+            }
+          } else {
+            ileDiagnostics.set(vscode.Uri.parse(`streamfile:${file}`), diagnostics);
+          }
+        } else
           ileDiagnostics.set(vscode.Uri.parse(`member:/${asp}${file}${evfeventInfo.ext ? `.` + evfeventInfo.ext : ``}`), diagnostics);
         
       }
@@ -272,11 +280,18 @@ module.exports = class CompileTools {
         if (command) {
 
           if (action.type === `file` && action.deployFirst) {
+            /** @type {{workspace: number}|false} */
             const deployResult = await vscode.commands.executeCommand(`code-for-ibmi.launchDeploy`);
 
             if (!deployResult) {
               vscode.window.showWarningMessage(`Action ${chosenOptionName} was cancelled.`);
               return;
+            } else {
+              const workspace = vscode.workspace.workspaceFolders.find(folder => folder.index === deployResult.workspace);
+              evfeventInfo.translate = {
+                local: workspace.uri.path,
+                remote: config.homeDirectory
+              }
             }
           }
 

--- a/src/api/CustomUI.js
+++ b/src/api/CustomUI.js
@@ -266,6 +266,8 @@ class Field  {
   }
 
   getHTML() {
+    this.default = this.default ? this.default.replace(/"/g, `&quot;`) : undefined;
+
     switch (this.type) {
     case `submit`:
       return `<vscode-button id="${this.id}">${this.label}</vscode-button>`;

--- a/src/api/Deployment.js
+++ b/src/api/Deployment.js
@@ -113,9 +113,7 @@ module.exports = class Deployment {
                         this.deploymentLog.appendLine(`Deployment finished.`);
                         vscode.window.showInformationMessage(`Deployment finished.`);
 
-                        return {
-                          workspace: folder.index
-                        };
+                        return true;
                       } catch (e) {
                         this.button.text = BUTTON_BASE;
                         vscode.window.showErrorMessage(`Deployment failed.`, `View Log`).then(async (action) => {
@@ -199,9 +197,7 @@ module.exports = class Deployment {
                 this.button.text = BUTTON_BASE;
                 if (uploadResult) {
                   vscode.window.showInformationMessage(`Deployment finished.`);
-                  return {
-                    workspace: folder.index
-                  };
+                  return true;
                   
                 } else {
                   vscode.window.showErrorMessage(`Deployment failed.`, `View Log`).then(async (action) => {

--- a/src/api/Deployment.js
+++ b/src/api/Deployment.js
@@ -105,6 +105,8 @@ module.exports = class Deployment {
                     
                       this.button.text = BUTTON_WORKING;
 
+                      vscode.window.showInformationMessage(`Deploying staged changes (${uploads.length}) to ${remotePath}`);
+
                       try {
                         await client.putFiles(uploads, {
                           concurrency: 5
@@ -127,7 +129,7 @@ module.exports = class Deployment {
                       }
 
                     } else {
-                      vscode.window.showInformationMessage(`No staged changes to deploy.`);
+                      vscode.window.showWarningMessage(`No staged changes to deploy.`);
                     }
 
                   } else {

--- a/src/api/Deployment.js
+++ b/src/api/Deployment.js
@@ -3,6 +3,7 @@ const path = require(`path`);
 const vscode = require(`vscode`);
 
 const IBMi = require(`./IBMi`);
+const Configuration = require(`./Configuration`);
 const Storage = require(`./Storage`);
 
 const gitExtension = vscode.extensions.getExtension(`vscode.git`).exports;
@@ -65,6 +66,15 @@ module.exports = class Deployment {
             if (method) {
               /** @type {IBMi} */
               const ibmi = instance.getConnection();
+
+              /** @type {Configuration} */
+              const config = instance.getConfig();
+
+              if (config.homeDirectory !== remotePath) {
+                await config.set(`homeDirectory`, remotePath);
+                vscode.window.showInformationMessage(`Home directory set to ${remotePath} for deployment.`);
+              }
+
               const client = ibmi.client;
               this.deploymentLog.clear();
 

--- a/src/api/Deployment.js
+++ b/src/api/Deployment.js
@@ -1,0 +1,181 @@
+
+const vscode = require(`vscode`);
+const IBMi = require(`./IBMi`);
+const Storage = require(`./Storage`);
+
+const DEPLOYMENT_KEY = `deployment`;
+
+const BUTTON_BASE = `$(cloud-upload) Deploy`;
+const BUTTON_WORKING = `$(sync~spin) Deploying`;
+
+module.exports = class Deployment {
+  /**
+   * 
+   * @param {vscode.ExtensionContext} context 
+   * @param {*} instance 
+   */
+  constructor(context, instance) {
+    this.instance = instance;
+    
+    this.deploymentLog = vscode.window.createOutputChannel(`IBM i Deployment`);
+
+    /** @type {vscode.StatusBarItem} */
+    this.button = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
+    this.button.command = {
+      command: `code-for-ibmi.launchDeploy`,
+      title: `Launch Deploy`
+    }
+    this.button.text = BUTTON_BASE;
+
+    context.subscriptions.push(this.button, this.deploymentLog);
+
+    if (vscode.workspace.workspaceFolders.length > 0) {
+      vscode.commands.executeCommand(`setContext`, `code-for-ibmi:workspace`, true);
+      this.button.show();
+    }
+
+    context.subscriptions.push(
+      vscode.commands.registerCommand(`code-for-ibmi.launchDeploy`, async (workspaceIndex) => {
+        /** @type {Storage} */
+        const storage = instance.getStorage();
+
+        let folder;
+
+        if (workspaceIndex) {
+          folder = vscode.workspace.workspaceFolders.find(dir => dir.index === workspaceIndex);
+        } else {
+          folder = await Deployment.getWorkspaceFolder();
+        }
+
+        if (folder) {
+          const existingPaths = storage.get(DEPLOYMENT_KEY) || {};
+          const remotePath = existingPaths[folder.uri.fsPath];
+
+          if (remotePath) {
+            const method = await vscode.window.showQuickPick(
+              [`Changes`, `All`],
+              { placeHolder: `Select deployment method` }
+            );
+
+            if (method) {
+              /** @type {IBMi} */
+              const ibmi = instance.getConnection();
+              const client = ibmi.client;
+              this.deploymentLog.clear();
+
+              switch (method) {
+              case `Changes`: // Uses git
+                break;
+
+              case `All`: // Uploads entire directory
+                const uploadResult = await vscode.window.withProgress({
+                  location: vscode.ProgressLocation.Notification,
+                  title: `Deploying to ${folder.name}`,
+                }, async (progress) => {
+                  this.button.text = BUTTON_WORKING;
+                  progress.report({ message: `Deploying to ${folder.name}` });
+                  try {
+                    await client.putDirectory(folder.uri.fsPath, remotePath, {
+                      recursive: true,
+                      concurrency: 5,
+                      tick: (localPath, remotePath, error) => {
+                        if (error) {
+                          progress.report({ message: `Failed to deploy ${localPath}` });
+                          this.deploymentLog.appendLine(`FAILED: ${localPath} -> ${remotePath}: ${error.message}`);
+                        } else {
+                          progress.report({ message: `Deployed ${localPath}` });
+                          this.deploymentLog.appendLine(`SUCCESS: ${localPath} -> ${remotePath}`);
+                        }
+                      }
+                    });
+
+                    progress.report({ message: `Deployment finished.` });
+                    this.deploymentLog.appendLine(`Deployment finished.`);
+
+                    return true;
+                  } catch (e) {
+                    progress.report({ message: `Deployment failed.` });
+                    this.deploymentLog.appendLine(`Deployment failed`);
+                    this.deploymentLog.appendLine(e);
+
+                    return false;
+                  }
+                });
+
+                this.button.text = BUTTON_BASE;
+                if (uploadResult) {
+                  vscode.window.showInformationMessage(`Deployment finished.`);
+                  return true;
+                } else {
+                  vscode.window.showErrorMessage(`Deployment failed.`, `View Log`).then(async (action) => {
+                    if (action === `View Log`) {
+                      this.deploymentLog.show();
+                    }
+                  });
+
+                  return false;
+                }
+              }
+            }
+          } else {
+            vscode.window.showErrorMessage(`Chosen folder (${folder.uri.fsPath}) is not configured for deployment.`);
+          }
+        } else {
+          vscode.window.showErrorMessage(`No folder selected for deployment.`);
+        }
+      }),
+
+      vscode.commands.registerCommand(`code-for-ibmi.setDeployDirectory`, async (directory) => {
+        let path;
+        if (directory) {
+          path = directory.path;
+        } else {
+          path = await vscode.window.showInputBox({
+            prompt: `Enter IFS directory to deploy to`,
+          });
+        }
+
+        if (path) {
+        /** @type {Storage} */
+          const storage = instance.getStorage();
+
+          const chosenWorkspaceFolder = await Deployment.getWorkspaceFolder();
+
+          if (chosenWorkspaceFolder) {
+            const existingPaths = storage.get(DEPLOYMENT_KEY) || {};
+            existingPaths[chosenWorkspaceFolder.uri.fsPath] = path;
+            await storage.set(DEPLOYMENT_KEY, existingPaths);
+
+            vscode.window.showInformationMessage(`Deployment directory set to ${path}`, `Deploy now`).then(async (choice) => {
+              if (choice === `Deploy now`) {
+                vscode.commands.executeCommand(`code-for-ibmi.launchDeploy`, chosenWorkspaceFolder.index);
+              }
+            });
+          }
+        }
+      }),
+    );
+  }
+
+  static async getWorkspaceFolder() {
+    const workspaces = vscode.workspace.workspaceFolders;
+
+    if (workspaces.length > 0) {
+      if (workspaces.length === 1) {
+        return workspaces[0];
+      } else {
+        const chosen = await vscode.window.showQuickPick(workspaces.map(dir => dir.name), {
+          placeHolder: `Select workspace to deploy to`
+        });
+
+        if (chosen) {
+          return workspaces.find(dir => dir.name === chosen);
+        }
+
+        return null;
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/webviews/actions/index.js
+++ b/src/webviews/actions/index.js
@@ -135,6 +135,7 @@ module.exports = class SettingsUI {
     const custom = config.customVariables.map(variable => `<li><b><code>&amp;${variable.name}</code></b>: <code>${variable.value}</code></li>`).join(``);
 
     let ui = new CustomUI();
+    let field;
 
     ui.addField(new Field(`input`, `name`, `Action name`));
     ui.fields[0].default = currentAction.name;
@@ -151,6 +152,7 @@ module.exports = class SettingsUI {
     case `member`:
       ui.fields[3].default = `0`;
       break;
+    case `file`:
     case `streamfile`:
       ui.fields[3].default = `1`;
       break;
@@ -164,7 +166,7 @@ module.exports = class SettingsUI {
         value: `<ul>${Variables.Member.map(variable => `<li><b><code>${variable.name}</code></b>: ${variable.text}</li>`).join(``)}${custom}</ul>`,
       },
       {
-        label: `Streamfile`,
+        label: `Streamfile / File`,
         value: `<ul>${Variables.Streamfile.map(variable => `<li><b><code>${variable.name}</code></b>: ${variable.text}</li>`).join(``)}${custom}</ul>`,
       },
       {
@@ -199,6 +201,12 @@ module.exports = class SettingsUI {
         value: `object`,
         description: `Object`,
         text: `Objects in the QSYS file system`,
+      },
+      {
+        selected: currentAction.type === `file`,
+        value: `file`,
+        description: `Local File (Workspace)`,
+        text: `Actions for local files in the VS Code Workspace.`,
       }
     ];
 
@@ -225,7 +233,15 @@ module.exports = class SettingsUI {
       }
     ];
 
-    const field = new Field(`buttons`);
+    ui.addField(new Field(`hr`));
+
+    field = new Field(`checkbox`, `deployFirst`, `Run Deploy First`);
+    field.description = `Run deploy first before running the command. Only works for local files.`;
+    ui.addField(field);
+
+    ui.addField(new Field(`hr`));
+
+    field = new Field(`buttons`);
     field.items = [
       {
         id: `saveAction`,
@@ -260,7 +276,8 @@ module.exports = class SettingsUI {
           extensions: data.extensions.split(`,`).map(item => item.trim().toUpperCase()),
           environment: data.environment,
           name: data.name,
-          command: data.command
+          command: data.command,
+          deployFirst: data.deployFirst,
         };
     
         if (id >= 0) {

--- a/src/webviews/actions/index.js
+++ b/src/webviews/actions/index.js
@@ -236,6 +236,7 @@ module.exports = class SettingsUI {
     ui.addField(new Field(`hr`));
 
     field = new Field(`checkbox`, `deployFirst`, `Run Deploy First`);
+    field.default = (currentAction.deployFirst ? `checked` : ``);
     field.description = `Run deploy first before running the command. Only works for local files.`;
     ui.addField(field);
 


### PR DESCRIPTION
### Changes

Adds the ability to deploy a VS Code workspace folder. Change list:

* New right-click menu to deploy to a certain IFS directory
* New status bar icon to Deploy current workspace folder(s)
* New Action type for 'file' (local files)
* New Action option to run the deploy before running the Action

### Checklist

* [x] have tested my change **(needs testing on Windows)**
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [x] **for feature PRs**: PR only includes one feature enhancement.
