### PR TITLE
Add some object type icons in object browser

### DIFF
--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -944,5 +944,15 @@ const objectIcons = {
   'CMD': `terminal`,
   'MODULE': `extensions`,
   'PGM': `file-binary`,
+  'DTAARA': `clippy`,
+  'DTAQ': `list-ordered`,
+  'JOBQ': `checklist`,
+  'LIB': `library`,
+  'MEDDFN': `save-all`,
+  'OUTQ': `symbol-enum`,
+  'PNLGRP': `book`,
+  'SBSD': `server-process`,
+  'SRVPGM': `file-submodule`,
+  'USRSPC': `chrome-maximize`,
   '': `circle-large-outline`
 }


### PR DESCRIPTION
### Changes

This PR adds icons for some object types in the object browser. The object types are

*DTAARA
*DTAQ
*JOBQ
*LIB
*MEDDFN
*OUTQ
*PNLGRP
*SBSD
*SRVPGM
*USRSPC

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [x] **for feature PRs**: PR only includes one feature enhancement.
