### PR TITLE
Option to show library description and attribute in User Library List view

### DIFF
--- a/package.json
+++ b/package.json
@@ -335,6 +335,11 @@
 									}
 								},
 								"default": []
+							},
+							"showDescInLibList": {
+								"type": "boolean",
+								"default": false,
+								"description": "Show description of libraries in User Library List (recommended to also enable SQL)."
 							}
 						}
 					}

--- a/src/api/Configuration.js
+++ b/src/api/Configuration.js
@@ -79,6 +79,9 @@ module.exports = class Configuration {
 
     /** @type {boolean} */
     this.autoSaveBeforeAction = (base.autoSaveBeforeAction === true);
+
+    /** @type {boolean} */
+    this.showDescInLibList = (base.showDescInLibList === true);
   }
 
   /**

--- a/src/api/IBMiContent.js
+++ b/src/api/IBMiContent.js
@@ -248,9 +248,9 @@ module.exports = class IBMiContent {
     
   }
 
-
   /**
-   * @param {string[]} libraries
+   * Get list of libraries with description and attribute
+   * @param {string[]} libraries Array of libraries to retrieve
    * @returns {Promise<{name: string, text: string, attribute: string}[]>} List of libraries
    */
   async getLibraryList(libraries) {
@@ -282,7 +282,6 @@ module.exports = class IBMiContent {
       };
 
       results = results.filter(object => (libraries.includes(this.ibmi.sysNameInLocal(object.ODOBNM))));
-
     };
 
     if (results.length === 0) return [];

--- a/src/api/IBMiContent.js
+++ b/src/api/IBMiContent.js
@@ -273,7 +273,7 @@ module.exports = class IBMiContent {
         const library = libraries[i];
         await this.ibmi.remoteCommand(`DSPOBJD OBJ(QSYS/*ALL) OBJTYPE(*LIB) DETAIL(*TEXTATR) OUTPUT(*OUTFILE) OUTFILE(${tempLib}/${TempName})`);
       };
-      let results = await this.getTable(tempLib, TempName, TempName, true);
+      results = await this.getTable(tempLib, TempName, TempName, true);
 
       if (results.length === 1) {
         if (results[0].ODOBNM.trim() === ``) {
@@ -281,7 +281,7 @@ module.exports = class IBMiContent {
         }
       };
 
-      results = results.filter(object => (libraries.includes(object.ODOBNM)));
+      results = results.filter(object => (libraries.includes(this.ibmi.sysNameInLocal(object.ODOBNM))));
 
     };
 
@@ -289,7 +289,7 @@ module.exports = class IBMiContent {
 
     return results
       .map(object => ({
-        name: this.ibmi.sysNameInLocal(object.ODOBNM),
+        name: config.enableSQL ? object.ODOBNM : this.ibmi.sysNameInLocal(object.ODOBNM),
         attribute: object.ODOBAT,
         text: object.ODOBTX
       }))

--- a/src/api/IBMiContent.js
+++ b/src/api/IBMiContent.js
@@ -248,6 +248,56 @@ module.exports = class IBMiContent {
     
   }
 
+
+  /**
+   * @param {string[]} libraries
+   * @returns {Promise<{name: string, text: string, attribute: string}[]>} List of libraries
+   */
+  async getLibraryList(libraries) {
+    const config = this.ibmi.config;
+    const tempLib = this.ibmi.config.tempLibrary;
+    const TempName = Tools.makeid();
+    let results;
+
+    if (config.enableSQL) {
+      const statement = `
+        select os.OBJNAME as ODOBNM
+             , coalesce(os.OBJTEXT, '') as ODOBTX
+             , os.OBJATTRIBUTE as ODOBAT
+          from table( SYSTOOLS.SPLIT( INPUT_LIST => '${libraries.toString()}', DELIMITER => ',' ) ) libs
+             , table( QSYS2.OBJECT_STATISTICS( OBJECT_SCHEMA => 'QSYS', OBJTYPELIST => '*LIB', OBJECT_NAME => libs.ELEMENT ) ) os
+      `;
+      results = await this.runSQL(statement);
+    } else {
+      for (let i = 0; i < libraries.length; i++) {
+        const library = libraries[i];
+        await this.ibmi.remoteCommand(`DSPOBJD OBJ(QSYS/*ALL) OBJTYPE(*LIB) DETAIL(*TEXTATR) OUTPUT(*OUTFILE) OUTFILE(${tempLib}/${TempName})`);
+      };
+      let results = await this.getTable(tempLib, TempName, TempName, true);
+
+      if (results.length === 1) {
+        if (results[0].ODOBNM.trim() === ``) {
+          return []
+        }
+      };
+
+      results = results.filter(object => (libraries.includes(object.ODOBNM)));
+
+    };
+
+    if (results.length === 0) return [];
+
+    return results
+      .map(object => ({
+        name: this.ibmi.sysNameInLocal(object.ODOBNM),
+        attribute: object.ODOBAT,
+        text: object.ODOBTX
+      }))
+      .sort((a, b) => {
+        return (libraries.indexOf(a.name) - libraries.indexOf(b.name));
+      });
+  }
+
   /**
    * @param {{library: string, object?: string, types?: string[]}} filters 
    * @returns {Promise<{library: string, name: string, type: string, text: string, attribute: string, count?: number}[]>} List of members 

--- a/src/views/libraryListView.js
+++ b/src/views/libraryListView.js
@@ -282,9 +282,14 @@ module.exports = class libraryListProvider {
     const config = instance.getConfig();
     const currentLibrary = config.currentLibrary.toUpperCase();
     let items = [];
+    let libraries = [];
 
     if (connection) {
-      const libraries = await content.getLibraryList(new Array(config.currentLibrary).concat(config.libraryList));
+      if (config.showDescInLibList === true) {
+        libraries = await content.getLibraryList(new Array(config.currentLibrary).concat(config.libraryList));
+      } else {
+        libraries = new Array(config.currentLibrary).concat(config.libraryList).map(lib => { return { name: lib, text: ``, attribute: `` }});
+      }
       items = libraries.map(lib => {
         return new Library(lib.name, lib.text, lib.attribute, (lib.name === currentLibrary ? `currentLibrary` : `library`));
       });

--- a/src/views/libraryListView.js
+++ b/src/views/libraryListView.js
@@ -124,13 +124,13 @@ module.exports = class libraryListProvider {
         }
       }),
 
-      vscode.commands.registerCommand(`code-for-ibmi.addToLibraryList`, async (newLibrary = '') => {
+      vscode.commands.registerCommand(`code-for-ibmi.addToLibraryList`, async (newLibrary = ``) => {
         const config = instance.getConfig();
         let addingLib;
 
         let libraryList = [...config.libraryList];
 
-        if(newLibrary == ''){
+        if(newLibrary == ``){
           addingLib = await vscode.window.showInputBox({
             prompt: `Library to add`
           });

--- a/src/views/libraryListView.js
+++ b/src/views/libraryListView.js
@@ -286,9 +286,9 @@ module.exports = class libraryListProvider {
 
     if (connection) {
       if (config.showDescInLibList === true) {
-        libraries = await content.getLibraryList(new Array(config.currentLibrary).concat(config.libraryList));
+        libraries = await content.getLibraryList([config.currentLibrary, ...config.libraryList]);
       } else {
-        libraries = new Array(config.currentLibrary).concat(config.libraryList).map(lib => { return { name: lib, text: ``, attribute: `` }});
+        libraries = [config.currentLibrary, ...config.libraryList].map(lib => { return { name: lib, text: ``, attribute: `` }});
       }
       items = libraries.map(lib => {
         return new Library(lib.name, lib.text, lib.attribute, (lib.name === currentLibrary ? `currentLibrary` : `library`));

--- a/src/webviews/settings/index.js
+++ b/src/webviews/settings/index.js
@@ -43,7 +43,7 @@ module.exports = class SettingsUI {
           }
         }
 
-        const restartFields = [`enableSQL`, `enableSourceDates`, `clContentAssistEnabled`, `tempDir`];
+        const restartFields = [`enableSQL`, `showDescInLibList`, `enableSourceDates`, `clContentAssistEnabled`, `tempDir`];
         let restart = false;
 
         let ui = new CustomUI();
@@ -72,6 +72,11 @@ module.exports = class SettingsUI {
         field = new Field(`checkbox`, `enableSQL`, `Enable SQL`);
         field.default = (config.enableSQL ? `checked` : ``);
         field.description = `Must be enabled to make the use of SQL and is enabled by default. If you find SQL isn't working for some reason, disable this. If your QCCSID is 65535, it is recommend SQL is disabled. When disabled, will use import files where possible.`;
+        ui.addField(field);
+
+        field = new Field(`checkbox`, `showDescInLibList`, `Show description of libraries in User Library List view`);
+        field.default = (config.showDescInLibList ? `checked` : ``);
+        field.description = `When enabled, library text and attribute will be shown in User Library List. It is recommended to also enable SQL for this.`;
         ui.addField(field);
     
         field = new Field(`input`, `sourceASP`, `Source ASP`);


### PR DESCRIPTION
### Changes

This PR will add a configuration value to allow showing library description and attribute in the User Library List view.

This was made optional, since it is quite slow to retrieve the description and attribute for the libraries when SQL is not enabled.

Two techniques were tested during development:

1. retrieving information for one library at a time and
2. retrieving information for all libraries and filter according to the library list

The second option was chosen since there did seem to be any speed difference and this option was easier to code.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [x] **for feature PRs**: PR only includes one feature enhancement.
