### PR TITLE
Data collection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,22 @@ Maintain your RPGLE, CL, COBOL, C/CPP on IBM i right from Visual Studio Code. Ed
 3. `npm i`
 4. 'Run Extension' from vscode debug.
 
+### Data collection
+
+We do not collect any Personally identifiable information (PII). We do collect:
+
+* When you connect to a system - but nothing about that system.
+* The version of Visual Studio Code you're using.
+* The version of the Code for IBM i you're using.
+* The architecture of the machine you're using (e.g. Windows, Linux, Mac, Cloud, etc)
+
+We do this for a few reasons:
+
+1. Curious to see how many active users we have.
+2. Allows us to see how often users are updating.
+3. Let's us know what operating systems we should cater to (e.g. Windows vs Mac)
+
+**You can disable this:** 
+
+1. Open the VS Code settings (Control / Command + Comma)
+2. Search `telemetry` and set `telemetry.telemetryLevel` to `none`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
 	"name": "code-for-ibmi",
-	"version": "1.3.4",
+	"version": "1.3.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "code-for-ibmi",
-			"version": "1.3.4",
+			"version": "1.3.7",
 			"license": "MIT",
 			"dependencies": {
 				"@bendera/vscode-webview-elements": "^0.6.3",
+				"@vscode/extension-telemetry": "^0.6.0",
 				"csv": "^6.0.5",
 				"escape-string-regexp": "^5.0.0",
 				"ignore": "^5.1.9",
@@ -211,6 +212,14 @@
 			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
 			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
 			"dev": true
+		},
+		"node_modules/@vscode/extension-telemetry": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.6.0.tgz",
+			"integrity": "sha512-zKETw3KgP31Ea8vRt/cu6bnF6lhtSz/9kp40+IsZheuq0vZ4z5Ce2oIB0WSiEvqrJQlmEbVTUlSj5Nmq0PSKMA==",
+			"engines": {
+				"vscode": "^1.60.0"
+			}
 		},
 		"node_modules/@webassemblyjs/ast": {
 			"version": "1.11.0",
@@ -3465,6 +3474,11 @@
 			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
 			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
 			"dev": true
+		},
+		"@vscode/extension-telemetry": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.6.0.tgz",
+			"integrity": "sha512-zKETw3KgP31Ea8vRt/cu6bnF6lhtSz/9kp40+IsZheuq0vZ4z5Ce2oIB0WSiEvqrJQlmEbVTUlSj5Nmq0PSKMA=="
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -646,7 +646,8 @@
 							],
 							"name": "Create SQL ILE RPG Module (CRTSQLRPGI)",
 							"command": "?CRTSQLRPGI OBJ(&BUILDLIB/&NAME) SRCSTMF('&FULLPATH') OBJTYPE(*MODULE) CLOSQLCSR(*ENDMOD) OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT)"
-						},						{
+						},
+						{
 							"type": "streamfile",
 							"extensions": [
 								"RPGLE",
@@ -671,7 +672,8 @@
 							],
 							"name": "Run SQL Statements (RUNSQLSTM)",
 							"command": "?RUNSQLSTM SRCSTMF('&FULLPATH') COMMIT(*NONE) NAMING(*SQL)"
-						},						{
+						},
+						{
 							"type": "streamfile",
 							"extensions": [
 								"cmd"
@@ -1549,6 +1551,7 @@
 	},
 	"dependencies": {
 		"@bendera/vscode-webview-elements": "^0.6.3",
+		"@vscode/extension-telemetry": "^0.6.0",
 		"csv": "^6.0.5",
 		"escape-string-regexp": "^5.0.0",
 		"ignore": "^5.1.9",

--- a/src/api/IBMi.js
+++ b/src/api/IBMi.js
@@ -1,6 +1,8 @@
 
 const vscode = require(`vscode`);
 
+const Reporter = require(`../reporter`);
+
 const node_ssh = require(`node-ssh`);
 const Configuration = require(`./Configuration`);
 const Tools = require(`./Tools`);
@@ -516,6 +518,8 @@ module.exports = class IBMi {
         } else {
           vscode.window.showWarningMessage(`Code for IBM i may not function correctly until your user has a home directory. Please set a home directory using CHGUSRPRF USRPRF(${connectionObject.username.toUpperCase()}) HOMEDIR('/home/${connectionObject.username.toLowerCase()}')`);
         }
+
+        Reporter.sendTelemetryEvent(`connected`)
 
         return {
           success: true

--- a/src/extension.js
+++ b/src/extension.js
@@ -19,15 +19,17 @@ function activate(context) {
 
   // Use the console to output diagnostic information (console.log) and errors (console.error)
   // This line of code will only be executed once when your extension is activated
-  console.log(`Congratulations, your extension "code-for-ibmi" is now active!`);
 
-  // @ts-ignore Used to check if extension is being debugged. If this
-  // is true, then don't send any data to the collection service.
-  if (vscode.env.isTelemetryEnabled && !process._debugProcess) {
-    console.log(`Telemetry is enabled.`);
+  console.log(`Congratulations, your extension "code-for-ibmi" is now active!`);
+  
+  if (vscode.env.isTelemetryEnabled) {
     const extensionName = process.env.EXT_NAME;
     const extensionVersion = process.env.EXT_VERSION;
     const azureKey = process.env.AZURE_COLLECT_KEY;
+
+    console.log(`Extension name: ${extensionName}`);
+    console.log(`Extension version: ${extensionVersion}`);
+    console.log(`Azure key: ${azureKey}`);
 
     const reporter = Reporter.create(extensionName, extensionVersion, azureKey);
     context.subscriptions.push(reporter);

--- a/src/extension.js
+++ b/src/extension.js
@@ -2,6 +2,8 @@
 // Import the module and reference it with the alias vscode in your code below
 const vscode = require(`vscode`);
 
+const Reporter = require(`./reporter`);
+
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 
@@ -18,6 +20,18 @@ function activate(context) {
   // Use the console to output diagnostic information (console.log) and errors (console.error)
   // This line of code will only be executed once when your extension is activated
   console.log(`Congratulations, your extension "code-for-ibmi" is now active!`);
+
+  // @ts-ignore Used to check if extension is being debugged. If this
+  // is true, then don't send any data to the collection service.
+  if (vscode.env.isTelemetryEnabled && !process._debugProcess) {
+    console.log(`Telemetry is enabled.`);
+    const extensionName = process.env.EXT_NAME;
+    const extensionVersion = process.env.EXT_VERSION;
+    const azureKey = process.env.AZURE_COLLECT_KEY;
+
+    const reporter = Reporter.create(extensionName, extensionVersion, azureKey);
+    context.subscriptions.push(reporter);
+  }
 
   //We setup the event emitter.
   instance.setupEmitter();

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,0 +1,22 @@
+const vscode = require(`vscode`);
+const TelemetryReporter = require(`@vscode/extension-telemetry`).default;
+
+/** @type {TelemetryReporter} */
+let reporter;
+
+module.exports = class {
+  static create(id, version, key) {
+    reporter = new TelemetryReporter(id, version, key);
+    return reporter;
+  }
+
+  /**
+   * 
+   * @param {string} event 
+   * @param {object} data 
+   */
+  static sendTelemetryEvent(event, data) {
+    if (reporter && vscode.env.isTelemetryEnabled)
+      return reporter.sendTelemetryEvent(event, data);
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,8 +3,14 @@
 'use strict';
 
 const path = require(`path`);
+const webpack = require(`webpack`);
 
-/**@type {import('webpack').Configuration}*/
+// @ts-ignore
+const extensionInfo = require(`./package.json`);
+
+const AZURE_COLLECT_KEY = `1b15d94b-bace-4a07-aab6-f33792c6e8fe`;
+
+/**@type {webpack.Configuration}*/
 const config = {
   target: `node`, // vscode extensions run in a Node.js-context 📖 -> https://webpack.js.org/configuration/node/
 
@@ -18,14 +24,21 @@ const config = {
   },
   devtool: `source-map`,
   externals: {
-    vscode: `commonjs vscode` // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
+    vscode: `commonjs vscode`, // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
+    'applicationinsights-native-metrics': `commonjs applicationinsights-native-metrics` // ignored because we don't ship native module -> https://github.com/microsoft/vscode-extension-telemetry/issues/41#issuecomment-598852991
   },
   resolve: {
     // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
     extensions: [`.ts`, `.js`, `.svg`],
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.AZURE_COLLECT_KEY': JSON.stringify(AZURE_COLLECT_KEY),
+      'process.env.EXT_VERSION': JSON.stringify(extensionInfo.version),
+      'process.env.EXT_NAME': JSON.stringify(extensionInfo.name),
+    })
+  ],
   module: {
-    
     rules: [
       {
         test: /\.js$/,


### PR DESCRIPTION
### Changes

Support for collecting non-PPI data. I am also happy if this does not get merged, but it would be interesting to see what data it can provide.

#### Data collection

We do not collect any Personally identifiable information (PII). We do collect:

* When you connect to a system - but nothing about that system.
* The version of Visual Studio Code you're using.
* The version of the Code for IBM i you're using.
* The architecture of the machine you're using (e.g. Windows, Linux, Mac, Cloud, etc)

We do this for a few reasons:

1. Curious to see how many active users we have.
2. Allows us to see how often users are updating.
3. Let's us know what operating systems we should cater to (e.g. Windows vs Mac)

**You can disable this:** 

1. Open the VS Code settings (Control / Command + Comma)
2. Search `telemetry` and set `telemetry.telemetryLevel` to `none`.

### Checklist

* [x] have tested my change
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
