### PR TITLE
Show search term and path when no results found

### DIFF
--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -455,7 +455,7 @@ module.exports = class ifsBrowserProvider {
                   setSearchResults(searchTerm, results);
 
                 } else {
-                  vscode.window.showInformationMessage(`No results found.`);
+                  vscode.window.showInformationMessage(`No results found searching for '${searchTerm}' in ${path}.`);
                 }
               });
 

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -529,7 +529,7 @@ module.exports = class objectBrowserTwoProvider {
                       setSearchResults(searchTerm, results);
 
                     } else {
-                      vscode.window.showInformationMessage(`No results found.`);
+                      vscode.window.showInformationMessage(`No results found searching for '${searchTerm}' in ${node.path}.`);
                     }
 
                   } else {


### PR DESCRIPTION
### Changes

This PR will fix issue #891 and show the search term and the search path when showing "No results found."

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [x] **for feature PRs**: PR only includes one feature enhancement.
