### PR TITLE
Converted localLanguageActions to TypeScript

### DIFF
--- a/src/api/Deployment.js
+++ b/src/api/Deployment.js
@@ -5,10 +5,9 @@ const vscode = require(`vscode`);
 const {default: IBMi} = require(`./IBMi`);
 const CompileTools = require(`./CompileTools`);
 
-
-const { ConnectionConfiguration } = require(`./Configuration`);
-const localLanguageActions = require(`../schemas/localLanguageActions`);
 const { Storage } = require(`./Storage`);
+const { ConnectionConfiguration } = require(`./Configuration`);
+const { LocalLanguageActions } = require(`../schemas/localLanguageActions`);
 
 const ignore = require(`ignore`).default;
 
@@ -57,7 +56,7 @@ module.exports = class Deployment {
         const chosenWorkspace = await module.exports.getWorkspaceFolder();
 
         if (chosenWorkspace) {
-          const types = Object.keys(localLanguageActions);
+          const types = Object.keys(LocalLanguageActions);
         
           const chosenTypes = await vscode.window.showQuickPick(types, {
             canPickMany: true,
@@ -66,7 +65,7 @@ module.exports = class Deployment {
 
           if (chosenTypes) {
             /** @type {Action[]} */
-            const newActions = chosenTypes.map(type => localLanguageActions[type]).flat();
+            const newActions = chosenTypes.map(type => LocalLanguageActions[type]).flat();
 
             const localActionsUri = vscode.Uri.file(path.join(chosenWorkspace.uri.fsPath, `.vscode`, `actions.json`));
 
@@ -111,7 +110,7 @@ module.exports = class Deployment {
           let ignoreRules = ignore({ignorecase: true}).add(`.git`);
           if (gitignores.length > 0) {
             // get the content from the file
-            const gitignoreContent = await (await vscode.workspace.fs.readFile(gitignores[0])).toString().replace(new RegExp(`\\\r`, `g`), ``);
+            const gitignoreContent = (await vscode.workspace.fs.readFile(gitignores[0])).toString().replace(new RegExp(`\\\r`, `g`), ``);
             ignoreRules.add(gitignoreContent.split(`\n`));
           }
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -29,7 +29,7 @@ interface MemberParts {
 interface Action {
   name: string;
   command: string;
-  type: "member"|"streamfile"|"object"|"file";
+  type?: "member"|"streamfile"|"object"|"file";
   environment: "ile"|"qsh"|"pase";
   extensions: string[];
   deployFirst?: boolean;

--- a/src/schemas/localLanguageActions.ts
+++ b/src/schemas/localLanguageActions.ts
@@ -1,5 +1,6 @@
 /** @type {{[language: string]: Action[]}} */
-module.exports = {
+
+export const LocalLanguageActions : Record<string, Action[]> = {
   RPGLE: [
     {
       name: `Create RPGLE Program`,


### PR DESCRIPTION
### Changes
* Converted `LocalLanguageActions` to TypeScript
* `type` in `Action` is now optional (or `type` would have to be defined on every predefined action)

### Checklist
* [x] have tested my change
* [x] updated relevant documentation
* [x] eslint is not complaining