### PR TITLE
Add Compile support for PFSQL type source members

### DIFF
--- a/package.json
+++ b/package.json
@@ -647,6 +647,22 @@
 							"command": "?RUNSQLSTM SRCFILE(&OPENLIB/&OPENSPF) SRCMBR(&OPENMBR) COMMIT(*NONE) NAMING(*SQL)"
 						},
 						{
+							"type": "member",
+							"extensions": [
+								"PFSQL"
+							],
+							"name": "Run SQL Statements (RUNSQLSTM)",
+							"command": "?RUNSQLSTM SRCFILE(&OPENLIB/&OPENSPF) SRCMBR(&OPENMBR) COMMIT(*NONE) NAMING(*SQL)"
+						},
+						{
+							"type": "member",
+							"extensions": [
+								"pfsql"
+							],
+							"name": "Run SQL Statements (RUNSQLSTM)",
+							"command": "?RUNSQLSTM SRCFILE(&OPENLIB/&OPENSPF) SRCMBR(&OPENMBR) COMMIT(*NONE) NAMING(*SQL)"
+						},						
+						{
 							"type": "streamfile",
 							"extensions": [
 								"rpgle"
@@ -713,6 +729,22 @@
 							"name": "Run SQL Statements (RUNSQLSTM)",
 							"command": "?RUNSQLSTM SRCSTMF('&FULLPATH') COMMIT(*NONE) NAMING(*SQL)"
 						},
+						{
+							"type": "streamfile",
+							"extensions": [
+								"PFSQL"
+							],
+							"name": "Create Bound RPG Program (CRTBNDRPG) with inputs",
+							"command": "?RUNSQLSTM SRCSTMF('&FULLPATH') COMMIT(*NONE) NAMING(*SQL)"
+						},
+						{
+							"type": "streamfile",
+							"extensions": [
+								"pfsql"
+							],
+							"name": "Create Bound RPG Program (CRTBNDRPG) with inputs",
+							"command": "?RUNSQLSTM SRCSTMF('&FULLPATH') COMMIT(*NONE) NAMING(*SQL)"
+						},						
 						{
 							"type": "streamfile",
 							"extensions": [


### PR DESCRIPTION
added RUNSQLSTM configuration for PFSQL type source members


### Changes

Description of change here.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
