### PR TITLE
Fixed ILEObject icon

### DIFF
--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -1050,7 +1050,7 @@ class ILEObject extends vscode.TreeItem {
   constructor(filter, {library, name, type, text, attribute}) {
     if (type.startsWith(`*`)) type = type.substring(1);
 
-    const icon = objectIcons[type] || objectIcons[``];
+    const icon = objectIcons[type.toUpperCase()] || objectIcons[``];
 
     super(`${name}.${type}`);
 


### PR DESCRIPTION
### Changes
ILEObject icon would always be `circle-large-outline` when the `showNamesInLowercase` setting was true, because the object's type would be lowercase and wouldn't match the icons array's.

### Checklist
* [x] have tested my change
* [x] eslint is not complaining