### PR TITLE
Fixed "Add to library list" action

### DIFF
--- a/src/views/libraryListView.js
+++ b/src/views/libraryListView.js
@@ -130,7 +130,7 @@ module.exports = class libraryListProvider {
 
         let libraryList = [...config.libraryList];
 
-        if(newLibrary == ``){
+        if(typeof newLibrary !== `string` || newLibrary == ``){
           addingLib = await vscode.window.showInputBox({
             prompt: `Library to add`
           });


### PR DESCRIPTION
"Add to library list" action is broken as soon as a library is selected in the view. Once this happen, the command receives the selected node in parameter, and never prompts for a name anymore, which results in the error message "Library is too long." being displayed right away.


### Changes

Checking if the "newLibrary" parameter is actually a string fixes the issue.

### Checklist

* [x] have tested my change
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
