### PR TITLE
Parse 5250 stream colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -349,6 +349,11 @@
 					"default": true,
 					"description": "If enabled, will log spool files from command executed. You can find it under Output for 'IBM i Compile Log'."
 				},
+				"code-for-ibmi.showSeuColors": {
+					"type": "boolean",
+					"default": false,
+					"description": "If enabled, will colourise lines like SEU. Only supports source members. Requires restart"
+				},
 				"code-for-ibmi.clearOutputEveryTime": {
 					"type": "boolean",
 					"default": true,

--- a/src/Instance.js
+++ b/src/Instance.js
@@ -127,6 +127,8 @@ module.exports = class Instance {
 
     const CLCommands = require(`./languages/clle/clCommands`);
 
+    const ColorProvider = require(`./languages/general/ColorProvider`);
+
     if (instance.connection) {
       instance.storage = new Storage(context, instance.connection.currentConnectionName);
 
@@ -401,10 +403,14 @@ module.exports = class Instance {
           })
         )
 
+        // ********* CL content assist */
         if (config.clContentAssistEnabled) {
           const clInstance = new CLCommands(context);
           clInstance.init();
         }
+
+        // ********* Color provider */
+        new ColorProvider(context);
 
         //********* Actions */
 

--- a/src/Instance.js
+++ b/src/Instance.js
@@ -421,7 +421,9 @@ module.exports = class Instance {
         }
 
         // ********* Color provider */
-        new ColorProvider(context);
+        if (Configuration.get(`showSeuColors`)) {
+          new ColorProvider(context);
+        }
 
         //********* Actions */
 

--- a/src/languages/general/ColorProvider.js
+++ b/src/languages/general/ColorProvider.js
@@ -1,0 +1,71 @@
+const vscode = require(`vscode`);
+
+const Colors = require(`./colors`);
+
+module.exports = class ColorProvider {
+  /** 
+   * @param {vscode.ExtensionContext} context
+   */
+  constructor(context) {
+    this.timeout = undefined;
+
+    context.subscriptions.push(
+      vscode.workspace.onDidChangeTextDocument(event => {
+        clearTimeout(this.timeout);
+        this.timeout = setTimeout(() => {
+          this.refreshDocumentColors(event.document);
+        }, 2000);
+      }),
+
+      vscode.window.onDidChangeActiveTextEditor(event => {
+        if (event && event.document) {
+          this.refreshDocumentColors(event.document);
+        }
+      })
+
+    );
+  }
+
+  /**
+   * @param {vscode.TextDocument} document 
+   */
+  refreshDocumentColors(document) {
+    if (document.uri.scheme === `member`) {
+      // This should only work for members.
+      // We don't want to support this everywhere because it's ugly.
+
+      const activeEditor = vscode.window.activeTextEditor;
+    
+      if (document.uri.path === activeEditor.document.uri.path) {
+      /** @type {{[byte: string]: vscode.DecorationOptions[]}} */
+        const colorDecorations = {};
+
+        // Set up the arrays
+        Colors.bytes.forEach(byte => {
+          colorDecorations[byte] = [];
+        });
+
+        // Find the lines and the bytes and all that...
+        for (let lineIndex = 0; lineIndex < document.lineCount; lineIndex++) {
+          const line = document.lineAt(lineIndex);
+
+          const lineBytes = Buffer.from(line.text);
+
+          Colors.bytes.forEach(byte => {
+            const byteIndex = lineBytes.indexOf(byte);
+            if (byteIndex >= 0) {
+              colorDecorations[byte].push({
+                range: new vscode.Range(lineIndex, byteIndex+1, lineIndex, line.text.length)
+              });
+            }
+          })
+        }
+
+        // Then set the decorations
+        Colors.bytes.forEach(byte => {
+          activeEditor.setDecorations(Colors.decorations[byte], colorDecorations[byte]);
+        });
+      }
+    } 
+  }
+}

--- a/src/languages/general/ColorProvider.js
+++ b/src/languages/general/ColorProvider.js
@@ -41,7 +41,7 @@ module.exports = class ColorProvider {
         const colorDecorations = {};
 
         // Set up the arrays
-        Colors.bytes.forEach(byte => {
+        Colors.list.forEach(byte => {
           colorDecorations[byte] = [];
         });
 
@@ -50,20 +50,23 @@ module.exports = class ColorProvider {
           const line = document.lineAt(lineIndex);
 
           const lineBytes = Buffer.from(line.text);
+          console.log((lineIndex + 1));
+          console.log(lineBytes);
 
-          Colors.bytes.forEach(byte => {
-            const byteIndex = lineBytes.indexOf(byte);
+          Colors.list.forEach(color => {
+            const byteIndex = lineBytes.indexOf(Colors.definitions[color].bytes);
             if (byteIndex >= 0) {
-              colorDecorations[byte].push({
-                range: new vscode.Range(lineIndex, byteIndex+1, lineIndex, line.text.length)
+              const definition = Colors.definitions[color];
+              colorDecorations[color].push({
+                range: new vscode.Range(lineIndex, byteIndex+definition.bytes.length, lineIndex, line.text.length)
               });
             }
           })
         }
 
         // Then set the decorations
-        Colors.bytes.forEach(byte => {
-          activeEditor.setDecorations(Colors.decorations[byte], colorDecorations[byte]);
+        Colors.list.forEach(color => {
+          activeEditor.setDecorations(Colors.definitions[color].decoration, colorDecorations[color]);
         });
       }
     } 

--- a/src/languages/general/ColorProvider.js
+++ b/src/languages/general/ColorProvider.js
@@ -63,7 +63,7 @@ module.exports = class ColorProvider {
             if (byteIndex >= 0) {
               const definition = Colors.definitions[color];
               colorDecorations[color].push({
-                range: new vscode.Range(lineIndex, byteIndex+definition.bytes.length, lineIndex, line.text.length)
+                range: new vscode.Range(lineIndex, byteIndex+definition.bytes.length-1, lineIndex, line.text.length)
               });
 
               hiddenDecorations.push({

--- a/src/languages/general/colors.js
+++ b/src/languages/general/colors.js
@@ -1,15 +1,184 @@
 const vscode = require(`vscode`);
 
-exports.hex = {
-  22: `#c99400`
-}
+exports.definitions = {
+  blue: {
+    bytes: Buffer.from([194, 154]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      color: `#3565cc`,
+      rangeBehavior: vscode.DecorationRangeBehavior.ClosedOpen,
+    })
+  },
+  blue_ri: {
+    bytes: Buffer.from([194, 155]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      backgroundColor: `#3565cc`,
+      color: `white`,
+      rangeBehavior: vscode.DecorationRangeBehavior.ClosedOpen,
+    })
+  },
+  blue_ul: {
+    bytes: Buffer.from([194, 158]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      color: `#3565cc`,
+      textDecoration: `; border-bottom: 1px solid #3565cc;`
+    })
+  },
+  green: {
+    bytes: Buffer.from([194, 128]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      color: `#28d15d`,
+    })
+  },
+  green_ri: {
+    bytes: Buffer.from([194, 129]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      backgroundColor: `#28d15d`,
+      color: `black`,
+    })
+  },
+  green_ul: {
+    bytes: Buffer.from([194, 132]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      color: `#28d15d`,
+      textDecoration: `; border-bottom: 1px solid #28d15d;`
+    })
+  },
+  // green_ul_ri not supported
+  // pnk not supported
+  pink_ri: {
+    bytes: Buffer.from([194, 153]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      backgroundColor: `#cf259c`,
+      color: `white`,
+    })
+  },
+  pink_ul: {
+    bytes: Buffer.from([20, 42]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      color: `#cf259c`,
+      textDecoration: `; border-bottom: 1px solid #cf259c;`
+    })
+  },
+  pink_ul_ri: {
+    bytes: Buffer.from([21, 42]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      backgroundColor: `#cf259c`,
+      color: `white`,
+    })
+  },
+  red: {
+    bytes: Buffer.from([194, 136]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      color: `#cf2331`,
+    })
+  },
+  // red_bl and red are the same
+  red_bl: {
+    bytes: Buffer.from([194, 138]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      color: `#cf2331`,
+    })
+  },
+  red_ri: {
+    bytes: Buffer.from([194, 137]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      backgroundColor: `#cf2331`,
+      color: `white`,
+    }),
+  },
+  // red_ri_bl and red_ri are the same
+  red_ri_bl: {
+    bytes: Buffer.from([194, 139]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      backgroundColor: `#cf2331`,
+      color: `white`,
+    }),
+  },
+  red_ul: {
+    bytes: Buffer.from([194, 140]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      color: `#cf2331`,
+      textDecoration: `; border-bottom: 1px solid #cf2331;`
+    })
+  },
+  turquoise: {
+    bytes: Buffer.from([194, 144]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      color: `#22c4d6`,
+    })
+  },
+  turquoise_ri: {
+    bytes: Buffer.from([194, 145]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      backgroundColor: `#22c4d6`,
+      color: `black`,
+    })
+  },
+  turquoise_ul: {
+    bytes: Buffer.from([194, 148]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      color: `#22c4d6`,
+      textDecoration: `; border-bottom: 1px solid #22c4d6;`
+    })
+  },
+  // turquoise_ul_ri is the same as turquoise_ri
+  turquoise_ul_ri: {
+    bytes: Buffer.from([194, 149]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      backgroundColor: `#22c4d6`,
+      color: `black`,
+    })
+  },
+  white: {
+    bytes: Buffer.from([194, 130]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      light: {
+        color: `#000000`,
+      },
+      dark: {
+        color: `#ffffff`,
+      }
+    })
+  },
+  white_ri: {
+    bytes: Buffer.from([194, 131]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      light: {
+        color: `#ffffff`,
+        backgroundColor: `#000000`,
+      },
+      dark: {
+        color: `#000000`,
+        backgroundColor: `#ffffff`,
+      }
+    })
+  },
+  white_ul: {
+    bytes: Buffer.from([23]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      light: {
+        color: `#000000`,
+        textDecoration: `; border-bottom: 1px solid #000000;`
+      },
+      dark: {
+        color: `#ffffff`,
+        textDecoration: `; border-bottom: 1px solid #ffffff;`
+      }
+    })
+  },
+  yellow: {
+    bytes: Buffer.from([22]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      color: `#f4c842`,
+    })
+  },
+  yellow_ul: {
+    bytes: Buffer.from([194, 150]),
+    decoration: vscode.window.createTextEditorDecorationType({
+      color: `#f4c842`,
+      textDecoration: `; border-bottom: 1px solid #f4c842;`
+    })
+  }
+};
 
-exports.decorations = {
-  // YLW_CS 
-  22: vscode.window.createTextEditorDecorationType({
-    color: this.hex[22],
-    rangeBehavior: vscode.DecorationRangeBehavior.ClosedOpen,
-  }), 
-}
-
-exports.bytes = Object.keys(this.decorations).map(byte => Number(byte));
+exports.list = Object.keys(exports.definitions);

--- a/src/languages/general/colors.js
+++ b/src/languages/general/colors.js
@@ -1,0 +1,15 @@
+const vscode = require(`vscode`);
+
+exports.hex = {
+  22: `#c99400`
+}
+
+exports.decorations = {
+  // YLW_CS 
+  22: vscode.window.createTextEditorDecorationType({
+    color: this.hex[22],
+    rangeBehavior: vscode.DecorationRangeBehavior.ClosedOpen,
+  }), 
+}
+
+exports.bytes = Object.keys(this.decorations).map(byte => Number(byte));


### PR DESCRIPTION
### Changes

SEU users love to use colors in their source code. This only really worked in SEU since it affected the 5250 byte stream, but I simply parse out the source and make the lines change based on the character code.

Needs a bunch of testing before release. Implements #552 

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
