### PR TITLE
Fix for building from local on Windows

### DIFF
--- a/src/api/CompileTools.js
+++ b/src/api/CompileTools.js
@@ -281,15 +281,19 @@ module.exports = class CompileTools {
 
           switch (action.type) {
           case `file`:
-            command = command.replace(new RegExp(`&LOCALPATH`, `g`), uri.path);
+            command = command.replace(new RegExp(`&LOCALPATH`, `g`), uri.fsPath);
 
             if (evfeventInfo.workspace !== false) {
               /** @type {vscode.WorkspaceFolder} *///@ts-ignore We know it's a number
               const currentWorkspace = vscode.workspace.workspaceFolders[evfeventInfo.workspace];
               if (currentWorkspace) {
-                const workspacePath = currentWorkspace.uri.path;
-                const relativePath = path.relative(workspacePath, uri.path);
-                const remoteDeploy = path.join(config.homeDirectory, relativePath)
+                const workspacePath = currentWorkspace.uri.fsPath;
+                
+                const relativePath = path.relative(workspacePath, uri.fsPath);
+                command = command.replace(new RegExp(`&RELATIVEPATH`, `g`), relativePath);
+
+                // We need to make sure the remote path is posix
+                const remoteDeploy = path.posix.join(config.homeDirectory, relativePath).split(path.sep).join(path.posix.sep);
 
                 command = command.replace(new RegExp(`&FULLPATH`, `g`), remoteDeploy);
               }

--- a/src/api/CompileTools.js
+++ b/src/api/CompileTools.js
@@ -300,6 +300,9 @@ module.exports = class CompileTools {
             }
             break;
           case `streamfile`:
+            const relativePath = path.relative(config.homeDirectory, uri.fsPath);
+            command = command.replace(new RegExp(`&RELATIVEPATH`, `g`), relativePath);
+            
             command = command.replace(new RegExp(`&FULLPATH`, `g`), uri.path);
             break;
           }

--- a/src/webviews/actions/varinfo.js
+++ b/src/webviews/actions/varinfo.js
@@ -17,6 +17,7 @@ module.exports = {
   ],
   'Streamfile': [
     {name: `&amp;FULLPATH`, text: `Full path of the streamfile`},
+    {name: `&amp;RELATIVEPATH`, text: `Relative path of the streamfile from the home directory or workspace.`},
     {name: `&amp;NAME`, text: `Name of the streamfile (<code>&amp;NAMEL</code> for lowercase)`},
     {name: `&amp;EXT`, text: `Extension of the streamfile (<code>&amp;EXTL</code> for lowercase)`},
     ...generic


### PR DESCRIPTION
### Changes

* Fix for Windows when running an Action against a local file
* Adds `&RELATIVEPATH` for both `streamfile` and `file` types.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
