### PR TITLE
New way to run statements without db2util

### DIFF
--- a/docs/api/extending.md
+++ b/docs/api/extending.md
@@ -14,7 +14,7 @@ We provide three base APIs for you to use. This document only covers `instance`.
 
 * `getConnection()`: [`IBMi`](https://github.com/halcyon-tech/vscode-ibmi/blob/master/src/api/IBMi.js)`|undefined` to get the current connection. Will return `undefined` when the current workspace is not connected to a remote system.
 * `getContent(): `[`IBMiContent`](https://github.com/halcyon-tech/vscode-ibmi/blob/master/src/api/IBMiContent.js) to work with content on the current connection
-   * `IBMiContent` has methods to run SQL statements (requires `db2util`), get the contents of tables (without `db2util`) and read and write members/streamfiles.
+   * `IBMiContent` has methods to run SQL statements (requires `db2util` or `db2` which is part of the OS), get the contents of tables (without `db2util`) and read and write members/streamfiles.
 * `getConfig(): `[`Configuration`](https://github.com/halcyon-tech/vscode-ibmi/blob/master/src/api/Configuration.js) to get/set configuration for the current connection
 * `on(event: string, callback: Function): void` to add an event handler. Available events:
   * `connected` which can be used to determine when Code for IBM i has established a connection.
@@ -83,10 +83,6 @@ You can use `instance.getConnection()` to determine if there is a connection:
   }
 ```
 
-### Temporary library
-
-Please remember that you cannot use `QTEMP` between commands since each command runs in a new job. Please refer to `instance.getConfig().tempLibrary` for a temporary library.
-
 ### Running commands with the user library list
 
 Code for IBM i ships a command that can be used by an extension to execute a remote command on the IBM i: `code-for-ibmi.runCommand`.
@@ -103,6 +99,25 @@ The command returns an object with the following properties:
 * `stdout: string` - usually contains the spoolfile from the `ile` environment
 * `stderr: string`
 * `code: number|null` - `0` or `null` usually indicates no error.
+
+```js
+const result = await vscode.commands.executeCommand(`code-for-ibmi.runCommand`, {
+  environment: `pase`,
+  command: `ls`
+});
+```
+
+### Running SQL queries
+
+Code for IBM i has a command that lets you run SQL statements and get a result back.
+
+```js
+const rows = await vscode.commands.executeCommand(`code-for-ibmi.runQuery`, statement);
+```
+
+### Temporary library
+
+Please remember that you cannot use `QTEMP` between commands since each command runs in a new job. Please refer to `instance.getConfig().tempLibrary` for a temporary library.
 
 ### Storing config specific to the connection
 

--- a/src/Instance.js
+++ b/src/Instance.js
@@ -499,7 +499,14 @@ module.exports = class Instance {
             } else {
               return null;
             }
-          })
+          }),
+          vscode.commands.registerCommand(`code-for-ibmi.runQuery`, (statement) => {
+            if (statement) {
+              return instance.content.runSQL(statement);
+            } else {
+              return null;
+            }
+          }),
         );
 
         context.subscriptions.push(

--- a/src/api/CompileTools.js
+++ b/src/api/CompileTools.js
@@ -70,7 +70,7 @@ module.exports = class CompileTools {
   
   /**
    * @param {*} instance
-   * @param {{asp?: string, lib: string, object: string, ext?: string, workspace?: number|boolean}} evfeventInfo
+   * @param {{asp?: string, lib: string, object: string, ext?: string, workspace?: number}} evfeventInfo
    */
   static async refreshDiagnostics(instance, evfeventInfo) {
     const content = instance.getContent();
@@ -123,7 +123,7 @@ module.exports = class CompileTools {
           }
         }
 
-        if (vscode.workspace && evfeventInfo.workspace !== null && evfeventInfo.workspace !== false) {
+        if (vscode.workspace && evfeventInfo.workspace && evfeventInfo.workspace >= 0) {
           const baseInfo = path.parse(file);
           const parentInfo = path.parse(baseInfo.dir);
 
@@ -169,7 +169,7 @@ module.exports = class CompileTools {
    * @param {vscode.Uri} uri 
    */
   static async RunAction(instance, uri) {
-    /** @type {{asp?: string, lib: string, object: string, ext?: string, workspace?: number|boolean}} */
+    /** @type {{asp?: string, lib: string, object: string, ext?: string, workspace?: number}} */
     let evfeventInfo = {asp: undefined, lib: ``, object: ``, workspace: null};
 
     /** @type {Configuration} */
@@ -283,7 +283,7 @@ module.exports = class CompileTools {
           case `file`:
             command = command.replace(new RegExp(`&LOCALPATH`, `g`), uri.fsPath);
 
-            if (evfeventInfo.workspace !== false) {
+            if (evfeventInfo.workspace) {
               /** @type {vscode.WorkspaceFolder} *///@ts-ignore We know it's a number
               const currentWorkspace = vscode.workspace.workspaceFolders[evfeventInfo.workspace];
               if (currentWorkspace) {

--- a/src/api/IBMi.js
+++ b/src/api/IBMi.js
@@ -11,7 +11,7 @@ let remoteApps = [
   },
   {
     path: `/usr/bin/`,
-    names: [`setccsid`]
+    names: [`setccsid`, `db2`]
   }
 ];
 
@@ -45,6 +45,7 @@ module.exports = class IBMi {
       grep: undefined,
       tn5250: undefined,
       setccsid: undefined,
+      db2: undefined,
       'GENCMDXML.PGM': undefined
     };
   }

--- a/src/filesystems/qsys/complex/content.js
+++ b/src/filesystems/qsys/complex/content.js
@@ -24,13 +24,13 @@ module.exports = class IBMiContent {
   static async downloadMemberContentWithDates(asp, lib, spf, mbr) {
     const connection = instance.getConnection();
     const content = instance.getContent();
-    const db2 = connection.remoteFeatures.db2util;
+    const db2util = connection.remoteFeatures.db2util;
 
     lib = lib.toUpperCase();
     spf = spf.toUpperCase();
     mbr = mbr.toUpperCase();
 
-    if (db2) {
+    if (db2util) {
       const tempLib = connection.config.tempLibrary;
       const alias = `${lib}_${spf}_${mbr.replace(/\./g, `_`)}`;
       const aliasPath = `${tempLib}.${alias}`;
@@ -83,10 +83,10 @@ module.exports = class IBMiContent {
    */
   static async uploadMemberContentWithDates(asp, lib, spf, mbr, body) {
     const connection = instance.getConnection();
-    const db2 = connection.remoteFeatures.db2util;
+    const db2util = connection.remoteFeatures.db2util;
     const setccsid = connection.remoteFeatures.setccsid;
 
-    if (db2) {
+    if (db2util) {
       const tempLib = connection.config.tempLibrary;
       const alias = `${lib}_${spf}_${mbr.replace(/\./g, `_`)}`;
       const aliasPath = `${tempLib}.${alias}`;


### PR DESCRIPTION
### Changes

* Ability to let the user run statements without having `db2util` installed.
* New runQuery command for other extensions to make use of.

### Checklist

* [x] have tested my change
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
