### PR TITLE
Support QsysFs INB files for IBM i Notebooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,3 +35,4 @@ Thanks so much to everyone [who has contributed](https://github.com/halcyon-tech
 * [@EddieSmith](https://github.com/EddieSmith)
 * [@fathert](https://github.com/fathert)
 * [@Teqed](https://github.com/Teqed)
+* [@Wright4i](https://github.com/Wright4i)

--- a/src/filesystems/qsys/complex.js
+++ b/src/filesystems/qsys/complex.js
@@ -18,9 +18,9 @@ module.exports = class ComplexQsysFs {
    */
   async readFile(uri) {
     const connection = instance.getConnection();
-    const {asp, library, file, member} = connection.parserMemberPath(uri.path);
+    const {asp, library, file, member, extension} = connection.parserMemberPath(uri.path);
 
-    const memberContent = await contentApi.downloadMemberContentWithDates(asp, library, file, member);
+    const memberContent = await contentApi.downloadMemberContentWithDates(asp, library, file, member, extension);
 
     return new Uint8Array(Buffer.from(memberContent, `utf8`));
   }
@@ -40,9 +40,9 @@ module.exports = class ComplexQsysFs {
    */
   writeFile(uri, content, options) {
     const connection = instance.getConnection();
-    const {asp, library, file, member} = connection.parserMemberPath(uri.path);
+    const {asp, library, file, member, extension} = connection.parserMemberPath(uri.path);
 
-    return contentApi.uploadMemberContentWithDates(asp, library, file, member, content.toString(`utf8`));
+    return contentApi.uploadMemberContentWithDates(asp, library, file, member, extension, content.toString(`utf8`));
   }
 
   /**


### PR DESCRIPTION
### Changes

Added support for saving source type `INB` files in Qsys. Before it would attempt to save the JSON from IBM i Notebooks up to the record length, causing malformed JSON and a loss of all data stored in your INB file.

**Writing to Qsys**
If extension is `INB` and the sourceData array has 1 element of valid JSON then it will use regex to split on recordLength instead of `\n`.

**Reading from Qsys**
If extension is `INB` join srcdta using ` `` ` instead of `\n` back to the body

### Checklist

* [x] have tested my change
* [x] updated relevant documentation [vscode-ibmi-notebooks commit/future PR](https://github.com/halcyon-tech/vscode-ibmi-notebooks/commit/c934df3a403b58dd4e1eaf4c5fcbce54b9c6acb0)
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [x] **for feature PRs**: PR only includes one feature enhancement.
