### PR TITLE
Remove executor config, db2 and db2util from extension

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -175,7 +175,7 @@ Add extra shortcuts as needed:
 
 ### Database Browser
 
-This shows libraries and the files/tables in each. It is effective only if db2Util is installed on the IBM i. Click on a file or table to see the field names.
+This shows libraries and the files/tables in each. Click on a file or table to see the field names.
 
 ## Editing and Compiling
 
@@ -553,7 +553,7 @@ Otherwise, leave blank.
 
 #### Enable source dates
 
-For source dates to be supported, `db2util` must be install on IBM i. This can be fetched via yum.
+When enabled, source dates will be retained.
 
 ## Snippets
 

--- a/docs/api/extending.md
+++ b/docs/api/extending.md
@@ -12,7 +12,7 @@ const { instance } = vscode.extensions.getExtension(`halcyontechltd.code-for-ibm
 
 * `getConnection()`: [`IBMi`](https://github.com/halcyon-tech/vscode-ibmi/blob/master/src/api/IBMi.js)`|undefined` to get the current connection. Will return `undefined` when the current workspace is not connected to a remote system.
 * `getContent(): `[`IBMiContent`](https://github.com/halcyon-tech/vscode-ibmi/blob/master/src/api/IBMiContent.js) to work with content on the current connection
-   * `IBMiContent` has methods to run SQL statements (requires `db2util` or `db2`, which is part of the OS), get the contents of tables (without `db2util`) and read and write members/streamfiles.
+   * `IBMiContent` has methods to run SQL statements, get the contents of tables and read and write members/streamfiles.
 * `getConfig(): `[`Configuration`](https://github.com/halcyon-tech/vscode-ibmi/blob/master/src/api/Configuration.js) to get/set configuration for the current connection
 * `on(event: string, callback: Function): void` to add an event handler. Available events:
   * `connected` which can be used to determine when Code for IBM i has established a connection.

--- a/package.json
+++ b/package.json
@@ -170,16 +170,10 @@
 								"default": false,
 								"description": "Automatically delete temporary objects from the temporary library on startup."
 							},
-							"sqlExecutor": {
-								"type": "string",
-								"default": "default",
-								"enum": [
-									"default",
-									"db2util",
-									"db2",
-									"none"
-								],
-								"description": "Which SQL executor that should be used for running queries."
+							"enableSQL": {
+								"type": "boolean",
+								"default": true,
+								"description": "Must be enabled to make the use of SQL and is enabled by default. If you find SQL isn't working for some reason, disable this. If this config is changed, you must reconnect to the system."
 							},
 							"currentLibrary": {
 								"type": "string",
@@ -192,7 +186,7 @@
 									"null"
 								],
 								"default": null,
-								"description": "If source files live within a specific ASP, please specify it here. Leave blank/null otherwise. You can ignore this column if you have access to `QSYS2.ASP_INFO` and have db2util installed, as Code for IBM i will fetch ASP information automatically."
+								"description": "If source files live within a specific ASP, please specify it here. Leave blank/null otherwise. You can ignore this column if you have access to `QSYS2.ASP_INFO` as Code for IBM i will fetch ASP information automatically."
 							},
 							"sourceFileCCSID": {
 								"type": "string",

--- a/src/Instance.js
+++ b/src/Instance.js
@@ -206,12 +206,12 @@ module.exports = class Instance {
 
         let qsysFs, basicMemberEditing = true;
         if (config.enableSourceDates) {
-          if (connection.remoteFeatures.db2util) {
+          if (connection.sqlEnabled) {
             basicMemberEditing = false;
             require(`./filesystems/qsys/complex/handler`).begin(context);
             qsysFs = new (require(`./filesystems/qsys/complex`));
           } else {
-            vscode.window.showWarningMessage(`Source date support is disabled. db2util must be installed.`);
+            vscode.window.showWarningMessage(`Source date support is disabled. SQL must be enabled.`);
           }
         }
 
@@ -502,7 +502,7 @@ module.exports = class Instance {
           }),
           vscode.commands.registerCommand(`code-for-ibmi.runQuery`, (statement) => {
             if (statement) {
-              return instance.content.runSQL(statement, config.sqlExecutor);
+              return instance.content.runSQL(statement);
             } else {
               return null;
             }

--- a/src/api/Configuration.js
+++ b/src/api/Configuration.js
@@ -32,8 +32,8 @@ module.exports = class Configuration {
     /** @type {string} */
     this.homeDirectory = base.homeDirectory || `.`;
 
-    /** @type {"default"|"db2util"|"db2"|"QZDFMDB2"|"none"} */
-    this.sqlExecutor = base.sqlExecutor || `default`;
+    /** @type {boolean} */
+    this.enableSQL = (base.enableSQL === true);
 
     /** @type {string} */
     this.tempLibrary = base.tempLibrary || `ILEDITOR`;

--- a/src/api/Tools.js
+++ b/src/api/Tools.js
@@ -1,0 +1,92 @@
+module.exports = class {
+  /**
+   * Parse standard out for `/usr/bin/db2`
+   * @param {string} output 
+   */
+  static db2Parse(output) {
+    let gotHeaders = false;
+    let figuredLengths = false;
+
+    let data = output.split(`\n`);
+
+    /** @type {{name: string, from: number, length: number}[]} */
+    let headers;
+  
+    let rows = [];
+      
+    data.forEach((line, index) => {
+      if (line.trim().length === 0 || index === data.length - 1) return;
+      if (gotHeaders === false) {
+        headers = line.split(` `).filter((x) => x.length > 0).map((x) => {
+          return {
+            name: x,
+            from: 0,
+            length: 0,
+          };
+        });
+      
+        gotHeaders = true;
+      } else
+      if (figuredLengths === false) {
+        let base = 0;
+        line.split(` `).forEach((x, i) => {
+          headers[i].from = base;
+          headers[i].length = x.length;
+      
+          base += x.length + 1;
+        });
+      
+        figuredLengths = true;
+      } else {
+        let row = {};
+      
+        headers.forEach((header) => {
+          const strValue = line.substring(header.from, header.from + header.length).trimEnd();
+
+          /** @type {string|number} */
+          let realValue = strValue;
+      
+          // is value a number?
+          if (strValue.startsWith(` `)) {
+            const asNumber = Number(strValue.trim());
+            if (!isNaN(asNumber)) {
+              realValue = asNumber;
+            }
+          } else if (strValue === `-`) {
+            realValue = ``; //null?
+          }
+                    
+          row[header.name] = realValue;
+        });
+      
+        rows.push(row);
+      }
+    });
+      
+    return rows;
+  }
+
+  static makeid() {
+    let text = `O_`;
+    let possible =
+      `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789`;
+  
+    for (let i = 0; i < 8; i++)
+      text += possible.charAt(Math.floor(Math.random() * possible.length));
+  
+    return text;
+  }
+
+  /**
+   * Build the IFS path string to a member
+   * @param {string|undefined} asp 
+   * @param {string} lib 
+   * @param {string} obj 
+   * @param {string} mbr 
+   */
+  static qualifyPath(asp, lib, obj, mbr) {
+    const path =
+      (asp && asp.length > 0 ? `/${asp}` : ``) + `/QSYS.lib/${lib}.lib/${obj}.file/${mbr}.mbr`;
+    return path;
+  }
+}

--- a/src/filesystems/qsys/complex/content.js
+++ b/src/filesystems/qsys/complex/content.js
@@ -24,54 +24,48 @@ module.exports = class IBMiContent {
   static async downloadMemberContentWithDates(asp, lib, spf, mbr) {
     const connection = instance.getConnection();
     const content = instance.getContent();
-    const db2util = connection.remoteFeatures.db2util;
 
     lib = lib.toUpperCase();
     spf = spf.toUpperCase();
     mbr = mbr.toUpperCase();
 
-    if (db2util) {
-      const tempLib = connection.config.tempLibrary;
-      const alias = `${lib}_${spf}_${mbr.replace(/\./g, `_`)}`;
-      const aliasPath = `${tempLib}.${alias}`;
+    const tempLib = connection.config.tempLibrary;
+    const alias = `${lib}_${spf}_${mbr.replace(/\./g, `_`)}`;
+    const aliasPath = `${tempLib}.${alias}`;
   
-      try {
-        await content.runSQL(`CREATE ALIAS ${aliasPath} for ${lib}.${spf}("${mbr}")`);
-      } catch (e) {}
+    try {
+      await content.runSQL(`CREATE ALIAS ${aliasPath} for ${lib}.${spf}("${mbr}")`);
+    } catch (e) {}
 
-      if (recordLengths[alias] === undefined) {
-        const result = await content.runSQL(`SELECT LENGTH(srcdta) as LENGTH FROM ${aliasPath} limit 1`);
-        if (result.length > 0) {
-          recordLengths[alias] = result[0].LENGTH;
-        } else {
-          recordLengths[alias] = DEFAULT_RECORD_LENGTH;
-        }
+    if (recordLengths[alias] === undefined) {
+      const result = await content.runSQL(`SELECT LENGTH(srcdta) as LENGTH FROM ${aliasPath} limit 1`);
+      if (result.length > 0) {
+        recordLengths[alias] = result[0].LENGTH;
+      } else {
+        recordLengths[alias] = DEFAULT_RECORD_LENGTH;
       }
-  
-      let rows = await content.runSQL(
-        `select srcdat, rtrim(srcdta) as srcdta from ${aliasPath}`,
-        `db2util`
-      );
-
-      if (rows.length === 0) {
-        rows.push({
-          SRCDAT: 0,
-          SRCDTA: ``,
-        });
-      }
-  
-      const sourceDates = rows.map(row => String(row.SRCDAT).padStart(6, `0`));
-      const body = rows
-        .map(row => row.SRCDTA)
-        .join(`\n`);
-
-      allSourceDates[alias] = sourceDates;
-
-      return body;
-
-    } else {
-      throw new Error(`db2util not installed on remote server.`);
     }
+  
+    let rows = await content.runSQL(
+      `select srcdat, rtrim(srcdta) as srcdta from ${aliasPath}`
+    );
+
+    if (rows.length === 0) {
+      rows.push({
+        SRCDAT: 0,
+        SRCDTA: ``,
+      });
+    }
+  
+    const sourceDates = rows.map(row => String(row.SRCDAT).padStart(6, `0`));
+    const body = rows
+      .map(row => row.SRCDTA)
+      .join(`\n`);
+
+    allSourceDates[alias] = sourceDates;
+
+    return body;
+
   }
 
   /**
@@ -84,50 +78,45 @@ module.exports = class IBMiContent {
    */
   static async uploadMemberContentWithDates(asp, lib, spf, mbr, body) {
     const connection = instance.getConnection();
-    const db2util = connection.remoteFeatures.db2util;
     const setccsid = connection.remoteFeatures.setccsid;
 
-    if (db2util) {
-      const tempLib = connection.config.tempLibrary;
-      const alias = `${lib}_${spf}_${mbr.replace(/\./g, `_`)}`;
-      const aliasPath = `${tempLib}.${alias}`;
-      const sourceDates = allSourceDates[alias];
+    const tempLib = connection.config.tempLibrary;
+    const alias = `${lib}_${spf}_${mbr.replace(/\./g, `_`)}`;
+    const aliasPath = `${tempLib}.${alias}`;
+    const sourceDates = allSourceDates[alias];
 
-      const client = connection.client;
-      const tempRmt = connection.getTempRemote(lib + spf + mbr);
-      const tmpobj = await tmpFile();
+    const client = connection.client;
+    const tempRmt = connection.getTempRemote(lib + spf + mbr);
+    const tmpobj = await tmpFile();
 
-      const sourceData = body.split(`\n`);
-      const recordLength = recordLengths[alias] || DEFAULT_RECORD_LENGTH;
+    const sourceData = body.split(`\n`);
+    const recordLength = recordLengths[alias] || DEFAULT_RECORD_LENGTH;
 
-      let rows = [],
-        sequence = 0;
-      for (let i = 0; i < sourceData.length; i++) {
-        sequence = i + 1;
-        if (sourceData[i].length > recordLength) {
-          sourceData[i] = sourceData[i].substring(0, recordLength);
-        }
-        
-        rows.push(
-          `(${sequence}, ${sourceDates[i] ? sourceDates[i].padEnd(6, `0`) : `0`}, '${this.escapeString(sourceData[i])}')`,
-        );
+    let rows = [],
+      sequence = 0;
+    for (let i = 0; i < sourceData.length; i++) {
+      sequence = i + 1;
+      if (sourceData[i].length > recordLength) {
+        sourceData[i] = sourceData[i].substring(0, recordLength);
       }
-
-      //We assume the alias still exists....
-      const query = `insert into ${aliasPath} values ${rows.join(`,`)};`;
-
-      await writeFileAsync(tmpobj, query, `utf8`);
-      await client.putFile(tmpobj, tempRmt);
-
-      await connection.remoteCommand(`CLRPFM FILE(${lib}/${spf}) MBR(${mbr})`);
-      if (setccsid) await connection.paseCommand(`${setccsid} 1208 ${tempRmt}`);
-      await connection.remoteCommand(
-        `QSYS/RUNSQLSTM SRCSTMF('${tempRmt}') COMMIT(*NONE) NAMING(*SQL)`,
+        
+      rows.push(
+        `(${sequence}, ${sourceDates[i] ? sourceDates[i].padEnd(6, `0`) : `0`}, '${this.escapeString(sourceData[i])}')`,
       );
-  
-    } else {
-      throw new Error(`db2util not installed on remote server.`);
     }
+
+    //We assume the alias still exists....
+    const query = `insert into ${aliasPath} values ${rows.join(`,`)};`;
+
+    await writeFileAsync(tmpobj, query, `utf8`);
+    await client.putFile(tmpobj, tempRmt);
+
+    await connection.remoteCommand(`CLRPFM FILE(${lib}/${spf}) MBR(${mbr})`);
+    if (setccsid) await connection.paseCommand(`${setccsid} 1208 ${tempRmt}`);
+    await connection.remoteCommand(
+      `QSYS/RUNSQLSTM SRCSTMF('${tempRmt}') COMMIT(*NONE) NAMING(*SQL)`,
+    );
+  
   }
 
   /**

--- a/src/views/databaseBrowser.js
+++ b/src/views/databaseBrowser.js
@@ -58,7 +58,6 @@ module.exports = class databaseBrowserProvider {
 
       vscode.commands.registerCommand(`code-for-ibmi.runEditorStatement`, async () => {
         const content = instance.getContent();
-        const config = instance.getConfig();
         const editor = vscode.window.activeTextEditor;
 
         if (editor.document.languageId === `sql`) {
@@ -69,7 +68,7 @@ module.exports = class databaseBrowserProvider {
             try {
               switch (statement.type) {
               case `sql`:
-                const data = await content.runSQL(statement.content, config.sqlExecutor);
+                const data = await content.runSQL(statement.content);
 
                 if (data.length > 0) {
                   const panel = vscode.window.createWebviewPanel(

--- a/src/webviews/settings/index.js
+++ b/src/webviews/settings/index.js
@@ -43,7 +43,7 @@ module.exports = class SettingsUI {
           }
         }
 
-        const restartFields = [`enableSourceDates`, `sourceDateLocation`, `clContentAssistEnabled`];
+        const restartFields = [`enableSQL`, `enableSourceDates`, `sourceDateLocation`, `clContentAssistEnabled`];
         let restart = false;
 
         let ui = new CustomUI();
@@ -59,45 +59,14 @@ module.exports = class SettingsUI {
         field.description = `Automatically clear temporary data in the chosen temporary library on startup. Deletes all <code>*FILE</code> objects that start with <code>O</code> in the chosen temporary library.`;
         ui.addField(field);
 
-        field = new Field(`select`, `sqlExecutor`, `SQL executor`);
-        field.description = `Which method should be used to execute SQL statements.`;
-        field.items = [
-          {
-            selected: config.sqlExecutor === `default`,
-            value: `default`,
-            description: `Default`,
-            text: `Will use whichever method is available.`,
-          },
-          {
-            selected: config.sqlExecutor === `db2util`,
-            value: `db2util`,
-            description: `db2util (PASE)`,
-            text: `db2util can be installed through yum`,
-          },
-          {
-            selected: config.sqlExecutor === `db2`,
-            value: `db2`,
-            description: `db2 (QSH)`,
-            text: `db2 is shipped with most versions of IBM i`,
-          },
-          {
-            selected: config.sqlExecutor === `QZDFMDB2`,
-            value: `QZDFMDB2`,
-            description: `QZDFMDB2 (QSYS)`,
-            text: `A program to run statements shipped with the OS. Works similarly to db2 (QSH)`,
-          },
-          {
-            selected: config.sqlExecutor === `none`,
-            value: `none`,
-            description: `None`,
-            text: `Uses import files where available`,
-          }
-        ];
+        field = new Field(`checkbox`, `enableSQL`, `Enable SQL`);
+        field.default = (config.enableSQL ? `checked` : ``);
+        field.description = `Must be enabled to make the use of SQL and is enabled by default. If you find SQL isn't working for some reason, disable this.`;
         ui.addField(field);
     
         field = new Field(`input`, `sourceASP`, `Source ASP`);
         field.default = config.sourceASP;
-        field.description = `If source files live within a specific ASP, please specify it here. Leave blank otherwise. You can ignore this if you have access to <code>QSYS2.ASP_INFO</code> and have db2util installed, as Code for IBM i will fetch ASP information automatically.`;
+        field.description = `If source files live within a specific ASP, please specify it here. Leave blank otherwise. You can ignore this if you have access to <code>QSYS2.ASP_INFO</code> as Code for IBM i will fetch ASP information automatically.`;
         ui.addField(field);
     
         field = new Field(`input`, `sourceFileCCSID`, `Source file CCSID`);


### PR DESCRIPTION
### Changes

* Removes SQL executor configuration
* Adds enable SQL configuration back
* Remove usage of `db2` and `db2util`

### Checklist

* [x] have tested my change
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
