### PR TITLE
Open symlinks to directories like normal directories in IFS browser

### DIFF
--- a/src/api/IBMiContent.js
+++ b/src/api/IBMiContent.js
@@ -388,7 +388,7 @@ module.exports = class IBMiContent {
    */
   async getFileList(remotePath) {
     const result = await this.ibmi.sendCommand({
-      command: `ls -a -p "${remotePath}"`
+      command: `ls -a -p -L "${remotePath}"`
     });
 
     //@ts-ignore


### PR DESCRIPTION
### Changes

This PR will change the reading of directories in the IFS browser to mark symbolic links to directories as regular directories and let them be opened like any other directory.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
