### PR TITLE
**/.gitignores causes deploy to ignore all if .gitignore found in subdirectory other than project root

### DIFF
--- a/src/api/local/deployment.ts
+++ b/src/api/local/deployment.ts
@@ -166,7 +166,7 @@ export namespace Deployment {
       const remotePath = existingPaths ? existingPaths[folder.uri.fsPath] : '';
 
       // get the .gitignore file from workspace
-      const gitignores = await vscode.workspace.findFiles(new vscode.RelativePattern(folder, `**/.gitignore`), ``, 1);
+      const gitignores = await vscode.workspace.findFiles(new vscode.RelativePattern(folder, `.gitignore`), ``, 1);
       const ignoreRules = ignore({ ignorecase: true }).add(`.git`);
       if (gitignores.length > 0) {
         // get the content from the file


### PR DESCRIPTION
### Changes

no longer match on **/.gitignores
so it only finds .gitignore in root

### Checklist

* [x ] have tested my change
* [ ] updated relevant documentation
* [x ] Remove any/all `console.log`s I added
* [ x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
