### PR TITLE
Editable library list as string

### DIFF
--- a/package.json
+++ b/package.json
@@ -737,6 +737,12 @@
 				"icon": "$(root-folder)"
 			},
 			{
+				"command": "code-for-ibmi.changeUserLibraryList",
+				"title": "Change user library list",
+				"category": "IBM i",
+				"icon": "$(explorer-view-icon)"
+			},
+			{
 				"command": "code-for-ibmi.clearDiagnostics",
 				"title": "Clear diagnostics.",
 				"category": "IBM i"
@@ -1065,17 +1071,17 @@
 					"when": "view == connectionBrowser"
 				},
 				{
+					"command": "code-for-ibmi.changeUserLibraryList",
+					"group": "navigation",
+					"when": "view == libraryListView"
+				},
+				{
 					"command": "code-for-ibmi.changeCurrentLibrary",
 					"group": "navigation",
 					"when": "view == libraryListView"
 				},
 				{
 					"command": "code-for-ibmi.addToLibraryList",
-					"group": "navigation",
-					"when": "view == libraryListView"
-				},
-				{
-					"command": "code-for-ibmi.refreshLibraryListView",
 					"group": "navigation",
 					"when": "view == libraryListView"
 				},


### PR DESCRIPTION
### Changes

* Adds new command to let the user edit the library list in the form of a string.
* Adds button in library list view to run command

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [x] **for feature PRs**: PR only includes one feature enhancement.
