### PR TITLE
Use double quotes in SQL alias member path

### DIFF
--- a/src/filesystems/qsys/complex/content.js
+++ b/src/filesystems/qsys/complex/content.js
@@ -29,7 +29,7 @@ module.exports = class IBMiContent {
     mbr = mbr.toUpperCase();
 
     const tempLib = connection.config.tempLibrary;
-    const alias = `${lib}_${spf}_${mbr.replace(/\./g, `_`)}`;
+    const alias = `${lib}_${spf}_${mbr}`.replace(/\./g, `_`);
     const aliasPath = `${tempLib}.${alias}`;
   
     try {

--- a/src/filesystems/qsys/complex/content.js
+++ b/src/filesystems/qsys/complex/content.js
@@ -9,7 +9,7 @@ const tmpFile = util.promisify(tmp.file);
 const writeFileAsync = util.promisify(fs.writeFile);
 
 const DEFAULT_RECORD_LENGTH = 80;
-let { allSourceDates, recordLengths } = require(`./data`);
+let { allSourceDates, recordLengths, getAliasName } = require(`./data`);
 
 module.exports = class IBMiContent {
   /**
@@ -29,7 +29,7 @@ module.exports = class IBMiContent {
     mbr = mbr.toUpperCase();
 
     const tempLib = connection.config.tempLibrary;
-    const alias = `${lib}_${spf}_${mbr}`.replace(/\./g, `_`);
+    const alias = getAliasName(lib, spf, mbr);
     const aliasPath = `${tempLib}.${alias}`;
   
     try {
@@ -85,7 +85,7 @@ module.exports = class IBMiContent {
     const setccsid = connection.remoteFeatures.setccsid;
 
     const tempLib = connection.config.tempLibrary;
-    const alias = `${lib}_${spf}_${mbr.replace(/\./g, `_`)}`;
+    const alias = getAliasName(lib, spf, mbr);
     const aliasPath = `${tempLib}.${alias}`;
     const sourceDates = allSourceDates[alias];
 

--- a/src/filesystems/qsys/complex/content.js
+++ b/src/filesystems/qsys/complex/content.js
@@ -33,7 +33,7 @@ module.exports = class IBMiContent {
     const aliasPath = `${tempLib}.${alias}`;
   
     try {
-      await content.runSQL(`CREATE OR REPLACE ALIAS ${aliasPath} for ${lib}.${spf}("${mbr}")`);
+      await content.runSQL(`CREATE OR REPLACE ALIAS ${aliasPath} for "${lib}"."${spf}"("${mbr}")`);
     } catch (e) {}
 
     if (recordLengths[alias] === undefined) {

--- a/src/filesystems/qsys/complex/data.js
+++ b/src/filesystems/qsys/complex/data.js
@@ -1,5 +1,9 @@
 
 module.exports = {
+  getAliasName: (library, sourceFile, member) => {
+    return `${library}_${sourceFile}_${member}`.replace(/\./g, `_`)
+  },
+
   /** @type {{[path: string]: string[]}} */
   allSourceDates: {},
   /** @type {{[path: string]: number}} */

--- a/src/filesystems/qsys/complex/handler.js
+++ b/src/filesystems/qsys/complex/handler.js
@@ -3,7 +3,7 @@ const Tools = require(`../../../api/Tools`);
 
 const {instance} = require(`../../../Instance`);
 
-let { allSourceDates, recordLengths } = require(`./data`);
+let { allSourceDates, recordLengths, getAliasName } = require(`./data`);
 
 const highlightedColor = new vscode.ThemeColor(`gitDecoration.modifiedResourceForeground`);
 
@@ -51,7 +51,7 @@ module.exports = class {
             }
 
             fullName = fullName.substring(0, fullName.lastIndexOf(`.`));
-            const alias = `${lib}_${file}_${fullName.replace(/\./g, `_`)}`;
+            const alias = getAliasName(lib, file, fullName);
             const recordLength = recordLengths[alias];
 
             /** @type {vscode.Diagnostic[]} */
@@ -84,7 +84,7 @@ module.exports = class {
           const {library, file, member} = connection.parserMemberPath(path);
 
 
-          const alias = `${library}_${file}_${member.replace(/\./g, `_`)}`;
+          const alias = getAliasName(library, file, member);
 
           let sourceDates = allSourceDates[alias];
           if (sourceDates) {
@@ -178,7 +178,7 @@ module.exports = class {
       const path = editor.document.uri.path;
       const {library, file, member} = connection.parserMemberPath(path);
 
-      const alias = `${library}_${file}_${member.replace(/\./g, `_`)}`;
+      const alias = getAliasName(library, file, member);;
 
       const sourceDates = allSourceDates[alias];
 


### PR DESCRIPTION
### Changes

Fix to alias path to use double quotes to allow for dots and other characters in the object names.

Was assisted by @forstie on this fix.

Fixes #912.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
