### PR TITLE
Eliminate deprecated string method substr()

### DIFF
--- a/src/api/CompileTools.js
+++ b/src/api/CompileTools.js
@@ -6,7 +6,6 @@ const errorHandlers = require(`./errors/index`);
 const IBMi = require(`./IBMi`);
 const Configuration = require(`./Configuration`);
 const { CustomUI, Field } = require(`./CustomUI`);
-const { Console } = require("console");
 
 const diagnosticSeverity = {
   0: vscode.DiagnosticSeverity.Information,

--- a/src/api/CompileTools.js
+++ b/src/api/CompileTools.js
@@ -6,6 +6,7 @@ const errorHandlers = require(`./errors/index`);
 const IBMi = require(`./IBMi`);
 const Configuration = require(`./Configuration`);
 const { CustomUI, Field } = require(`./CustomUI`);
+const { Console } = require("console");
 
 const diagnosticSeverity = {
   0: vscode.DiagnosticSeverity.Information,
@@ -632,7 +633,7 @@ module.exports = class CompileTools {
       panel.dispose();
       if (data) {
         for (const component of components.reverse()) {
-          command = command.substr(0, component.positions[0]) + data[component.name] + command.substr(component.positions[1]);
+          command = command.substring(0, component.positions[0]) + data[component.name] + command.substring(component.positions[1]);
         }
       } else {
         command = undefined;

--- a/src/api/IBMi.js
+++ b/src/api/IBMi.js
@@ -181,8 +181,8 @@ module.exports = class IBMi {
 
             let lib, type;
             for (const line of libraryList) {
-              lib = line.substr(0, 10).trim();
-              type = line.substr(12);
+              lib = line.substring(0, 10).trim();
+              type = line.substring(12);
 
               switch (type) {
               case `USR`:

--- a/src/api/IBMiContent.js
+++ b/src/api/IBMiContent.js
@@ -401,11 +401,11 @@ module.exports = class IBMiContent {
       list = list.filter(item => item !== `../` && item !== `./`);
 
       const items = list.map(item => {
-        const type = ((item.substr(item.length - 1, 1) === `/`) ? `directory` : `streamfile`);
+        const type = (item.endsWith(`/`) ? `directory` : `streamfile`);
 
         return {
           type, 
-          name: (type === `directory` ? item.substr(0, item.length - 1) : item),
+          name: (type === `directory` ? item.substring(0, item.length - 1) : item),
           path: path.posix.join(remotePath, item)
         };
       });

--- a/src/api/Search.js
+++ b/src/api/Search.js
@@ -61,7 +61,7 @@ module.exports = class Search {
       if (line.startsWith(`Binary`)) continue;
   
       parts = line.split(`:`);
-      currentFile = parts[0].substr(10); //Remove '/QSYS.LIB/'
+      currentFile = parts[0].substring(10); //Remove '/QSYS.LIB/'
       currentFile = currentFile.replace(`.LIB`, ``).replace(`.FILE`, ``).replace(`.MBR`, ``);
 
       currentLine = Number(parts[1]);
@@ -76,7 +76,7 @@ module.exports = class Search {
       contentIndex = nthIndex(line, `:`, 2);
       
       if (contentIndex >= 0) {
-        curContent = line.substr(contentIndex+1);
+        curContent = line.substring(contentIndex+1);
   
         files[currentFile].lines.push({
           number: currentLine,
@@ -147,7 +147,7 @@ module.exports = class Search {
         contentIndex = nthIndex(line, `:`, 2);
       
         if (contentIndex >= 0) {
-          content = line.substr(contentIndex+1);
+          content = line.substring(contentIndex+1);
     
           files[parts[0]].lines.push({
             number: Number(parts[1]),

--- a/src/api/errors/format.js
+++ b/src/api/errors/format.js
@@ -1,6 +1,6 @@
 function formatName(input) {
   let pieces = input.split(`/`);
-  let path = pieces[1].substr(pieces[1], pieces[1].length-1).split(`(`);
+  let path = pieces[1].substring(0, pieces[1].length-1).split(`(`);
 
   return [pieces[0], path[0], path[1]].join(`/`)
 }

--- a/src/api/errors/handlers/new.js
+++ b/src/api/errors/handlers/new.js
@@ -41,8 +41,8 @@ module.exports = function getErrors(lines) {
     line = line.padEnd(150);
 
     pieces = line.split(` `).filter(x => x !== ``);
-    curtype = line.substr(0, 10).trim();
-    _FileID = Number(line.substr(13, 3));
+    curtype = line.substring(0, 10).trim();
+    _FileID = Number(line.substring(13, 13+3));
     tempFileID = _FileID;
 
     switch (curtype) {
@@ -104,12 +104,12 @@ module.exports = function getErrors(lines) {
       break;
 
     case `ERROR`:
-      let sev = Number(line.substr(58, 2));
-      let linenum = Number(line.substr(37, 6))-1;
-      let column = Number(line.substr(33, 3));
-      let toColumn = Number(line.substr(44, 3));
-      let text = line.substr(65).trim();
-      let code = line.substr(48, 7).trim();
+      let sev = Number(line.substring(58, 58+2));
+      let linenum = Number(line.substring(37, 37+6))-1;
+      let column = Number(line.substring(33, 33+3));
+      let toColumn = Number(line.substring(44, 44+3));
+      let text = line.substring(65).trim();
+      let code = line.substring(48, 48+7).trim();
 
       existingFile = currentProcessor.files.find(x => x.id === _FileID);
       if (existingFile)

--- a/src/api/errors/handlers/old.js
+++ b/src/api/errors/handlers/old.js
@@ -36,8 +36,8 @@ module.exports = function(lines) {
     line = line.padEnd(150);
 
     pieces = arrayClean(line.split(` `), ``);
-    curtype = line.substr(0, 10).trim();
-    _FileID = Number(line.substr(13, 3));
+    curtype = line.substring(0, 10).trim();
+    _FileID = Number(line.substring(13, 13+3));
     tempFileID = undefined;
 
     switch (curtype) {
@@ -53,7 +53,7 @@ module.exports = function(lines) {
         _Expansions[_FileID] = [];
 
         //000000 check means that the current FILEID is not an include
-        _TrackCopies[_FileID] = (line.substr(17, 6) != `000000`);
+        _TrackCopies[_FileID] = (line.substring(17, 17+6) != `000000`);
         ranges.push(new expRange(Number(pieces[3]), 0));
       } else {
         ranges.push(new expRange(Number(pieces[3]), 0));
@@ -81,12 +81,12 @@ module.exports = function(lines) {
       break;
         
     case `ERROR`:
-      let sev = Number(line.substr(58, 2));
-      let linenum = Number(line.substr(37, 6));
-      let column = Number(line.substr(33, 3));
-      let toColumn = Number(line.substr(44, 3)) ;
-      let text = line.substr(65).trim();
-      let code = line.substr(48, 7).trim();
+      let sev = Number(line.substring(58, 58+2));
+      let linenum = Number(line.substring(37, 37+6));
+      let column = Number(line.substring(33, 33+3));
+      let toColumn = Number(line.substring(44, 44+3)) ;
+      let text = line.substring(65).trim();
+      let code = line.substring(48, 48+7).trim();
       let  sqldiff = 0;
 
       if (!text.includes(`name or indicator SQ`)) {

--- a/src/filesystems/qsys/complex/handler.js
+++ b/src/filesystems/qsys/complex/handler.js
@@ -50,7 +50,7 @@ module.exports = class {
               fullName = path[4];
             }
 
-            fullName = fullName.substr(0, fullName.lastIndexOf(`.`));
+            fullName = fullName.substring(0, fullName.lastIndexOf(`.`));
             const alias = `${lib}_${file}_${fullName.replace(/\./g, `_`)}`;
             const recordLength = recordLengths[alias];
 

--- a/src/languages/clle/clCommands.js
+++ b/src/languages/clle/clCommands.js
@@ -45,7 +45,7 @@ module.exports = class CLCommands {
 
               // Determine if we're prompting a paramater vs a command
               let parmIdx = parts[parts.length-1].indexOf(`(`);
-              if (parmIdx > -1 && parts[parts.length-1].includes(`)`) === false) currentParameter = parts[parts.length-1].substr(0, parmIdx);
+              if (parmIdx > -1 && parts[parts.length-1].includes(`)`) === false) currentParameter = parts[parts.length-1].substring(0, parmIdx);
 
               // If we found a command..
               if (nameIndex > -1) {
@@ -54,7 +54,7 @@ module.exports = class CLCommands {
                 // get the parms we already have defined in the document
                 const existingParms = parts
                   .slice(nameIndex)
-                  .map(part => part.includes(`(`) ? part.substr(0, part.indexOf(`(`)).toUpperCase() : undefined);
+                  .map(part => part.includes(`(`) ? part.substring(0, part.indexOf(`(`)).toUpperCase() : undefined);
 
                 if (name.length > 2) {
 
@@ -114,7 +114,7 @@ module.exports = class CLCommands {
 
             if (possibleParm.endsWith(`(`)) {
               //If the word we're highlighting is a paramater name, we need to find the command that uses it 
-              possibleParm = possibleParm.substr(0, possibleParm.length - 1);
+              possibleParm = possibleParm.substring(0, possibleParm.length - 1);
 
               // get the document in parts
               const parts = CLCommands.getCLParts(document, new vscode.Range(new vscode.Position(0, 0), position));

--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -358,7 +358,7 @@ module.exports = class ifsBrowserProvider {
             if (process.platform === `win32`) {
               //Issue with getFile not working propertly on Windows
               //when there was a / at the start.
-              if (localPath[0] === `/`) localPath = localPath.substr(1);
+              if (localPath[0] === `/`) localPath = localPath.substring(1);
             }
 
             try {

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -281,7 +281,7 @@ module.exports = class objectBrowserTwoProvider {
             if (process.platform === `win32`) {
               //Issue with getFile not working propertly on Windows
               //when there was a / at the start.
-              if (localPath[0] === `/`) localPath = localPath.substr(1);
+              if (localPath[0] === `/`) localPath = localPath.substring(1);
             }
 
             try {


### PR DESCRIPTION
### Changes

This PR will remove all use of the deprecated string method substr(), mostly by using substring() instead.
The difference in the second parameter is only a problem when the first parameter is not zero, and it has been changed into <start>+<length>.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
