### PR TITLE
Allow special chars in IFS browser

### DIFF
--- a/src/api/IBMiContent.js
+++ b/src/api/IBMiContent.js
@@ -388,7 +388,7 @@ module.exports = class IBMiContent {
    */
   async getFileList(remotePath) {
     const result = await this.ibmi.sendCommand({
-      command: `ls -a -p -L "${remotePath}"`
+      command: `ls -a -p -L ${Tools.escapePath(remotePath)}`
     });
 
     //@ts-ignore

--- a/src/api/Search.js
+++ b/src/api/Search.js
@@ -2,6 +2,7 @@
 const Configuration = require(`./Configuration`);
 const IBMi = require(`./IBMi`);
 const IBMiContent = require(`./IBMiContent`);
+const Tools = require(`./Tools`);
 
 module.exports = class Search {
   /**
@@ -121,7 +122,7 @@ module.exports = class Search {
       }
 
       const grepRes = await connection.sendCommand({
-        command: `${grep} -inr -F -f - ${ignoreString} "${path}"`,
+        command: `${grep} -inr -F -f - ${ignoreString} ${Tools.escapePath(path)}`,
         stdin: term
       });
 

--- a/src/api/Tools.js
+++ b/src/api/Tools.js
@@ -156,4 +156,13 @@ module.exports = class {
 
     return result;
   }
+
+  /**
+   * @param {string} Path
+   * @returns {string} escapedPath
+   */
+  static escapePath(Path) {
+    const escapedPath = Path.replace(/'|"|\$|\\| /g, function(matched){return `\\`.concat(matched)});
+    return escapedPath;
+  }
 }

--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -6,6 +6,7 @@ const path = require(`path`);
 let instance = require(`../Instance`);
 const Configuration = require(`../api/Configuration`);
 const Search = require(`../api/Search`);
+const Tools = require(`../api/Tools`);
 
 module.exports = class ifsBrowserProvider {
   /**
@@ -130,7 +131,7 @@ module.exports = class ifsBrowserProvider {
         if (fullName) {
 
           try {
-            await connection.paseCommand(`mkdir "${fullName}"`);
+            await connection.paseCommand(`mkdir ${Tools.escapePath(fullName)}`);
 
             if (Configuration.get(`autoRefresh`)) this.refresh();
 
@@ -164,7 +165,7 @@ module.exports = class ifsBrowserProvider {
           try {
             vscode.window.showInformationMessage(`Creating streamfile ${fullName}.`);
 
-            await connection.paseCommand(`echo "" > "${fullName}"`);
+            await connection.paseCommand(`echo "" > ${Tools.escapePath(fullName)}`);
 
             vscode.commands.executeCommand(`code-for-ibmi.openEditable`, fullName);
 
@@ -226,7 +227,7 @@ module.exports = class ifsBrowserProvider {
             const connection = instance.getConnection();
 
             try {
-              await connection.paseCommand(`rm -rf "${node.path}"`)
+              await connection.paseCommand(`rm -rf ${Tools.escapePath(node.path)}`)
 
               vscode.window.showInformationMessage(`Deleted ${node.path}.`);
 
@@ -253,7 +254,7 @@ module.exports = class ifsBrowserProvider {
             const connection = instance.getConnection();
 
             try {
-              await connection.paseCommand(`mv "${node.path}" "${fullName}"`);
+              await connection.paseCommand(`mv ${Tools.escapePath(node.path)} ${Tools.escapePath(fullName)}`);
               if (Configuration.get(`autoRefresh`)) this.refresh();
 
             } catch (e) {
@@ -279,7 +280,7 @@ module.exports = class ifsBrowserProvider {
             const connection = instance.getConnection();
 
             try {
-              await connection.paseCommand(`cp "${node.path}" "${fullName}"`);
+              await connection.paseCommand(`cp ${Tools.escapePath(node.path)} ${Tools.escapePath(fullName)}`);
               if (Configuration.get(`autoRefresh`)) this.refresh();
 
             } catch (e) {


### PR DESCRIPTION
### Changes

This PR allows handling of special characters in path names in the IFS browser.

The remote path will have the special characters quote, double-quote, dollar sign, backslash and the space escaped before using the path name. The list of characters is not complete but can be extended - it only contains the characters that I personally experienced problems with.

Now you can use all operations in the IFS browser even when the path contains the above mentioned special characters.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
