### PR TITLE
Remove period after home directory command

### DIFF
--- a/src/api/IBMi.js
+++ b/src/api/IBMi.js
@@ -302,7 +302,7 @@ module.exports = class IBMi {
               });
           }
         } else {
-          vscode.window.showWarningMessage(`Code for IBM i may not function correctly until your user has a home directory. Please set a home directory using CHGUSRPRF USRPRF(${connectionObject.username.toUpperCase()}) HOMEDIR('/home/${connectionObject.username.toLowerCase()}').`);
+          vscode.window.showWarningMessage(`Code for IBM i may not function correctly until your user has a home directory. Please set a home directory using CHGUSRPRF USRPRF(${connectionObject.username.toUpperCase()}) HOMEDIR('/home/${connectionObject.username.toLowerCase()}')`);
         }
 
         return {


### PR DESCRIPTION
Make it easier to copy and paste the CHGUSRPRF command by removing the period after it. First time I pasted the command, it included the period and didn't work. (Very helpful message, incidentally!)

You can see how the period would end up copy/pasted accidentally.
![image](https://user-images.githubusercontent.com/5905791/148447204-e255a77a-a212-4c30-9d89-bea87ae59317.png)


### Changes

Description of change here.

### Checklist

* [ ] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
