### PR TITLE
IFS browser directories before streamFiles

### DIFF
--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -407,7 +407,9 @@ module.exports = class ifsBrowserProvider {
         try {
           const objects = await content.getFileList(element.path);
 
-          items = objects.filter(o => o.type === `directory`).concat(objects.filter(o => o.type === `streamfile`)).map(object => new Object(object.type, object.name, object.path));
+          items = objects.filter(o => o.type === `directory`)
+                  .concat(objects.filter(o => o.type === `streamfile`))
+                  .map(object => new Object(object.type, object.name, object.path));
           await this.storeIFSList(element.path, objects.filter(o => o.type === `streamfile`).map(o => o.name));
 
         } catch (e) {

--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -407,7 +407,7 @@ module.exports = class ifsBrowserProvider {
         try {
           const objects = await content.getFileList(element.path);
 
-          items = objects.map(object => new Object(object.type, object.name, object.path));
+          items = objects.filter(o => o.type === `directory`).concat(objects.filter(o => o.type === `streamfile`)).map(object => new Object(object.type, object.name, object.path));
           await this.storeIFSList(element.path, objects.filter(o => o.type === `streamfile`).map(o => o.name));
 
         } catch (e) {


### PR DESCRIPTION
### Changes

Description of change here.
add filter and concat to have directories list before streamfile list in the ifs browser.

### Checklist

* [X] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [ ] **for feature PRs**: PR only includes one feature enhancement.
