### PR TITLE
Action management improvements

### DIFF
--- a/src/webviews/actions/index.js
+++ b/src/webviews/actions/index.js
@@ -292,7 +292,7 @@ module.exports = class SettingsUI {
       if (data) {
         switch (data.buttons) {
         case `deleteAction`:
-          const result = await vscode.window.showInformationMessage(`Are you sure you want to delete this action?`, `Yes`, `No`)
+          const result = await vscode.window.showInformationMessage(`Are you sure you want to delete this action?`, { modal:true }, `Yes`, `No`)
           if (result === `Yes`) {
             allActions.splice(id, 1);
             await Configuration.setGlobal(`actions`, allActions);

--- a/src/webviews/actions/index.js
+++ b/src/webviews/actions/index.js
@@ -133,6 +133,7 @@ module.exports = class SettingsUI {
     let allActions = Configuration.get(`actions`);
     let currentAction;
     let uiTitle;
+    let stayOnPanel = true;
 
     if (id >= 0) {
       //Fetch existing action
@@ -285,47 +286,53 @@ module.exports = class SettingsUI {
       });
     ui.addField(field);
 
-    let {panel, data} = await ui.loadPage(uiTitle);
+    while (stayOnPanel === true) {
+      let {panel, data} = await ui.loadPage(uiTitle);
 
-    if (data) {
-      panel.dispose();
-      switch (data.buttons) {
-      case `deleteAction`:
-        const result = await vscode.window.showInformationMessage(`Are you sure you want to delete this action?`, `Yes`, `No`)
-        if (result === `Yes`) {
-          allActions.splice(id, 1);
+      if (data) {
+        switch (data.buttons) {
+        case `deleteAction`:
+          const result = await vscode.window.showInformationMessage(`Are you sure you want to delete this action?`, `Yes`, `No`)
+          if (result === `Yes`) {
+            allActions.splice(id, 1);
+            await Configuration.setGlobal(`actions`, allActions);
+            stayOnPanel=false;
+          }
+          break;
+
+        case `cancelAction`:
+          stayOnPanel=false;
+          break;
+
+        default:
+          // We don't want \r (Windows line endings)
+          data.command = data.command.replace(new RegExp(`\\\r`, `g`), ``);
+
+          const newAction = {
+            type: data.type,
+            extensions: data.extensions.split(`,`).map(item => item.trim().toUpperCase()),
+            environment: data.environment,
+            name: data.name,
+            command: data.command,
+          };
+      
+          if (id >= 0) {
+            allActions[id] = newAction;
+          } else {
+            allActions.push(newAction);
+          }
+
           await Configuration.setGlobal(`actions`, allActions);
+          stayOnPanel=false;
+          break;
         }
-        break;
-
-      case `cancelAction`:
-        break;
-
-      default:
-        // We don't want \r (Windows line endings)
-        data.command = data.command.replace(new RegExp(`\\\r`, `g`), ``);
-
-        const newAction = {
-          type: data.type,
-          extensions: data.extensions.split(`,`).map(item => item.trim().toUpperCase()),
-          environment: data.environment,
-          name: data.name,
-          command: data.command,
-        };
-    
-        if (id >= 0) {
-          allActions[id] = newAction;
-        } else {
-          allActions.push(newAction);
-        }
-
-        await Configuration.setGlobal(`actions`, allActions);
-        break;
+        
       }
 
+      panel.dispose();
     }
 
     this.MainMenu();
   }
-
+  
 }

--- a/src/webviews/actions/index.js
+++ b/src/webviews/actions/index.js
@@ -115,9 +115,7 @@ module.exports = class SettingsUI {
         const index = action.value;
 
         const newAction = {...actions[index]};
-        actions.push(newAction);
-        await Configuration.setGlobal(`actions`, actions);
-        this.WorkAction(actions.length - 1);
+        this.WorkAction(-1, newAction);
       } else {
         this.MainMenu();
       }
@@ -128,8 +126,9 @@ module.exports = class SettingsUI {
   /**
    * Edit an existing action
    * @param {number} id Existing action index, or -1 for a brand new index
+   * @param {object} ActionDefault Default action properties
    */
-  static async WorkAction(id) {
+  static async WorkAction(id, ActionDefault) {
     const config = instance.getConfig();
     let allActions = Configuration.get(`actions`);
     let currentAction;
@@ -139,6 +138,8 @@ module.exports = class SettingsUI {
 
       currentAction = allActions[id];
 
+    } else if (ActionDefault) {
+      currentAction = ActionDefault;
     } else {
       //Otherwise.. prefill with defaults
       currentAction = {

--- a/src/webviews/actions/index.js
+++ b/src/webviews/actions/index.js
@@ -132,14 +132,17 @@ module.exports = class SettingsUI {
     const config = instance.getConfig();
     let allActions = Configuration.get(`actions`);
     let currentAction;
-    
+    let uiTitle;
+
     if (id >= 0) {
       //Fetch existing action
-
+      
       currentAction = allActions[id];
+      uiTitle = `Edit action "${currentAction.name}"`;
 
     } else if (ActionDefault) {
       currentAction = ActionDefault;
+      uiTitle = `Duplicate action "${currentAction.name}"`;
     } else {
       //Otherwise.. prefill with defaults
       currentAction = {
@@ -152,6 +155,7 @@ module.exports = class SettingsUI {
         name: ``,
         command: ``
       }
+      uiTitle = `Create action`;
     }
 
     if (currentAction.environment === undefined) currentAction.environment = `ile`;
@@ -276,7 +280,7 @@ module.exports = class SettingsUI {
     };
     ui.addField(field);
 
-    let {panel, data} = await ui.loadPage(`Work with Actions`);
+    let {panel, data} = await ui.loadPage(uiTitle);
 
     if (data) {
       panel.dispose();

--- a/src/webviews/actions/index.js
+++ b/src/webviews/actions/index.js
@@ -278,6 +278,11 @@ module.exports = class SettingsUI {
           label: `Delete`,
         });
     };
+    field.items.push(
+      {
+        id: `cancelAction`,
+        label: `Cancel`,
+      });
     ui.addField(field);
 
     let {panel, data} = await ui.loadPage(uiTitle);
@@ -291,6 +296,9 @@ module.exports = class SettingsUI {
           allActions.splice(id, 1);
           await Configuration.setGlobal(`actions`, allActions);
         }
+        break;
+
+      case `cancelAction`:
         break;
 
       default:

--- a/src/webviews/actions/index.js
+++ b/src/webviews/actions/index.js
@@ -328,6 +328,9 @@ module.exports = class SettingsUI {
         }
         
       }
+      else {
+        stayOnPanel=false;
+      }
 
       panel.dispose();
     }


### PR DESCRIPTION
### Changes

This PR has the following improvements to action management:

- Duplicated actions are not saved before confirmation. The action selected for duplication will be shown in the action edit panel, where the user can change and save the action.
- The title for the action panel is changed according to the operation, e.g. `Change action "xxxx"` when changing an action. Previously the title was always `Work with Actions`.
- A button labeled `Cancel` is added to all action management panels. This is more intuitive for cancelling the operation and go back to the list of actions than having to close the panel using Ctrl-W or click on X.
- The action edit panel will stay on screen if the user clicks `Delete` and then selects No or cancel on the confirmation message. However, the changed values will be reset to the initial values, I have not yet figured out how to keep the changed values.
- Show Delete confirmation message as modal to bring full attention to the user.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
