### PR TITLE
FIX: Ability for extensions to get and change config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "code-for-ibmi",
-	"version": "1.5.23",
+	"version": "1.5.24",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "code-for-ibmi",
-			"version": "1.5.23",
+			"version": "1.5.24",
 			"license": "MIT",
 			"dependencies": {
 				"@bendera/vscode-webview-elements": "^0.6.3",

--- a/src/api/Configuration.ts
+++ b/src/api/Configuration.ts
@@ -38,6 +38,7 @@ export namespace ConnectionConfiguration {
     connectringStringFor5250: string;
     autoSaveBeforeAction: boolean;
     showDescInLibList: boolean;
+    [name: string]: any;
   }
 
   export interface ObjectFilters {
@@ -70,6 +71,7 @@ export namespace ConnectionConfiguration {
 
   function initialize(parameters: Partial<Parameters>) : Parameters{
     return {
+      ...parameters,
       name : parameters.name!,
       host : parameters.host || '',
       objectFilters : parameters.objectFilters || [],

--- a/src/api/Instance.ts
+++ b/src/api/Instance.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import IBMi from "./IBMi";
 import IBMiContent from "./IBMiContent";
 import {Storage} from "./Storage";
+import { ConnectionConfiguration } from "./Configuration";
 
 export default class Instance {
     connection: IBMi|undefined;
@@ -17,7 +18,12 @@ export default class Instance {
     getConnection() {
       return this.connection;
     }
-    getConfig () {
+
+    async setConfig(newConfig: ConnectionConfiguration.Parameters) {
+      await ConnectionConfiguration.update(newConfig);
+      if (this.connection) this.connection.config = newConfig;
+    }
+    getConfig() {
       return this.connection?.config;
     }
     getContent () {


### PR DESCRIPTION
### Changes

During the conversion to TS, `config#get` and `config#set` were removed. Turns out, the vscode-db2i and code-coverage-ibmi extensions relied on those API heavily to store connection specific configuration.

This PR adds `instance#setConfig` to allow external extensions to update connection configs, as well as add their own configurations.

Fixes are in places for those extensions to use this new API when this is merge:

* vscode-db2i: https://github.com/halcyon-tech/vscode-db2i/commit/a6070a2d4a844f2eb336cf1e1baedf884032fb21
* code-coverage-ibmi: https://github.com/halcyon-tech/code-coverage-ibmi/commit/4f687b1959255d3d99c234f63ba13693ca66cc59

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [x] **for feature PRs**: PR only includes one feature enhancement.
