### PR TITLE
Expose event emitter

### DIFF
--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -583,13 +583,3 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
   if (instance.emitter)
     instance.emitter.fire(`connected`);
 }
-
-/**
- * Register event
- */
-export function on(event: string, func: Function) {
-  instance.events.push({
-    event,
-    func
-  });
-}

--- a/src/api/Instance.ts
+++ b/src/api/Instance.ts
@@ -14,6 +14,13 @@ export default class Instance {
     constructor() {
         this.events = [];
     }
+
+    on(event: string, func: Function) {
+      this.events.push({
+        event,
+        func
+      });
+    }
   
     getConnection() {
       return this.connection;


### PR DESCRIPTION
### Changes

The event emitter has been in Code for IBM i for the longest time, but we haven't really exposed it. This will simplify the event API.

See updated docs here: https://github.com/halcyon-tech/docs/blob/main/docs/pages/api/extending.md#event-listener

### Checklist

* [x] have tested my change
* [x] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
