### PR TITLE
New filter context to create a savefile (#709)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1020,6 +1020,11 @@
 				"icon": "$(file-directory-create)"
 			},
 			{
+				"command": "code-for-ibmi.createSaveFile",
+				"title": "Create Save File",
+				"category": "IBM i"
+			},
+			{
 				"command": "code-for-ibmi.runEditorStatement",
 				"title": "Run selected statement",
 				"category": "IBM i",
@@ -1397,6 +1402,11 @@
 					"command": "code-for-ibmi.createSourceFile",
 					"when": "view == objectBrowser && viewItem == filter",
 					"group": "1_LibActions@1"
+				},
+				{
+					"command": "code-for-ibmi.createSaveFile",
+					"when": "view == objectBrowser && viewItem == filter",
+					"group": "1_LibActions@2"
 				},
 				{
 					"command": "code-for-ibmi.runAction",

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -468,7 +468,7 @@ module.exports = class objectBrowserTwoProvider {
 
           await vscode.window.withProgress({
             location: vscode.ProgressLocation.Notification,
-            title: `Searching`,
+            title: `Savefile`,
           }, async progress => {
             progress.report({
               message: `Fetching object list for ${library}.`

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -14,7 +14,6 @@ const Configuration = require(`../api/Configuration`);
 const Search = require(`../api/Search`);
 const Tools = require(`../api/Tools`);
 const path = require(`path`);
-const { select } = require(`../api/terminal`);
 
 module.exports = class objectBrowserTwoProvider {
   /**


### PR DESCRIPTION
### Changes

Implements new user context to 

1. let the user select which objects to put into a savefile
2. select where to put the savefile on the IFS
3. download, and optionally delete the streamfile

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
