### PR TITLE
Support more dynamic sandbox

### DIFF
--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -25,12 +25,12 @@ export default async function () {
 
         switch (parts.length) {
           case 2:
-            if (!server) server = parts[0];
-            if (!server) username = parts[1].toUpperCase();
+            server = parts[0];
+            username = parts[1].toUpperCase(); 
             break;
           case 1:
             // We don't want to overwrite the username if one is set
-            if (!username) username = parts[0].toUpperCase();
+            username = parts[0].toUpperCase();
             break;
         }
       }

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -6,8 +6,13 @@ import { instance } from "./instantiate";
 import { ConnectionData } from "./typings";
 
 export default async function () {
+
+  let server: string | undefined = env.SANDBOX_SERVER;
+  let username: string | undefined = env.SANDBOX_USER;
+  let password: string | undefined = env.SANDBOX_PASS;
+
+  // If Sandbox mode is enabled, then the server and username can be inherited from the branch name
   if (env.VSCODE_IBMI_SANDBOX) {
-    console.log(`Sandbox mode enabled. Look at branch name as username`);
     const gitAPI = extensions.getExtension<GitExtension>(`vscode.git`)?.exports.getAPI(1);
     if (gitAPI && gitAPI.repositories && gitAPI.repositories.length > 0) {
       const repo = gitAPI.repositories[0];
@@ -17,77 +22,86 @@ export default async function () {
         console.log(branchName);
 
         const parts = branchName.split(`/`);
-        if (parts.length === 2) {
 
-          const server = parts[0];
-          const username = parts[1].toUpperCase();
-
-          const connectionData: ConnectionData = {
-            host: server,
-            name: `Sandbox-${username}`,
-            username: username,
-            password: username,
-            port: 22,
-            privateKey: null,
-            keepaliveInterval: 35000
-          };
-
-          window.showInformationMessage(`Thanks for trying the Code for IBM i Sandbox!`, {
-            modal: true,
-            detail: `You are using this system at your own risk. Do not share any sensitive or private information.`
-          });
-
-          const connectionResult = await commands.executeCommand(`code-for-ibmi.connectDirect`, connectionData);
-
-          if (connectionResult) {
-            const config = instance.getConfig();
-            if (config) {
-              const libraryList = config.libraryList;
-              if (!libraryList.includes(username)) {
-                config.libraryList = [...config.libraryList, username];
-
-                config.objectFilters.push(
-                  {
-                    name: "Sandbox Sources",
-                    library: username,
-                    object: "*",
-                    types: [
-                      "*SRCPF"
-                    ],
-                    member: "*",
-                    memberType: ""
-                  },
-                  {
-                    name: "Sandbox Object Filters",
-                    library: username,
-                    object: "*",
-                    types: [
-                      "*ALL"
-                    ],
-                    member: "*",
-                    memberType: ""
-                  },
-                );
-
-                await ConnectionConfiguration.update(config);
-                commands.executeCommand(`code-for-ibmi.refreshLibraryListView`);
-                commands.executeCommand(`code-for-ibmi.refreshObjectBrowser`);
-              }
-            }
-
-          } else {
-            window.showInformationMessage(`Oh no! The sandbox is down.`, {
-              modal: true,
-              detail: `Sorry, but the sandbox is offline right now. Try again another time.`
-            });
-          }
-        } else {
-          window.showInformationMessage(`How'd that happen?`, {
-            modal: true,
-            detail: `Looks like the branch format is incorrect!`
-          });
+        switch (parts.length) {
+          case 2:
+            if (!server) server = parts[0];
+            if (!server) username = parts[1].toUpperCase();
+            break;
+          case 1:
+            // We don't want to overwrite the username if one is set
+            if (!username) username = parts[0].toUpperCase();
+            break;
         }
       }
+    }
+
+    // In sandbox mode, the username and password are frequently the same
+    if (username && !password) password = username.toUpperCase();
+  }
+
+  if (server && username && password) {
+    const connectionData: ConnectionData = {
+      host: server,
+      name: `Sandbox-${username}`,
+      username,
+      password,
+      port: 22,
+      privateKey: null,
+      keepaliveInterval: 35000
+    };
+
+    if (env.VSCODE_IBMI_SANDBOX) {
+      console.log(`Sandbox mode enabled.`);
+      window.showInformationMessage(`Thanks for trying the Code for IBM i Sandbox!`, {
+        modal: true,
+        detail: `You are using this system at your own risk. Do not share any sensitive or private information.`
+      });
+    }
+
+    const connectionResult = await commands.executeCommand(`code-for-ibmi.connectDirect`, connectionData);
+
+    if (connectionResult) {
+      const config = instance.getConfig();
+      if (config) {
+        const libraryList = config.libraryList;
+        if (!libraryList.includes(username)) {
+          config.libraryList = [...config.libraryList, username];
+
+          config.objectFilters.push(
+            {
+              name: "Sandbox Sources",
+              library: username,
+              object: "*",
+              types: [
+                "*SRCPF"
+              ],
+              member: "*",
+              memberType: ""
+            },
+            {
+              name: "Sandbox Object Filters",
+              library: username,
+              object: "*",
+              types: [
+                "*ALL"
+              ],
+              member: "*",
+              memberType: ""
+            },
+          );
+
+          await ConnectionConfiguration.update(config);
+          commands.executeCommand(`code-for-ibmi.refreshLibraryListView`);
+          commands.executeCommand(`code-for-ibmi.refreshObjectBrowser`);
+        }
+      }
+
+    } else {
+      window.showInformationMessage(`Oh no! The sandbox is down.`, {
+        modal: true,
+        detail: `Sorry, but the sandbox is offline right now. Try again another time.`
+      });
     }
   }
 } 


### PR DESCRIPTION
Brand new methods to spin up the sandbox environment.

Now accepts environment variables for connection details, which might be useful on private clouds with the use of on-prem code server instances (code-server, Gitpod, Coder.com)

* `SANDBOX_SERVER`
* `SANDBOX_USER`
* `SANDBOX_PASS`

For public sandbox environments, the branch name can support a hostname/IP address.

* Just username, which grabs the server from `SANDBOX_SERVER`: `JUNK5`
* New, which allows for server and username: `SERVER/JUNK5`