### PR TITLE
Add sqlExecutor config to let user choose which CLI tool to use

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,6 +165,16 @@
 								"default": "ILEDITOR",
 								"description": "Temporary library. Cannot be QTEMP."
 							},
+							"sqlExecutor": {
+								"type": "string",
+								"default": "default",
+								"enum": [
+									"default",
+									"db2util",
+									"db2"
+								],
+								"description": "The location of the source date of the current line will be displayed."
+							},
 							"currentLibrary": {
 								"type": "string",
 								"default": "QTEMP",

--- a/src/Instance.js
+++ b/src/Instance.js
@@ -522,7 +522,7 @@ module.exports = class Instance {
           }),
           vscode.commands.registerCommand(`code-for-ibmi.runQuery`, (statement) => {
             if (statement) {
-              return instance.content.runSQL(statement);
+              return instance.content.runSQL(statement, config.sqlExecutor);
             } else {
               return null;
             }

--- a/src/api/Configuration.js
+++ b/src/api/Configuration.js
@@ -29,6 +29,9 @@ module.exports = class Configuration {
     /** @type {string} */
     this.homeDirectory = base.homeDirectory || `.`;
 
+    /** @type {"default"|"db2util"|"db2"} */
+    this.sqlExecutor = base.sqlExecutor || `default`;
+
     /** @type {string} */
     this.tempLibrary = base.tempLibrary || `ILEDITOR`;
 

--- a/src/views/databaseBrowser.js
+++ b/src/views/databaseBrowser.js
@@ -58,6 +58,7 @@ module.exports = class databaseBrowserProvider {
 
       vscode.commands.registerCommand(`code-for-ibmi.runEditorStatement`, async () => {
         const content = instance.getContent();
+        const config = instance.getConfig();
         const editor = vscode.window.activeTextEditor;
 
         if (editor.document.languageId === `sql`) {
@@ -68,7 +69,7 @@ module.exports = class databaseBrowserProvider {
             try {
               switch (statement.type) {
               case `sql`:
-                const data = await content.runSQL(statement.content);
+                const data = await content.runSQL(statement.content, config.sqlExecutor);
 
                 if (data.length > 0) {
                   const panel = vscode.window.createWebviewPanel(

--- a/src/webviews/settings/index.js
+++ b/src/webviews/settings/index.js
@@ -53,6 +53,30 @@ module.exports = class SettingsUI {
         field.default = config.tempLibrary;
         field.description = `Temporary library. Cannot be QTEMP.`;
         ui.addField(field);
+
+        field = new Field(`select`, `sqlExecutor`, `SQL executor`);
+        field.description = `Which method should be used to execute SQL statements.`;
+        field.items = [
+          {
+            selected: config.sqlExecutor === `default`,
+            value: `default`,
+            description: `Default`,
+            text: `db2util if is available, otherwise db2`,
+          },
+          {
+            selected: config.sqlExecutor === `db2util`,
+            value: `db2util`,
+            description: `db2util (PASE)`,
+            text: `db2util can be installed through yum`,
+          },
+          {
+            selected: config.sqlExecutor === `db2`,
+            value: `db2`,
+            description: `db2 (QSH)`,
+            text: `db2 is shipped with most versions of IBM i`,
+          }
+        ];
+        ui.addField(field);
     
         field = new Field(`input`, `sourceASP`, `Source ASP`);
         field.default = config.sourceASP;


### PR DESCRIPTION
### Changes

* Adds new configuration to let the user select which SQL tool should be used to run SQL statements.

### Checklist

* [x] have tested my change
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
