### PR TITLE
Allow library list to be delimited by commas and/or spaces(s)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "code-for-ibmi",
-	"version": "1.1.0",
+	"version": "1.2.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "code-for-ibmi",
-			"version": "1.1.0",
+			"version": "1.2.5",
 			"license": "MIT",
 			"dependencies": {
 				"@bendera/vscode-webview-elements": "^0.6.3",


### PR DESCRIPTION
Allow library list to be delimited by commas and/or spaces(s)
Remove duplicate libraries from the library list (keep first occurrence).
Add more specific check of stderr to determine library in error.


### Changes

Description of change here.

### Checklist

* [ ] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
