### PR TITLE
Escape special characters in IFS directory name

### DIFF
--- a/src/api/IBMiContent.js
+++ b/src/api/IBMiContent.js
@@ -387,8 +387,9 @@ module.exports = class IBMiContent {
    * @return {Promise<{type: "directory"|"streamfile", name: string, path: string}[]>} Resulting list
    */
   async getFileList(remotePath) {
+    remotePath = remotePath.replace(/'|"|\$|\\| /g, function(matched){return `\\`.concat(matched)});
     const result = await this.ibmi.sendCommand({
-      command: `ls -a -p "${remotePath}"`
+      command: `ls -a -p ${remotePath}`
     });
 
     //@ts-ignore


### PR DESCRIPTION
### Changes

This PR fixes the problem opening an IFS directory with a quote in the name.

The remote path will have the special characters quote, double-quote, dollar sign, backslash and the space escaped before opening the directory. The list of characters is not complete but can be extended - it only contains the characters that I personally experienced problems with. 

Since the name is now escaped, it is no longer necessary to put it in quotes on the `ls` command.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
