### PR TITLE
Initial work to fix path var for local fs (#845)

### DIFF
--- a/src/api/CompileTools.js
+++ b/src/api/CompileTools.js
@@ -379,9 +379,9 @@ module.exports = class CompileTools {
             currentWorkspace = vscode.workspace.workspaceFolders[evfeventInfo.workspace || 0];
 
             if (currentWorkspace) {
-              baseDir = currentWorkspace.uri.fsPath;
+              baseDir = currentWorkspace.uri.path;
               
-              relativePath = path.posix.relative(baseDir, uri.fsPath).split(path.sep).join(path.posix.sep);
+              relativePath = path.posix.relative(baseDir, uri.path).split(path.sep).join(path.posix.sep);
               variables[`&RELATIVEPATH`] = relativePath;
   
               // We need to make sure the remote path is posix


### PR DESCRIPTION
### Changes

Issue on Windows where `&RELATIVEPATH` and `&FULLPATH` were whack. See #845 

Tested in Windows and Mac. Fix is ok.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
