### PR TITLE
5250 connection string now configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -298,6 +298,11 @@
 								"default": false,
 								"description": "If enabled, user will be prompted for the terminal device name."
 							},
+							"connectringStringFor5250": {
+								"type": "string",
+								"default": "localhost",
+								"description": "The connectring string for the 5250 emulator. To use the 5250 emulator, tn5250 must be installed on the remote system via yum."
+							},
 							"autoSaveBeforeAction": {
 								"type": "boolean",
 								"default": false,

--- a/src/api/Configuration.js
+++ b/src/api/Configuration.js
@@ -74,6 +74,9 @@ module.exports = class Configuration {
     /** @type {boolean} */
     this.setDeviceNameFor5250 = (base.setDeviceNameFor5250 === true);
 
+    /** @type {string} */
+    this.connectringStringFor5250 = base.connectringStringFor5250 || `localhost`;
+
     /** @type {boolean} */
     this.autoSaveBeforeAction = (base.autoSaveBeforeAction === true);
   }

--- a/src/api/terminal.js
+++ b/src/api/terminal.js
@@ -45,7 +45,8 @@ module.exports = class Terminal {
         Terminal.createTerminal(instance, type, {
           encoding,
           terminal,
-          name
+          name,
+          connectionString: configuration.connectringStringFor5250
         });
       }
     });
@@ -55,7 +56,7 @@ module.exports = class Terminal {
    * 
    * @param {*} instance 
    * @param {"PASE"|"5250"} type 
-   * @param {{encoding?: string, terminal?: string, name?: string}} [greenScreenSettings]
+   * @param {{encoding?: string, terminal?: string, name?: string, connectionString?: string}} [greenScreenSettings]
    */
   static createTerminal(instance, type, greenScreenSettings = {}) {
     const writeEmitter = new vscode.EventEmitter();
@@ -130,10 +131,11 @@ module.exports = class Terminal {
       if (type === `5250`) {
         channel.stdin.write([
           `TERM=xterm /QOpenSys/pkgs/bin/tn5250`,
-          `${greenScreenSettings.encoding ? `map=${greenScreenSettings.encoding}` : ``}`,
-          `${greenScreenSettings.terminal ? `env.TERM=${greenScreenSettings.terminal}` : ``}`,
-          `${greenScreenSettings.name ? `env.DEVNAME=${greenScreenSettings.name}` : ``}`,
-          `localhost\n`
+          greenScreenSettings.encoding ? `map=${greenScreenSettings.encoding}` : ``,
+          greenScreenSettings.terminal ? `env.TERM=${greenScreenSettings.terminal}` : ``,
+          greenScreenSettings.name ? `env.DEVNAME=${greenScreenSettings.name}` : ``,
+          greenScreenSettings.connectionString || `localhost`,
+          `\n`
         ].join(` `));
       } else {
         channel.stdin.write(`echo "Terminal started. Thanks for using Code for IBM i"\n`);

--- a/src/webviews/settings/index.js
+++ b/src/webviews/settings/index.js
@@ -189,6 +189,11 @@ module.exports = class SettingsUI {
         field.default = (config.setDeviceNameFor5250 ? `checked` : ``);
         field.description = `When enabled, the user will be able to enter a device name before the terminal starts.`;
         ui.addField(field);
+    
+        field = new Field(`input`, `connectringStringFor5250`, `Connection string for 5250`);
+        field.default = config.connectringStringFor5250;
+        field.description = `Default is <code>localhost</code>. A common SSL string is <code>ssl:localhost 992</code>`;
+        ui.addField(field);
 
         ui.addField(new Field(`hr`));
     


### PR DESCRIPTION
### Changes

Adds a new config prop to make the 5250 connection string configurable.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
