### PR TITLE
New Deployment option `Changes` not taking gitignore into account

### DIFF
--- a/src/api/Deployment.js
+++ b/src/api/Deployment.js
@@ -262,6 +262,7 @@ module.exports = class Deployment {
 
                     return folder.index;
                   } catch (e) {
+                    this.button.text = BUTTON_BASE;
                     this.showErrorButton();
                     this.deploymentLog.appendLine(`Deployment failed.`);
                     this.deploymentLog.appendLine(e);

--- a/src/api/Deployment.js
+++ b/src/api/Deployment.js
@@ -214,7 +214,7 @@ module.exports = class Deployment {
                         return folder.index;
                       } catch (e) {
                         this.button.text = BUTTON_BASE;
-                        Deployment.showErrorButton();
+                        this.showErrorButton();
                       
                         this.deploymentLog.appendLine(`Deployment failed.`);
                         this.deploymentLog.appendLine(e);
@@ -235,6 +235,8 @@ module.exports = class Deployment {
 
               case `Changes`:
                 if (changedFiles.length > 0) {
+
+                  //TODO: validate list against ignore file
                   const uploads = changedFiles.map(fileUri => {
                     const relative = path.relative(folder.uri.path, fileUri.path).replace(new RegExp(`\\\\`, `g`), `/`);
                     const remote = path.posix.join(remotePath, relative);
@@ -260,7 +262,7 @@ module.exports = class Deployment {
 
                     return folder.index;
                   } catch (e) {
-                    Deployment.showErrorButton();
+                    this.showErrorButton();
                     this.deploymentLog.appendLine(`Deployment failed.`);
                     this.deploymentLog.appendLine(e);
                   }
@@ -326,7 +328,7 @@ module.exports = class Deployment {
                   return folder.index;
                   
                 } else {
-                  Deployment.showErrorButton();
+                  this.showErrorButton();
                 }
 
                 break;
@@ -457,7 +459,7 @@ module.exports = class Deployment {
     }
   }
 
-  static async showErrorButton() {
+  async showErrorButton() {
     vscode.window.showErrorMessage(`Deployment failed.`, `View Log`).then(async (action) => {
       if (action === `View Log`) {
         this.deploymentLog.show();


### PR DESCRIPTION
### Changes

@edmundreinhardt found an issue where the new deployment `Changes` option was not taking the gitignore into account.

This PR will:

* Fix issue where status bar button would continue to spin after failure
* Enable the View Log button to actually work
* Check the gitignore when uploading files to the server when using the `Changes` option.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
