### PR TITLE
Feature/sort ifs shortcuts

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,11 @@
 								"default": [],
 								"description": "List of directories shown in IFS Browser"
 							},
+							"autoSortIFSShortcuts": {
+								"type": "boolean",
+								"default": false,
+								"description": "Automatically sort the shortcuts in IFS browser when shortcut is added or removed."
+							},
 							"homeDirectory": {
 								"type": "string",
 								"default": ".",

--- a/package.json
+++ b/package.json
@@ -990,6 +990,24 @@
 				"icon": "$(remove)"
 			},
 			{
+				"command": "code-for-ibmi.sortIFSShortcuts",
+				"title": "Sort IFS shortcuts",
+				"category": "IBM i",
+				"icon": "$(list-ordered)"
+			},
+			{
+				"command": "code-for-ibmi.moveIFSShortcutDown",
+				"title": "Move IFS shortcut down",
+				"category": "IBM i",
+				"icon": "$(arrow-down)"
+			},
+			{
+				"command": "code-for-ibmi.moveIFSShortcutUp",
+				"title": "Move IFS shortcut up",
+				"category": "IBM i",
+				"icon": "$(arrow-up)"
+			},
+		{
 				"command": "code-for-ibmi.maintainFilter",
 				"title": "Maintain filter",
 				"category": "IBM i",
@@ -1198,6 +1216,11 @@
 					"when": "view == ifsBrowser"
 				},
 				{
+					"command": "code-for-ibmi.sortIFSShortcuts",
+					"group": "navigation",
+					"when": "view == ifsBrowser"
+				},
+				{
 					"command": "code-for-ibmi.refreshIFSBrowser",
 					"group": "navigation",
 					"when": "view == ifsBrowser"
@@ -1329,6 +1352,16 @@
 					"group": "3_memberTransfer@2"
 				},
 				{
+					"command": "code-for-ibmi.moveIFSShortcutDown",
+					"when": "view == ifsBrowser && viewItem == shortcut",
+					"group": "inline"
+				},
+				{
+					"command": "code-for-ibmi.moveIFSShortcutUp",
+					"when": "view == ifsBrowser && viewItem == shortcut",
+					"group": "inline"
+				},
+				{
 					"command": "code-for-ibmi.runAction",
 					"when": "view == ifsBrowser && viewItem == streamfile",
 					"group": "1_workspace@1"
@@ -1374,6 +1407,31 @@
 					"group": "3_ifsStuff@3"
 				},
 				{
+					"command": "code-for-ibmi.createDirectory",
+					"when": "view == ifsBrowser && viewItem == shortcut",
+					"group": "2_ifsStuff@2"
+				},
+				{
+					"command": "code-for-ibmi.createStreamfile",
+					"when": "view == ifsBrowser && viewItem == shortcut",
+					"group": "2_ifsStuff@1"
+				},
+				{
+					"command": "code-for-ibmi.searchIFS",
+					"when": "view == ifsBrowser && viewItem == shortcut",
+					"group": "3_ifsStuff@1"
+				},
+				{
+					"command": "code-for-ibmi.removeIFSShortcut",
+					"when": "view == ifsBrowser && viewItem == shortcut",
+					"group": "3_ifsStuff@2"
+				},
+				{
+					"command": "code-for-ibmi.changeWorkingDirectory",
+					"when": "view == ifsBrowser && viewItem == shortcut",
+					"group": "3_ifsStuff@3"
+				},
+				{
 					"command": "code-for-ibmi.downloadStreamfile",
 					"when": "view == ifsBrowser && viewItem == streamfile",
 					"group": "3_ifsTransfer@1"
@@ -1386,6 +1444,16 @@
 				{
 					"command": "code-for-ibmi.setDeployLocation",
 					"when": "view == ifsBrowser && viewItem == directory && code-for-ibmi:workspace == true",
+					"group": "3_ifsTransfer@3"
+				},
+				{
+					"command": "code-for-ibmi.uploadStreamfile",
+					"when": "view == ifsBrowser && viewItem == shortcut",
+					"group": "3_ifsTransfer@2"
+				},
+				{
+					"command": "code-for-ibmi.setDeployLocation",
+					"when": "view == ifsBrowser && viewItem == shortcut && code-for-ibmi:workspace == true",
 					"group": "3_ifsTransfer@3"
 				},
 				{

--- a/package.json
+++ b/package.json
@@ -1007,7 +1007,19 @@
 				"category": "IBM i",
 				"icon": "$(arrow-up)"
 			},
-		{
+			{
+				"command": "code-for-ibmi.moveIFSShortcutToTop",
+				"title": "Move IFS shortcut to top",
+				"category": "IBM i",
+				"icon": "$(arrow-up)"
+			},
+			{
+				"command": "code-for-ibmi.moveIFSShortcutToBottom",
+				"title": "Move IFS shortcut to bottom",
+				"category": "IBM i",
+				"icon": "$(arrow-up)"
+			},
+			{
 				"command": "code-for-ibmi.maintainFilter",
 				"title": "Maintain filter",
 				"category": "IBM i",
@@ -1432,19 +1444,29 @@
 					"group": "3_ifsStuff@3"
 				},
 				{
-					"command": "code-for-ibmi.moveIFSShortcutUp",
+					"command": "code-for-ibmi.moveIFSShortcutToTop",
 					"when": "view == ifsBrowser && viewItem == shortcut",
 					"group": "4_ifsStuff@1"
 				},
 				{
-					"command": "code-for-ibmi.moveIFSShortcutDown",
+					"command": "code-for-ibmi.moveIFSShortcutUp",
 					"when": "view == ifsBrowser && viewItem == shortcut",
 					"group": "4_ifsStuff@2"
 				},
 				{
-					"command": "code-for-ibmi.sortIFSShortcuts",
+					"command": "code-for-ibmi.moveIFSShortcutDown",
 					"when": "view == ifsBrowser && viewItem == shortcut",
 					"group": "4_ifsStuff@3"
+				},
+				{
+					"command": "code-for-ibmi.moveIFSShortcutToBottom",
+					"when": "view == ifsBrowser && viewItem == shortcut",
+					"group": "4_ifsStuff@4"
+				},
+				{
+					"command": "code-for-ibmi.sortIFSShortcuts",
+					"when": "view == ifsBrowser && viewItem == shortcut",
+					"group": "4_ifsStuff@5"
 				},
 				{
 					"command": "code-for-ibmi.downloadStreamfile",

--- a/package.json
+++ b/package.json
@@ -1449,24 +1449,9 @@
 					"group": "4_ifsStuff@1"
 				},
 				{
-					"command": "code-for-ibmi.moveIFSShortcutUp",
-					"when": "view == ifsBrowser && viewItem == shortcut",
-					"group": "4_ifsStuff@2"
-				},
-				{
-					"command": "code-for-ibmi.moveIFSShortcutDown",
-					"when": "view == ifsBrowser && viewItem == shortcut",
-					"group": "4_ifsStuff@3"
-				},
-				{
 					"command": "code-for-ibmi.moveIFSShortcutToBottom",
 					"when": "view == ifsBrowser && viewItem == shortcut",
 					"group": "4_ifsStuff@4"
-				},
-				{
-					"command": "code-for-ibmi.sortIFSShortcuts",
-					"when": "view == ifsBrowser && viewItem == shortcut",
-					"group": "4_ifsStuff@5"
 				},
 				{
 					"command": "code-for-ibmi.downloadStreamfile",

--- a/package.json
+++ b/package.json
@@ -1432,6 +1432,21 @@
 					"group": "3_ifsStuff@3"
 				},
 				{
+					"command": "code-for-ibmi.moveIFSShortcutUp",
+					"when": "view == ifsBrowser && viewItem == shortcut",
+					"group": "4_ifsStuff@1"
+				},
+				{
+					"command": "code-for-ibmi.moveIFSShortcutDown",
+					"when": "view == ifsBrowser && viewItem == shortcut",
+					"group": "4_ifsStuff@2"
+				},
+				{
+					"command": "code-for-ibmi.sortIFSShortcuts",
+					"when": "view == ifsBrowser && viewItem == shortcut",
+					"group": "4_ifsStuff@3"
+				},
+				{
 					"command": "code-for-ibmi.downloadStreamfile",
 					"when": "view == ifsBrowser && viewItem == streamfile",
 					"group": "3_ifsTransfer@1"

--- a/src/api/Configuration.js
+++ b/src/api/Configuration.js
@@ -26,7 +26,7 @@ module.exports = class Configuration {
     /** @type {string[]} */
     this.ifsShortcuts = base.ifsShortcuts || [];
 
-    /** @type {boolean} Undefined means not created, so default to on */
+    /** @type {boolean} Default auto sorting of shortcuts to off  */
     this.autoSortIFSShortcuts = (base.autoSortIFSShortcuts === true );
 
     /** @type {string} */

--- a/src/api/Configuration.js
+++ b/src/api/Configuration.js
@@ -26,6 +26,9 @@ module.exports = class Configuration {
     /** @type {string[]} */
     this.ifsShortcuts = base.ifsShortcuts || [];
 
+    /** @type {boolean} Undefined means not created, so default to on */
+    this.autoSortIFSShortcuts = (base.autoSortIFSShortcuts === true );
+
     /** @type {string} */
     this.homeDirectory = base.homeDirectory || `.`;
 

--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -193,6 +193,66 @@ module.exports = class ifsBrowserProvider {
         }
       }),
 
+      vscode.commands.registerCommand(`code-for-ibmi.moveIFSShortcutToTop`, async (node) => {
+        const config = instance.getConfig();
+
+        let moveDir;
+
+        let shortcuts = config.ifsShortcuts;
+
+        if (node) {
+          moveDir = node.path;
+        }
+
+        if (moveDir) {
+
+          try {
+            moveDir = moveDir.trim();
+
+            const inx = shortcuts.indexOf(moveDir);
+
+            if (inx >= 1 && inx < shortcuts.length) {
+              shortcuts.splice(inx, 1);
+              shortcuts.splice(0, 0, moveDir);
+              await config.set(`ifsShortcuts`, shortcuts);
+              if (Configuration.get(`autoRefresh`)) this.refresh();
+            }
+          } catch (e) {
+            console.log(e);
+          }
+        }
+      }),
+
+      vscode.commands.registerCommand(`code-for-ibmi.moveIFSShortcutToBottom`, async (node) => {
+        const config = instance.getConfig();
+
+        let moveDir;
+
+        let shortcuts = config.ifsShortcuts;
+
+        if (node) {
+          moveDir = node.path;
+        }
+
+        if (moveDir) {
+
+          try {
+            moveDir = moveDir.trim();
+
+            const inx = shortcuts.indexOf(moveDir);
+
+            if (inx >= 0 && inx < shortcuts.length) {
+              shortcuts.splice(inx, 1);
+              shortcuts.splice( shortcuts.length, 0, moveDir);
+              await config.set(`ifsShortcuts`, shortcuts);
+              if (Configuration.get(`autoRefresh`)) this.refresh();
+            }
+          } catch (e) {
+            console.log(e);
+          }
+        }
+      }),
+
       vscode.commands.registerCommand(`code-for-ibmi.createDirectory`, async (node) => {
         const connection = instance.getConnection();
         const config = instance.getConfig();

--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -54,6 +54,7 @@ module.exports = class ifsBrowserProvider {
         let newDirectory;
 
         let shortcuts = config.ifsShortcuts;
+        let autoSortIFSShortcuts = config.autoSortIFSShortcuts;
 
         if (node) {
           newDirectory = node.path;
@@ -70,6 +71,7 @@ module.exports = class ifsBrowserProvider {
             if (!shortcuts.includes(newDirectory)) {
               shortcuts.push(newDirectory);
               await config.set(`ifsShortcuts`, shortcuts);
+              if (autoSortIFSShortcuts === true) vscode.commands.executeCommand(`code-for-ibmi.sortIFSShortcuts`);
               if (Configuration.get(`autoRefresh`)) this.refresh();
             }
           }

--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -66,7 +66,7 @@ module.exports = class ifsBrowserProvider {
         try {
           if (newDirectory) {
             newDirectory = newDirectory.trim();
-            
+
             if (!shortcuts.includes(newDirectory)) {
               shortcuts.push(newDirectory);
               await config.set(`ifsShortcuts`, shortcuts);
@@ -98,7 +98,7 @@ module.exports = class ifsBrowserProvider {
             removeDir = removeDir.trim();
 
             const inx = shortcuts.indexOf(removeDir);
-            
+
             if (inx >= 0) {
               shortcuts.splice(inx, 1);
               await config.set(`ifsShortcuts`, shortcuts);
@@ -110,6 +110,81 @@ module.exports = class ifsBrowserProvider {
         }
       }),
 
+      vscode.commands.registerCommand(`code-for-ibmi.sortIFSShortcuts`, async (node) => {
+        const config = instance.getConfig();
+
+        let shortcuts = config.ifsShortcuts;
+
+        try {
+
+          shortcuts.sort();
+          await config.set(`ifsShortcuts`, shortcuts);
+          if (Configuration.get(`autoRefresh`)) this.refresh();
+        } catch (e) {
+          console.log(e);
+        }
+      }),
+
+      vscode.commands.registerCommand(`code-for-ibmi.moveIFSShortcutDown`, async (node) => {
+        const config = instance.getConfig();
+
+        let moveDir;
+
+        let shortcuts = config.ifsShortcuts;
+
+        if (node) {
+          moveDir = node.path;
+        }
+
+        if (moveDir) {
+
+          try {
+            moveDir = moveDir.trim();
+
+            const inx = shortcuts.indexOf(moveDir);
+
+            if (inx >= 0 && inx < shortcuts.length) {
+              shortcuts.splice(inx, 1);
+              shortcuts.splice(inx + 1, 0, moveDir);
+              await config.set(`ifsShortcuts`, shortcuts);
+              if (Configuration.get(`autoRefresh`)) this.refresh();
+            }
+          } catch (e) {
+            console.log(e);
+          }
+        }
+      }),
+
+      vscode.commands.registerCommand(`code-for-ibmi.moveIFSShortcutUp`, async (node) => {
+        const config = instance.getConfig();
+
+        let moveDir;
+
+        let shortcuts = config.ifsShortcuts;
+
+        if (node) {
+          moveDir = node.path;
+        }
+
+        if (moveDir) {
+
+          try {
+            moveDir = moveDir.trim();
+
+            const inx = shortcuts.indexOf(moveDir);
+
+            if (inx >= 1 && inx < shortcuts.length) {
+              shortcuts.splice(inx, 1);
+              shortcuts.splice(inx - 1, 0, moveDir);
+              await config.set(`ifsShortcuts`, shortcuts);
+              if (Configuration.get(`autoRefresh`)) this.refresh();
+            }
+          } catch (e) {
+            console.log(e);
+          }
+        }
+      }),
+
       vscode.commands.registerCommand(`code-for-ibmi.createDirectory`, async (node) => {
         const connection = instance.getConnection();
         const config = instance.getConfig();
@@ -117,7 +192,7 @@ module.exports = class ifsBrowserProvider {
 
         if (node) {
           //Running from right click
-          
+
           root = node.path;
         } else {
           root = config.homeDirectory;
@@ -148,12 +223,12 @@ module.exports = class ifsBrowserProvider {
 
         if (node) {
           //Running from right click
-          
+
           root = node.path;
         } else {
           root = config.homeDirectory;
         }
-        
+
         const fullName = await vscode.window.showInputBox({
           prompt: `Name of new streamfile`,
           value: root
@@ -195,7 +270,7 @@ module.exports = class ifsBrowserProvider {
 
         /** @type {{local: string, remote: string}[]} */
         const uploads = [];
-        
+
         chosenFiles.forEach(uri => {
           uploads.push({
             local: uri.fsPath,
@@ -244,7 +319,7 @@ module.exports = class ifsBrowserProvider {
       vscode.commands.registerCommand(`code-for-ibmi.moveIFS`, async (node) => {
         if (node) {
           //Running from right click
-          
+
           const fullName = await vscode.window.showInputBox({
             prompt: `Name of new path`,
             value: node.path
@@ -298,7 +373,7 @@ module.exports = class ifsBrowserProvider {
           console.log(this);
         }
       }),
-      
+
       vscode.commands.registerCommand(`code-for-ibmi.searchIFS`, async (node) => {
         const connection = instance.getConnection();
         const config = instance.getConfig();
@@ -405,7 +480,7 @@ module.exports = class ifsBrowserProvider {
 
     if (connection) {
       const config = instance.getConfig();
-      
+
       if (element) { //Chosen directory
         //Fetch members
         console.log(element.path);
@@ -426,7 +501,7 @@ module.exports = class ifsBrowserProvider {
         }
 
       } else {
-        items = config.ifsShortcuts.map(directory => new Object(`directory`, directory, directory));
+        items = config.ifsShortcuts.map(directory => new Object(`shortcut`, directory, directory));
         // const objects = await content.getFileList(config.homeDirectory);
 
         // for (let object of objects) {
@@ -439,9 +514,9 @@ module.exports = class ifsBrowserProvider {
   }
 
   /**
-   * 
-   * @param {string} path 
-   * @param {string[]} list 
+   *
+   * @param {string} path
+   * @param {string[]} list
    */
   storeIFSList(path, list) {
     const storage = instance.getStorage();
@@ -455,8 +530,8 @@ module.exports = class ifsBrowserProvider {
 
 class Object extends vscode.TreeItem {
   /**
-   * @param {"directory"|"streamfile"} type 
-   * @param {string} label 
+   * @param {"shortcut"|"directory"|"streamfile"} type
+   * @param {string} label
    * @param {string} path
    */
   constructor(type, label, path) {
@@ -465,7 +540,7 @@ class Object extends vscode.TreeItem {
     this.contextValue = type;
     this.path = path;
 
-    if (type === `directory`) {
+    if (type === `shortcut` || type === `directory`) {
       this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
     } else {
       this.resourceUri = vscode.Uri.parse(path).with({scheme: `streamfile`});

--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -119,7 +119,13 @@ module.exports = class ifsBrowserProvider {
 
         try {
 
-          shortcuts.sort();
+          shortcuts.sort(function(a, b){
+            let x = a.toLowerCase();
+            let y = b.toLowerCase();
+            if (x < y) {return -1;}
+            if (x > y) {return 1;}
+            return 0;
+          });
           await config.set(`ifsShortcuts`, shortcuts);
           if (Configuration.get(`autoRefresh`)) this.refresh();
         } catch (e) {

--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -136,29 +136,24 @@ module.exports = class ifsBrowserProvider {
       vscode.commands.registerCommand(`code-for-ibmi.moveIFSShortcutDown`, async (node) => {
         const config = instance.getConfig();
 
-        let moveDir;
-
         let shortcuts = config.ifsShortcuts;
 
         if (node) {
-          moveDir = node.path;
-        }
-
-        if (moveDir) {
-
-          try {
-            moveDir = moveDir.trim();
-
-            const inx = shortcuts.indexOf(moveDir);
-
-            if (inx >= 0 && inx < shortcuts.length) {
-              shortcuts.splice(inx, 1);
-              shortcuts.splice(inx + 1, 0, moveDir);
-              await config.set(`ifsShortcuts`, shortcuts);
-              if (Configuration.get(`autoRefresh`)) this.refresh();
+          const moveDir = node.path ? node.path.trim() : null;
+          
+          if (moveDir) {
+            try {
+              const inx = shortcuts.indexOf(moveDir);
+              
+              if (inx >= 0 && inx < shortcuts.length) {
+                shortcuts.splice(inx, 1);
+                shortcuts.splice(inx + 1, 0, moveDir);
+                await config.set(`ifsShortcuts`, shortcuts);
+                if (Configuration.get(`autoRefresh`)) this.refresh();
+              }
+            } catch (e) {
+              console.log(e);
             }
-          } catch (e) {
-            console.log(e);
           }
         }
       }),
@@ -166,29 +161,24 @@ module.exports = class ifsBrowserProvider {
       vscode.commands.registerCommand(`code-for-ibmi.moveIFSShortcutUp`, async (node) => {
         const config = instance.getConfig();
 
-        let moveDir;
-
         let shortcuts = config.ifsShortcuts;
 
         if (node) {
-          moveDir = node.path;
-        }
+          const moveDir = node.path ? node.path.trim() : null;
+          
+          if (moveDir) {
+            try {
+              const inx = shortcuts.indexOf(moveDir);
 
-        if (moveDir) {
-
-          try {
-            moveDir = moveDir.trim();
-
-            const inx = shortcuts.indexOf(moveDir);
-
-            if (inx >= 1 && inx < shortcuts.length) {
-              shortcuts.splice(inx, 1);
-              shortcuts.splice(inx - 1, 0, moveDir);
-              await config.set(`ifsShortcuts`, shortcuts);
-              if (Configuration.get(`autoRefresh`)) this.refresh();
+              if (inx >= 1 && inx < shortcuts.length) {
+                shortcuts.splice(inx, 1);
+                shortcuts.splice(inx - 1, 0, moveDir);
+                await config.set(`ifsShortcuts`, shortcuts);
+                if (Configuration.get(`autoRefresh`)) this.refresh();
+              }
+            } catch (e) {
+              console.log(e);
             }
-          } catch (e) {
-            console.log(e);
           }
         }
       }),
@@ -196,29 +186,24 @@ module.exports = class ifsBrowserProvider {
       vscode.commands.registerCommand(`code-for-ibmi.moveIFSShortcutToTop`, async (node) => {
         const config = instance.getConfig();
 
-        let moveDir;
-
         let shortcuts = config.ifsShortcuts;
 
         if (node) {
-          moveDir = node.path;
-        }
-
-        if (moveDir) {
-
-          try {
-            moveDir = moveDir.trim();
-
-            const inx = shortcuts.indexOf(moveDir);
-
-            if (inx >= 1 && inx < shortcuts.length) {
-              shortcuts.splice(inx, 1);
-              shortcuts.splice(0, 0, moveDir);
-              await config.set(`ifsShortcuts`, shortcuts);
-              if (Configuration.get(`autoRefresh`)) this.refresh();
+          const moveDir = node.path ? node.path.trim() : null;
+          
+          if (moveDir) {
+            try {
+              const inx = shortcuts.indexOf(moveDir);
+              
+              if (inx >= 1 && inx < shortcuts.length) {
+                shortcuts.splice(inx, 1);
+                shortcuts.splice(0, 0, moveDir);
+                await config.set(`ifsShortcuts`, shortcuts);
+                if (Configuration.get(`autoRefresh`)) this.refresh();
+              }
+            } catch (e) {
+              console.log(e);
             }
-          } catch (e) {
-            console.log(e);
           }
         }
       }),
@@ -226,29 +211,24 @@ module.exports = class ifsBrowserProvider {
       vscode.commands.registerCommand(`code-for-ibmi.moveIFSShortcutToBottom`, async (node) => {
         const config = instance.getConfig();
 
-        let moveDir;
-
         let shortcuts = config.ifsShortcuts;
 
         if (node) {
-          moveDir = node.path;
-        }
-
-        if (moveDir) {
-
-          try {
-            moveDir = moveDir.trim();
-
-            const inx = shortcuts.indexOf(moveDir);
-
-            if (inx >= 0 && inx < shortcuts.length) {
-              shortcuts.splice(inx, 1);
-              shortcuts.splice( shortcuts.length, 0, moveDir);
-              await config.set(`ifsShortcuts`, shortcuts);
-              if (Configuration.get(`autoRefresh`)) this.refresh();
+          const moveDir = node.path ? node.path.trim() : null;
+          
+          if (moveDir) {
+            try {
+              const inx = shortcuts.indexOf(moveDir);
+              
+              if (inx >= 0 && inx < shortcuts.length) {
+                shortcuts.splice(inx, 1);
+                shortcuts.splice( shortcuts.length, 0, moveDir);
+                await config.set(`ifsShortcuts`, shortcuts);
+                if (Configuration.get(`autoRefresh`)) this.refresh();
+              }
+            } catch (e) {
+              console.log(e);
             }
-          } catch (e) {
-            console.log(e);
           }
         }
       }),

--- a/src/webviews/settings/index.js
+++ b/src/webviews/settings/index.js
@@ -64,6 +64,11 @@ module.exports = class SettingsUI {
         field.description = `Automatically clear temporary data in the chosen temporary library when it's done with and on startup. Deletes all <code>*FILE</code> objects that start with <code>O_</code> in the chosen temporary library.`;
         ui.addField(field);
 
+        field = new Field(`checkbox`, `autoSortIFSShortcuts`, `Sort IFS shortcuts automatically`);
+        field.default = (config.autoSortIFSShortcuts ? `checked` : ``)
+        field.description = `Automatically sort the shortcuts in IFS browser when shortcut is added or removed.`;
+        ui.addField(field);
+
         field = new Field(`checkbox`, `enableSQL`, `Enable SQL`);
         field.default = (config.enableSQL ? `checked` : ``);
         field.description = `Must be enabled to make the use of SQL and is enabled by default. If you find SQL isn't working for some reason, disable this. If your QCCSID is 65535, it is recommend SQL is disabled. When disabled, will use import files where possible.`;


### PR DESCRIPTION
### Changes

This PR will add the ability to sort the IFS shortcuts in the IFS browser:

- The shortcuts have a new item type `shortcut` - previously they were `directory` like regular directories.
- There are new icons for the shortcuts to move the shortcut up or down in the list, to the top or bottom and to sort the list.
- There is a new icon in the view to sort the shortcuts alphabetically - case-insensitive.
- There is a new setting in the configuration to automatically sort the shortcuts when a shortcut is added or removed.

It was my ambition to have a drag-and-drop function implemented so one could just reorder by dragging the shortcut into he desired place - but this is currently way above my skills in VS Code extension programming! 😆 

I use the IFS browser almost all the time - with my sources in IFS - so that's why I have focused my contributions to this area of your excellent VS Code extension. My many IFS shortcuts had been added in a long time-frame and were in a chaotic order, and I added this functionality for my own convenience, but it could be useful to others as well. I know I could have manually ordered the shortcut list in the configuration, but this may not be obvious to all...

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [x] **for feature PRs**: PR only includes one feature enhancement.
