### PR TITLE
Fix regexp pattern to remove ASP and/or QSYS.LIB from path

### DIFF
--- a/src/api/Search.ts
+++ b/src/api/Search.ts
@@ -4,7 +4,7 @@ import Instance from './Instance';
 import { Tools } from './Tools';
 
 export namespace Search {
-  const QSYS_PATTERN = /(?:\/QSYS\.LIB\/)|(?:\.LIB)|(?:\.FILE)|(?:\.MBR)/g;
+  const QSYS_PATTERN = /(?:\/\w{1,10}\/QSYS\.LIB\/)|(?:\/QSYS\.LIB\/)|(?:\.LIB)|(?:\.FILE)|(?:\.MBR)/g;
 
   export interface Result {
     path: string


### PR DESCRIPTION
### Changes

This PR is an attempt to solve the problem discussed in issue #1082 - by changing the regular expression used to remove the ASP name and/or /QSYS.LIB/ from the front of the paths returned by the grep search.

It was tested using ASP setting on the users job description, not the ASP setting in the connection.
I am not sure what is the idea behind the ASP setting in the connection configuration or the retrieval of ASP's using SQL ASP_INFO...?

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
