### PR TITLE
Fix issue where control characters in body caused crash

### DIFF
--- a/src/api/IBMiContent.js
+++ b/src/api/IBMiContent.js
@@ -134,9 +134,13 @@ module.exports = class IBMiContent {
       let output = await this.ibmi.paseCommand(`DB2UTIL_JSON_CONTAINER=array ${command} -o json "${statement}"`);
 
       if (typeof output === `string`) {
-        //Little hack for db2util returns blanks where it should be null.
+        // Little hack for db2util returns blanks where it should be null.
         output = output.replace(new RegExp(`:,`, `g`), `:null,`);
         output = output.replace(new RegExp(`:}`, `g`), `:null}`);
+
+        // Remove control characters
+        output = output.replace(/[\u0000-\u001F\u007F-\u009F]/g, ` `);
+
         const rows = JSON.parse(output);
         for (let row of rows)
           for (let key in row) {

--- a/src/filesystems/qsys/complex.js
+++ b/src/filesystems/qsys/complex.js
@@ -36,7 +36,7 @@ module.exports = class ComplexQsysFs {
       return new Uint8Array(Buffer.from(memberContent, `utf8`));
 
     } catch (e) {
-      vscode.window.showErrorMessage(e);
+      vscode.window.showErrorMessage(`Error downloading member content: ${e.message}`);
     }
 
   }


### PR DESCRIPTION
### Changes

Members with control characters were causing members not to load when db2 was enabled. This 'fix' removes to control characters before the SQL JSON response is parsed.

Closes #450 

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
