### PR TITLE
Fixed "Name of profile" prompt

### DIFF
--- a/src/views/profilesView.js
+++ b/src/views/profilesView.js
@@ -33,7 +33,7 @@ module.exports = class profilesProvider {
         let currentProfiles = config.connectionProfiles;
 
         const profileName = profileNode ? profileNode.profile : await vscode.window.showInputBox({
-		      value: currentProfile,						
+	  value: typeof currentProfile === `object` ? `` : currentProfile,
           prompt: `Name of profile`
         });
 

--- a/src/views/profilesView.js
+++ b/src/views/profilesView.js
@@ -33,7 +33,7 @@ module.exports = class profilesProvider {
         let currentProfiles = config.connectionProfiles;
 
         const profileName = profileNode ? profileNode.profile : await vscode.window.showInputBox({
-	  value: typeof currentProfile === `object` ? `` : currentProfile,
+	  value: typeof currentProfile === `string` ? currentProfile : ``,
           prompt: `Name of profile`
         });
 


### PR DESCRIPTION
### Changes
The "Name of profile" input box would show "[Object object]" as the default value when no "last profile name" is already stored.

### Checklist
* [x] have tested my change
* [x] eslint is not complaining