### PR TITLE
Search without filter

### DIFF
--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -448,8 +448,16 @@ module.exports = class ifsBrowserProvider {
           let path;
           if (node)
             path = node.path;
-          else
+          else {
             path = config.homeDirectory;
+            path = await vscode.window.showInputBox({
+              value: path,
+              prompt: `Enter IFS directory to search`,
+              title: `Search directory`
+            })
+          }
+
+          if (!path) return;
 
           let searchTerm = await vscode.window.showInputBox({
             prompt: `Search ${path}.`


### PR DESCRIPTION
### Changes

This PR will allow searching a source file without using a filter. When the `Search Source File` command is run from the command palette, the user will be prompted for the source file (and members) to search in.

The PR was created as a solution to issue #927.

In addition the `Search Directory` command was changed to allow the user to specify the directory to search when run from command palette.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [x] **for feature PRs**: PR only includes one feature enhancement.
