### PR TITLE
Fix for libraries with dollar signs in the name

### DIFF
--- a/src/api/CompileTools.js
+++ b/src/api/CompileTools.js
@@ -632,9 +632,9 @@ module.exports = class CompileTools {
       case `qsh`:
         commandResult = await connection.sendQsh({
           command: [
-            `liblist -d ` + connection.defaultUserLibraries.join(` `),
-            `liblist -c ` + config.currentLibrary,
-            `liblist -a ` + libl.join(` `),
+            `liblist -d ` + connection.defaultUserLibraries.join(` `).replace(/\$/g, `\\$`),
+            `liblist -c ` + config.currentLibrary.replace(/\$/g, `\\$`),
+            `liblist -a ` + libl.join(` `).replace(/\$/g, `\\$`),
             ...commands,
           ],
           directory: cwd,
@@ -648,9 +648,9 @@ module.exports = class CompileTools {
 
         commandResult = await connection.sendQsh({
           command: [
-            `liblist -d ` + connection.defaultUserLibraries.join(` `),
-            `liblist -c ` + config.currentLibrary,
-            `liblist -a ` + libl.join(` `),
+            `liblist -d ` + connection.defaultUserLibraries.join(` `).replace(/\$/g, `\\$`),
+            `liblist -c ` + config.currentLibrary.replace(/\$/g, `\\$`),
+            `liblist -a ` + libl.join(` `).replace(/\$/g, `\\$`),
             ...commands.map(command => 
               `${`system ${Configuration.get(`logCompileOutput`) ? `` : `-s`} "${command.replace(/[$]/g, `\\$&`)}"; if [[ $? -ne 0 ]]; then exit 1; fi`}`
             ),

--- a/src/views/libraryListView.js
+++ b/src/views/libraryListView.js
@@ -242,8 +242,8 @@ module.exports = class libraryListProvider {
     /** @type {object} */
     const result = await connection.sendQsh({
       command: [
-        `liblist -d ` + connection.defaultUserLibraries.join(` `),
-        ...newLibl.map(lib => `liblist -a ` + lib)
+        `liblist -d ` + connection.defaultUserLibraries.join(` `).replace(/\$/g, `\\$`),
+        ...newLibl.map(lib => `liblist -a ` + lib.replace(/\$/g, `\\$`))
       ]
     });
 


### PR DESCRIPTION
### Changes

Support for libraries with dollar signs in the name when managing the library list.

Fixes #873 

### Checklist

* [ ] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
