### PR TITLE
Fix/701 pound sign names

### DIFF
--- a/src/api/Tools.js
+++ b/src/api/Tools.js
@@ -130,7 +130,7 @@ module.exports = class {
       basename: undefined,
     };
 
-    const validQsysName = new RegExp(`^[A-Z0-9@#$][A-Z0-9_#@$.]{0,9}$`);
+    const validQsysName = new RegExp(`^[A-Z0-9@#£$][A-Z0-9_#@£$.]{0,9}$`);
 
     // Remove leading slash
     const path = string.startsWith(`/`) ? string.substring(1).toUpperCase().split(`/`) : string.toUpperCase().split(`/`);


### PR DESCRIPTION
### Changes
Allow pound symbol as valid object name


### Checklist

* [ ] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
