### PR TITLE
Fix for #883 - Uses ROW_LENGTH from SYSTABLES for new source members

### DIFF
--- a/src/filesystems/qsys/complex/content.js
+++ b/src/filesystems/qsys/complex/content.js
@@ -41,7 +41,12 @@ module.exports = class IBMiContent {
       if (result.length > 0) {
         recordLengths[alias] = result[0].LENGTH;
       } else {
-        recordLengths[alias] = DEFAULT_RECORD_LENGTH;
+        const result = await content.runSQL(`SELECT row_length-12 as LENGTH FROM QSYS2.SYSTABLES WHERE TABLE_SCHEMA = '${lib}' and TABLE_NAME = '${spf}' limit 1`);
+        if (result.length > 0) {
+          recordLengths[alias] = result[0].LENGTH;
+        } else {
+          recordLengths[alias] = DEFAULT_RECORD_LENGTH;
+        }
       }
     }
   


### PR DESCRIPTION
### Changes

Fix for #883. Uses QSYS2/SYSTABLES to get ROW_LENGTH-12 when unable to get a row length using LENGTH(srcdta) when using SQL (Source Dates enabled)

![image](https://user-images.githubusercontent.com/93156666/192378324-ee7883f3-d713-4252-91a4-a3ec13e3c49e.png)

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
