### PR TITLE
Minor improvements to the member search function

### DIFF
--- a/src/api/Search.js
+++ b/src/api/Search.js
@@ -42,7 +42,7 @@ module.exports = class Search {
     }
 
     const result = await connection.sendQsh({
-      command: `/usr/bin/grep -in -F "${term}" ${asp}/QSYS.LIB/${connection.sysNameInAmerican(lib)}.LIB/${connection.sysNameInAmerican(spf)}.FILE/${memberFilter ? memberFilter : `*`}`,
+      command: `/usr/bin/grep -in -F "${term}" ${asp}/QSYS.LIB/${connection.sysNameInAmerican(lib)}.LIB/${connection.sysNameInAmerican(spf)}.FILE/${memberFilter ? connection.sysNameInAmerican(memberFilter) : `*`}`,
     });
 
     //@ts-ignore stderr does exist.

--- a/src/api/Search.js
+++ b/src/api/Search.js
@@ -42,7 +42,7 @@ module.exports = class Search {
     }
 
     const result = await connection.sendQsh({
-      command: `/usr/bin/grep -in -F "${term}" ${asp}/QSYS.LIB/${connection.sysNameInAmerican(lib)}.LIB/${connection.sysNameInAmerican(spf)}.FILE/${memberFilter ? connection.sysNameInAmerican(memberFilter) : `*`}`,
+      command: `/usr/bin/grep -inHR -F "${term}" ${asp}/QSYS.LIB/${connection.sysNameInAmerican(lib)}.LIB/${connection.sysNameInAmerican(spf)}.FILE/${memberFilter ? connection.sysNameInAmerican(memberFilter) : `*`}`,
     });
 
     //@ts-ignore stderr does exist.

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -371,7 +371,8 @@ module.exports = class objectBrowserTwoProvider {
                       results.forEach(result => {
                         const resultPath = result.path.split(`/`);
                         const resultName = resultPath[resultPath.length-1];
-                        result.path += `.${members.find(member => member.name === resultName).extension.toLowerCase()}`;
+                        result.path += `.${members.find(member => member.name === resultName).extension}`;
+                        result.path = result.path.toLowerCase();
                       });
 
                       instance.setSearchResults(searchTerm, results);

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -352,7 +352,7 @@ module.exports = class objectBrowserTwoProvider {
                       }
                     }, timeoutInternal);
 
-                    const results = await Search.searchMembers(instance, path[0], path[1], node.memberFilter, searchTerm);
+                    let results = await Search.searchMembers(instance, path[0], path[1], `${node.memberFilter}.MBR`, searchTerm);
 
                     // Filter search result by member type filter.
                     if (results.length > 0) {

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -355,7 +355,7 @@ module.exports = class objectBrowserTwoProvider {
                     let results = await Search.searchMembers(instance, path[0], path[1], `${node.memberFilter}.MBR`, searchTerm);
 
                     // Filter search result by member type filter.
-                    if (results.length > 0) {
+                    if (results.length > 0 && node.memberTypeFilter) {
                       const patternExt = new RegExp(`^` + node.memberTypeFilter.replace(/[*]/g, `.*`).replace(/[$]/g, `\\$`) + `$`);
                       results = results.filter(result => {
                         const resultPath = result.path.split(`/`);

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -375,6 +375,10 @@ module.exports = class objectBrowserTwoProvider {
                         result.path = result.path.toLowerCase();
                       });
 
+                      results = results.sort((a, b) => {
+                        return a.path.localeCompare(b.path);
+                      });
+                  
                       instance.setSearchResults(searchTerm, results);
 
                     } else {


### PR DESCRIPTION
### Changes

This PR will
- make both member name and member type in lowercase in the search result window - previously member name was uppercase while member type was lowercase.
- sort the search result list in local order - instead of the server order which was American and did not correspond to the local order when the variant characters were vowels.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
