### PR TITLE
Fix catch for missing directory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,3 +34,4 @@ Thanks so much to everyone [who has contributed](https://github.com/halcyon-tech
 * [@dman247](https://github.com/dman247)
 * [@EddieSmith](https://github.com/EddieSmith)
 * [@fathert](https://github.com/fathert)
+* [@Teqed](https://github.com/Teqed)

--- a/src/api/IBMi.js
+++ b/src/api/IBMi.js
@@ -398,9 +398,9 @@ module.exports = class IBMi {
         );
 
         //Next, we see what pase features are available (installed via yum)
-        try {
-          //This may enable certain features in the future.
-          for (const feature of remoteApps) {
+        //This may enable certain features in the future.
+        for (const feature of remoteApps) {
+          try {
             progress.report({
               message: `Checking installed components on host IBM i: ${feature.path}`
             });
@@ -418,10 +418,9 @@ module.exports = class IBMi {
                     this.remoteFeatures[name] = feature.path + name;
               }
             }
+          } catch (e) {
+            console.log(e);
           }
-          
-        } catch (e) {
-          console.log(e);
         }
 
         if (this.remoteFeatures[`QZDFMDB2.PGM`]) {


### PR DESCRIPTION
### Issue
Example system has setccsid, iconv, and attr installed in `/usr/bin/`. The path `/QOpenSys/pkgs/bin/` does not exist.
When trying to use the "Support EBCDIC streamfiles" feature, an error message appears: `EBCDIC streamfiles will not be rendered correctly since attr or iconv is not installed on the host. They should both exist in \usr\bin\.`

If the directory `/QOpenSys/pkgs/bin/` is created, even if nothing is installed to it, the feature works as expected.

### Changes
Exchange the `try (for) catch` remoteApps uses to check paths for a `for (try catch)` that allows the `for` loop to continue.

### Checklist

* [X] have tested my change
* [ ] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [X] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
