### PR TITLE
Make member search respect member type filter

### DIFF
--- a/src/api/Search.js
+++ b/src/api/Search.js
@@ -42,7 +42,7 @@ module.exports = class Search {
     }
 
     const result = await connection.sendQsh({
-      command: `/usr/bin/grep -in -F "${term}" ${asp}/QSYS.LIB/${connection.sysNameInAmerican(lib)}.LIB/${connection.sysNameInAmerican(spf)}.FILE/${memberFilter ? memberFilter : `*`}`,
+      command: `/usr/bin/grep -in -F "${term}" ${asp}/QSYS.LIB/${connection.sysNameInAmerican(lib)}.LIB/${connection.sysNameInAmerican(spf)}.FILE/${memberFilter ? connection.sysNameInAmerican(memberFilter) : `*`}`,
     });
 
     //@ts-ignore stderr does exist.

--- a/src/api/Search.js
+++ b/src/api/Search.js
@@ -42,7 +42,7 @@ module.exports = class Search {
     }
 
     const result = await connection.sendQsh({
-      command: `/usr/bin/grep -in -F "${term}" ${asp}/QSYS.LIB/${connection.sysNameInAmerican(lib)}.LIB/${connection.sysNameInAmerican(spf)}.FILE/${memberFilter ? connection.sysNameInAmerican(memberFilter) : `*`}`,
+      command: `/usr/bin/grep -inHR -F "${term}" ${asp}/QSYS.LIB/${connection.sysNameInAmerican(lib)}.LIB/${connection.sysNameInAmerican(spf)}.FILE/${memberFilter ? connection.sysNameInAmerican(memberFilter) : `*`}`,
     });
 
     //@ts-ignore stderr does exist.

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -352,7 +352,7 @@ module.exports = class objectBrowserTwoProvider {
                       }
                     }, timeoutInternal);
 
-                    const results = await Search.searchMembers(instance, path[0], path[1], node.memberFilter, searchTerm);
+                    let results = await Search.searchMembers(instance, path[0], path[1], `${node.memberFilter}.MBR`, searchTerm);
 
                     // Filter search result by member type filter.
                     if (results.length > 0) {

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -355,7 +355,7 @@ module.exports = class objectBrowserTwoProvider {
                     let results = await Search.searchMembers(instance, path[0], path[1], `${node.memberFilter}.MBR`, searchTerm);
 
                     // Filter search result by member type filter.
-                    if (results.length > 0) {
+                    if (results.length > 0 && node.memberTypeFilter) {
                       const patternExt = new RegExp(`^` + node.memberTypeFilter.replace(/[*]/g, `.*`).replace(/[$]/g, `\\$`) + `$`);
                       results = results.filter(result => {
                         const resultPath = result.path.split(`/`);


### PR DESCRIPTION
### Changes

This PR will
- enhance the member search feature to respect any member type filter.
- fix error received when member filter is not ending in `*`.
- fix empty result set when searching in only one member in filter.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
