### PR TITLE
Speedup display of library text and fixes

### DIFF
--- a/src/api/IBMiContent.js
+++ b/src/api/IBMiContent.js
@@ -283,15 +283,13 @@ module.exports = class IBMiContent {
 
     if (results.length === 0) return [];
 
-    return results
-      .map(object => ({
-        name: config.enableSQL ? object.ODOBNM : this.ibmi.sysNameInLocal(object.ODOBNM),
-        attribute: object.ODOBAT,
-        text: object.ODOBTX
-      }))
-      .sort((a, b) => {
-        return (libraries.indexOf(a.name) - libraries.indexOf(b.name));
-      });
+    results = results.map(object => ({
+      name: config.enableSQL ? object.ODOBNM : this.ibmi.sysNameInLocal(object.ODOBNM),
+      attribute: object.ODOBAT,
+      text: object.ODOBTX
+    }));
+
+    return libraries.map(lib => {return results.find(info => info.name === lib)});
   }
 
   /**

--- a/src/api/IBMiContent.js
+++ b/src/api/IBMiContent.js
@@ -269,10 +269,7 @@ module.exports = class IBMiContent {
       `;
       results = await this.runSQL(statement);
     } else {
-      for (let i = 0; i < libraries.length; i++) {
-        const library = libraries[i];
-        await this.ibmi.remoteCommand(`DSPOBJD OBJ(QSYS/*ALL) OBJTYPE(*LIB) DETAIL(*TEXTATR) OUTPUT(*OUTFILE) OUTFILE(${tempLib}/${TempName})`);
-      };
+      await this.ibmi.remoteCommand(`DSPOBJD OBJ(QSYS/*ALL) OBJTYPE(*LIB) DETAIL(*TEXTATR) OUTPUT(*OUTFILE) OUTFILE(${tempLib}/${TempName})`);
       results = await this.getTable(tempLib, TempName, TempName, true);
 
       if (results.length === 1) {

--- a/src/views/libraryListView.js
+++ b/src/views/libraryListView.js
@@ -290,8 +290,8 @@ module.exports = class libraryListProvider {
       } else {
         libraries = [config.currentLibrary, ...config.libraryList].map(lib => { return { name: lib, text: ``, attribute: `` }});
       }
-      items = libraries.map(lib => {
-        return new Library(lib.name, lib.text, lib.attribute, (lib.name === currentLibrary ? `currentLibrary` : `library`));
+      items = libraries.map((lib, index) => {
+        return new Library(lib.name, lib.text, lib.attribute, (index === 0 ? `currentLibrary` : `library`));
       });
     }
 


### PR DESCRIPTION
### Changes

This PR will
- speed up the library list view by omitting multiple (unnecessary) calls to get library information
- fix error when library was current library and also in library list (it would not show in the list part, only as current library)
- fix error displaying `(current library)` (when library was also in library list, `(current library)` would show in both places)

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
