### PR TITLE
Fixed launchActionsSetup crashing

### DIFF
--- a/src/api/local/deployment.ts
+++ b/src/api/local/deployment.ts
@@ -119,7 +119,7 @@ export namespace Deployment {
   }
 
   async function launchActionsSetup() {
-    const chosenWorkspace = await module.exports.getWorkspaceFolder();
+    const chosenWorkspace = await getWorkspaceFolder();
 
     if (chosenWorkspace) {
       const types = Object.entries(LocalLanguageActions).map(([type, actions]) => ({ label: type, actions }));


### PR DESCRIPTION
### Changes
Fixed `launchActionsSetup` crashing right at the beginning because of a wrong call to `getWorkspaceFolders` prefixed by `module.exports` (how I let that slipped is still a mystery...sorry!).

### Checklist
* [x] have tested my change
* [x] eslint is not complaining