### PR TITLE
Add option to show names in uppercase

### DIFF
--- a/package.json
+++ b/package.json
@@ -393,10 +393,10 @@
 					"default": true,
 					"description": "If enabled, listings will refresh when items are interacted with (create, copy, delele, etc). Turn this off if you find performance is bad."
 				},
-				"code-for-ibmi.ObjectBrowser.showNamesInUppercase": {
+				"code-for-ibmi.ObjectBrowser.showNamesInLowercase": {
 					"type": "boolean",
-					"default": false,
-					"description": "If enabled, names and types of object and members will be shown in uppercase (like in 5250 sessions)"
+					"default": true,
+					"description": "If enabled, names and types of object and members will be shown in lowercase. If disabled, the names will be shown as is on the server (like in 5250 sessions)"
 				},
 				"code-for-ibmi.connections": {
 					"type": "array",

--- a/package.json
+++ b/package.json
@@ -393,6 +393,11 @@
 					"default": true,
 					"description": "If enabled, listings will refresh when items are interacted with (create, copy, delele, etc). Turn this off if you find performance is bad."
 				},
+				"code-for-ibmi.ObjectBrowser.showNamesInUppercase": {
+					"type": "boolean",
+					"default": false,
+					"description": "If enabled, names and types of object and members will be shown in uppercase (like in 5250 sessions)"
+				},
 				"code-for-ibmi.connections": {
 					"type": "array",
 					"items": {

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -603,7 +603,7 @@ module.exports = class objectBrowserTwoProvider {
   async getChildren(element) {
     const content = instance.getContent();
     const config = instance.getConfig();
-    const objectNamesUpper = Configuration.get(`ObjectBrowser.showNamesInUppercase`);
+    const objectNamesLower = Configuration.get(`ObjectBrowser.showNamesInLowercase`);
     let items = [], item;
 
     if (element) {
@@ -616,7 +616,7 @@ module.exports = class objectBrowserTwoProvider {
 
         filter = config.objectFilters.find(filter => filter.name === obj.filter);
         let objects = await content.getObjectList(filter);
-        if (!objectNamesUpper || objectNamesUpper === false) {
+        if (objectNamesLower === true) {
           objects = objects.map(object => {
             object.name = object.name.toLocaleLowerCase();
             object.type = object.type.toLocaleLowerCase();
@@ -638,7 +638,7 @@ module.exports = class objectBrowserTwoProvider {
 
         try {
           let members = await content.getMemberList(path[0], path[1], filter.member, filter.memberType);
-          if (!objectNamesUpper || objectNamesUpper === false) {
+          if (objectNamesLower === true) {
             members = members.map(member => {
               member.file = member.file.toLocaleLowerCase();
               member.name = member.name.toLocaleLowerCase();

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -603,6 +603,7 @@ module.exports = class objectBrowserTwoProvider {
   async getChildren(element) {
     const content = instance.getContent();
     const config = instance.getConfig();
+    const objectNamesUpper = Configuration.get(`ObjectBrowser.showNamesInUppercase`);
     let items = [], item;
 
     if (element) {
@@ -614,9 +615,17 @@ module.exports = class objectBrowserTwoProvider {
         const obj = element;
 
         filter = config.objectFilters.find(filter => filter.name === obj.filter);
-        const objects = await content.getObjectList(filter);
+        let objects = await content.getObjectList(filter);
+        if (!objectNamesUpper || objectNamesUpper === false) {
+          objects = objects.map(object => {
+            object.name = object.name.toLocaleLowerCase();
+            object.type = object.type.toLocaleLowerCase();
+            object.attribute = object.attribute.toLocaleLowerCase();
+            return object;
+          })
+        };
         items = objects.map(object =>
-          object.attribute === `*PHY` ? new SPF(filter.name, object, filter.member, filter.memberType) : new ILEObject(filter.name, object)
+          object.attribute.toLocaleUpperCase() === `*PHY` ? new SPF(filter.name, object, filter.member, filter.memberType) : new ILEObject(filter.name, object)
         );
         break;
 
@@ -628,7 +637,15 @@ module.exports = class objectBrowserTwoProvider {
         const path = spf.path.split(`/`);
 
         try {
-          const members = await content.getMemberList(path[0], path[1], filter.member, filter.memberType);
+          let members = await content.getMemberList(path[0], path[1], filter.member, filter.memberType);
+          if (!objectNamesUpper || objectNamesUpper === false) {
+            members = members.map(member => {
+              member.file = member.file.toLocaleLowerCase();
+              member.name = member.name.toLocaleLowerCase();
+              member.extension = member.extension.toLocaleLowerCase();
+              return member;
+            })
+          };
           items = members.map(member => new Member(member));
 
           await this.storeMemberList(spf.path, members.map(member => `${member.name}.${member.extension}`));
@@ -708,7 +725,7 @@ class SPF extends vscode.TreeItem {
    * @param {string} memberTypeFilter Member type filter string
    */
   constructor(filter, detail, memberFilter, memberTypeFilter) {
-    super(detail.name.toLowerCase(), vscode.TreeItemCollapsibleState.Collapsed);
+    super(detail.name, vscode.TreeItemCollapsibleState.Collapsed);
 
     this.filter = filter;
     this.memberFilter = memberFilter;
@@ -732,14 +749,14 @@ class ILEObject extends vscode.TreeItem {
 
     const icon = objectIcons[type] || objectIcons[``];
 
-    super(`${name.toLowerCase()}.${type.toLowerCase()}`);
+    super(`${name}.${type}`);
 
     this.filter = filter;
 
     this.contextValue = `object`;
     this.path = `${library}/${name}`;
     this.type = type;
-    this.description = text + (attribute ? ` (${attribute.toLowerCase()})` : ``);
+    this.description = text + (attribute ? ` (${attribute})` : ``);
     this.iconPath = new vscode.ThemeIcon(icon);
 
     this.resourceUri = vscode.Uri.from({
@@ -754,7 +771,7 @@ class Member extends vscode.TreeItem {
   constructor(member) {
     const path = `${member.asp ? `${member.asp}/` : ``}${member.library}/${member.file}/${member.name}.${member.extension}`;
 
-    super(`${member.name}.${member.extension}`.toLowerCase());
+    super(`${member.name}.${member.extension}`);
 
     this.contextValue = `member`;
     this.description = member.text;


### PR DESCRIPTION
### Changes

This PR will add a configuration option to show names and types in lowercase or original (upper/mixed) case:

![billede](https://user-images.githubusercontent.com/13275072/190982821-0a4a6e77-a15c-4304-88c1-23c0b2e5620d.png)

The option will be enabled by default to make the extension work as before this option. The user will have to disable it to have names shown in uppercase / mixed case.

Here is a sample screenshot with the option disabled:

![billede](https://user-images.githubusercontent.com/13275072/190266370-67396ba5-5c3d-41e7-a096-b1eec4c8a16f.png)

And another screenshot of a member list (IBM provides the text for files and members in QSYSINC as uppercase, this is not done by the extension):

![billede](https://user-images.githubusercontent.com/13275072/190267225-bec551f5-0cb7-4936-acd5-ed0f2d94dffa.png)

IMHO this option should be disabled by default to make the extension more familiar to old-school IBM i people. I myself prefer names in the /QSYS.LIB filesystem (objects and members) to be shown in uppercase. This would however change the visual of this extension, and that may not be what you want. So I have set it to `true` - enabled - for now.

There is no change in the IFS browser, everything is shown as stored in the server. I use mixed case here and think most people do the same.

WDYT?

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [x] **for feature PRs**: PR only includes one feature enhancement.
