### PR TITLE
Support additional SEU colours

### DIFF
--- a/src/filesystems/qsys/complex/content.js
+++ b/src/filesystems/qsys/complex/content.js
@@ -13,6 +13,10 @@ const {calcNewSourceDates} = require(`./handlers/diffHandler`);
 const DEFAULT_RECORD_LENGTH = 80;
 let { baseDates, recordLengths, getAliasName, baseSource } = require(`./data`);
 
+// Translate x'25' to x'2F' and back, or x'25' will become x'0A' (linefeed)!
+const SEU_GREEN_UL_RI = `x'25'`;
+const SEU_GREEN_UL_RI_temp = `x'2F'`;
+
 module.exports = class IBMiContent {
   /**
    * Download the contents of a source member using SQL.
@@ -54,7 +58,7 @@ module.exports = class IBMiContent {
     }
   
     let rows = await content.runSQL(
-      `select srcdat, rtrim(srcdta) as srcdta from ${aliasPath}`
+      `select srcdat, rtrim(translate(srcdta, ${SEU_GREEN_UL_RI_temp}, ${SEU_GREEN_UL_RI})) as srcdta from ${aliasPath}`
     );
 
     if (rows.length === 0) {
@@ -116,7 +120,7 @@ module.exports = class IBMiContent {
       }
         
       rows.push(
-        `(${sequence}, ${sourceDates[i] ? sourceDates[i].padEnd(6, `0`) : `0`}, '${this.escapeString(sourceData[i])}')`,
+        `(${sequence}, ${sourceDates[i] ? sourceDates[i].padEnd(6, `0`) : `0`}, translate('${this.escapeString(sourceData[i])}', ${SEU_GREEN_UL_RI}, ${SEU_GREEN_UL_RI_temp}))`,
       );
     }
 

--- a/src/languages/general/SEUColors.ts
+++ b/src/languages/general/SEUColors.ts
@@ -50,7 +50,12 @@ export namespace SEUColors {
       })
     },
     // green_ul_ri not supported
-    // pnk not supported
+    pink: {
+      bytes: Buffer.from([194, 152]),
+      decoration: vscode.window.createTextEditorDecorationType({
+        color: `#cf259c`,
+      })
+    },
     pink_ri: {
       bytes: Buffer.from([194, 153]),
       decoration: vscode.window.createTextEditorDecorationType({
@@ -106,6 +111,14 @@ export namespace SEUColors {
         color: `#cf2331`,
         textDecoration: `; border-bottom: 1px solid #cf2331;`
       })
+    },
+    red_ri_ul: {
+      bytes: Buffer.from([5]),
+      decoration: vscode.window.createTextEditorDecorationType({
+        backgroundColor: `#cf2331`,
+        color: `white`,
+        textDecoration: `; border-bottom: 1px solid white;`
+      }),
     },
     turquoise: {
       bytes: Buffer.from([194, 144]),
@@ -176,6 +189,13 @@ export namespace SEUColors {
       bytes: Buffer.from([22]),
       decoration: vscode.window.createTextEditorDecorationType({
         color: `#f4c842`,
+      })
+    },
+    yellow_ri: {
+      bytes: Buffer.from([194, 147]),
+      decoration: vscode.window.createTextEditorDecorationType({
+        color: `#000000`,
+        backgroundColor: `#f4c842`
       })
     },
     yellow_ul: {

--- a/src/languages/general/SEUColors.ts
+++ b/src/languages/general/SEUColors.ts
@@ -75,6 +75,7 @@ export namespace SEUColors {
       decoration: vscode.window.createTextEditorDecorationType({
         backgroundColor: `#cf259c`,
         color: `white`,
+        textDecoration: `; border-bottom: 1px solid white;`
       })
     },
     red: {
@@ -146,6 +147,7 @@ export namespace SEUColors {
       decoration: vscode.window.createTextEditorDecorationType({
         backgroundColor: `#22c4d6`,
         color: `black`,
+        textDecoration: `; border-bottom: 1px solid black;`
       })
     },
     white: {

--- a/src/languages/general/SEUColors.ts
+++ b/src/languages/general/SEUColors.ts
@@ -49,7 +49,14 @@ export namespace SEUColors {
         textDecoration: `; border-bottom: 1px solid #28d15d;`
       })
     },
-    // green_ul_ri not supported
+    green_ul_ri: {
+      bytes: Buffer.from([7]),
+      decoration: vscode.window.createTextEditorDecorationType({
+        backgroundColor: `#28d15d`,
+        color: `black`,
+        textDecoration: `; border-bottom: 1px solid black;`
+      })
+    },
     pink: {
       bytes: Buffer.from([194, 152]),
       decoration: vscode.window.createTextEditorDecorationType({


### PR DESCRIPTION
### Changes

This PR will add support for more SEU colours. Some colours were for some reason not implemented, but the PR will correct this.
The underlining has also been corrected for some colours, and the colour used for underline is now the same as for the foreground text.

One particular challenge was green, underline, reversed image, which uses hex 25. This hex value is the equivalent of ASCII / UTF8 hex 0A - linefeed! So my solution was to have SQL convert the hex 25 to hex 2F, which is converted to hex 07 in ASCII / UTF8, when reading the source member, and vice versa when saving the member, and map the text decorator for green, underline, reversed image to hex 07. Since this is done in SQL and only active when source dates are enabled, the conversion is not done when source dates are not enabled - and green, underline, reversed image still converts to a linefeed in this situation.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
