### PR TITLE
Change default object filter to source file

### DIFF
--- a/src/webviews/filters/index.js
+++ b/src/webviews/filters/index.js
@@ -17,6 +17,7 @@ module.exports = class FiltersUI {
     let filter;
 
     if (name) {
+      // If a name is provided, then find the existing filter
       existingConfigIndex = objectFilters.findIndex(filter => filter.name === name);
 
       if (existingConfigIndex >= 0) {
@@ -27,11 +28,12 @@ module.exports = class FiltersUI {
       }
 
     } else {
+      // Otherwise, set the default values
       filter = {
         name: `Filter ${objectFilters.length + 1}`,
         library: `QGPL`,
         object: `*`,
-        types: [`*ALL`],
+        types: [`*SRCPF`],
         member: `*`,
       }
     }


### PR DESCRIPTION
### Changes

Most people initially want to open source code, so it makes sense to make to make the default object filter `*SRCPF` for that reason. 

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [x] **for feature PRs**: PR only includes one feature enhancement.
