### PR TITLE
Show current library in library list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1337,6 +1337,11 @@
 					"group": "inline"
 				},
 				{
+					"command": "code-for-ibmi.changeCurrentLibrary",
+					"when": "view == libraryListView && viewItem == currentLibrary",
+					"group": "libraryChangeCurrent@1"
+				},
+				{
 					"command": "code-for-ibmi.removeFromLibraryList",
 					"when": "view == libraryListView && viewItem == library",
 					"group": "libraryRemove@1"

--- a/package.json
+++ b/package.json
@@ -1208,11 +1208,6 @@
 					"when": "view == libraryListView"
 				},
 				{
-					"command": "code-for-ibmi.changeCurrentLibrary",
-					"group": "navigation",
-					"when": "view == libraryListView"
-				},
-				{
 					"command": "code-for-ibmi.addToLibraryList",
 					"group": "navigation",
 					"when": "view == libraryListView"
@@ -1339,7 +1334,7 @@
 				{
 					"command": "code-for-ibmi.changeCurrentLibrary",
 					"when": "view == libraryListView && viewItem == currentLibrary",
-					"group": "libraryChangeCurrent@1"
+					"group": "inline"
 				},
 				{
 					"command": "code-for-ibmi.removeFromLibraryList",

--- a/src/views/libraryListView.js
+++ b/src/views/libraryListView.js
@@ -34,6 +34,7 @@ module.exports = class libraryListProvider {
 
         if (newLibrary && newLibrary !== currentLibrary) {
           await config.set(`currentLibrary`, newLibrary);
+          if (Configuration.get(`autoRefresh`)) this.refresh();
         }
       }),
 
@@ -230,6 +231,11 @@ module.exports = class libraryListProvider {
     let items = [];
 
     if (connection) {
+      let currentLibrary = new Library(config.currentLibrary.toUpperCase());
+      currentLibrary.contextValue = `currentLibrary`;
+      currentLibrary.description = `(current library)`;
+      items.push(currentLibrary);
+
       const libraryList = config.libraryList;
 
       for (let library of libraryList) {


### PR DESCRIPTION
### Changes

This is a quick PR to provide a solution for the discussion in #751 and show the current library at the top of the library list.
I agree with Jon that it would be beneficial to see the current library - it is after all a part of the complete library list and is used during compile and other commands.

The current library has been given a special context value of `currentLibrary` to mark the object and omit the actions for moving up and down. Also the description is `(current library)`.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
