### PR TITLE
Correctly escape input for regex characters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,23 @@
 {
 	"name": "code-for-ibmi",
-	"version": "0.8.13",
+	"version": "0.9.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "code-for-ibmi",
-			"version": "0.8.13",
+			"version": "0.9.1",
 			"license": "MIT",
 			"dependencies": {
 				"@bendera/vscode-webview-elements": "^0.6.3",
 				"csv-parse": "^4.15.1",
+				"escape-string-regexp": "^5.0.0",
 				"ignore": "^5.1.9",
 				"node-ssh": "^11.1.1",
 				"tmp": "^0.2.1",
 				"xml2js": "^0.4.23"
 			},
 			"devDependencies": {
-        "semver": "^7.3.5",
 				"@types/glob": "^7.1.3",
 				"@types/mocha": "^8.0.4",
 				"@types/node": "^12.11.7",
@@ -72,6 +72,15 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/@bendera/vscode-webview-elements": {
@@ -949,12 +958,14 @@
 			}
 		},
 		"node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true,
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
 			"engines": {
-				"node": ">=0.8.0"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/eslint": {
@@ -3298,6 +3309,12 @@
 						"escape-string-regexp": "^1.0.5",
 						"supports-color": "^5.3.0"
 					}
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				}
 			}
 		},
@@ -4063,10 +4080,9 @@
 			"dev": true
 		},
 		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
 		},
 		"eslint": {
 			"version": "7.20.0",

--- a/package.json
+++ b/package.json
@@ -1385,6 +1385,7 @@
 	"dependencies": {
 		"@bendera/vscode-webview-elements": "^0.6.3",
 		"csv-parse": "^4.15.1",
+		"escape-string-regexp": "^5.0.0",
 		"ignore": "^5.1.9",
 		"node-ssh": "^11.1.1",
 		"tmp": "^0.2.1",


### PR DESCRIPTION
### Changes

* Escapes all search strings so regex is ignored.
* IFS search is now case in-sensitive (same as how member search works)

Fixes #165.

### Checklist

* [x] have tested my change
* [x] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
