### PR TITLE
New API to set and get connection secret

### DIFF
--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -554,6 +554,15 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
             return null;
           }
         }),
+        vscode.commands.registerCommand(`code-for-ibmi.secret`, async (key, newValue) => {
+          const connectionKey = `${connection.currentConnectionName}_${key}`;
+          if (newValue) {
+            await context.secrets.store(connectionKey, newValue);
+            return newValue;
+          }
+
+          const value = context.secrets.get(connectionKey);
+        })
       );
 
       context.subscriptions.push(

--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -562,6 +562,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
           }
 
           const value = context.secrets.get(connectionKey);
+          return value;
         })
       );
 


### PR DESCRIPTION
As requested by other extension developers, this provides the ability to store connection specific secrets.

After this PR has been tested, the API docs should be updated.

### Changes

New VS Code command API to get/set connection secret.

```ts
// to get
const theAdminUser = await vscode.commands.executeCommand(`code-for-ibmi.secret`, `adminUser`);

// to set
const theAdminUser = await vscode.commands.executeCommand(`code-for-ibmi.secret`, `adminUser`, `QSECOFR`);
```

### Checklist

* [ ] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
