### PR TITLE
Fix/emptyfilter

### DIFF
--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -552,7 +552,7 @@ module.exports = class objectBrowserTwoProvider {
                       }
                     }, timeoutInternal);
 
-                    let results = await Search.searchMembers(instance, path[0], path[1], `${node.memberFilter}.MBR`, searchTerm);
+                    let results = await Search.searchMembers(instance, path[0], path[1], `${node.memberFilter || `*`}.MBR`, searchTerm);
 
                     // Filter search result by member type filter.
                     if (results.length > 0 && node.memberTypeFilter) {

--- a/src/webviews/filters/index.js
+++ b/src/webviews/filters/index.js
@@ -75,6 +75,11 @@ module.exports = class FiltersUI {
         case `types`:
           data[key] = data[key].split(`,`).map(item => item.trim().toUpperCase()).filter(item => item !== ``);
           break;
+        case `object`:
+        case `member`:
+        case `memberType`:
+          data[key] = data[key].trim() || `*`;
+          break;
         default:
           data[key] = data[key].toUpperCase();
           break;


### PR DESCRIPTION
### Changes
Fixes issue https://github.com/halcyon-tech/vscode-ibmi/issues/1116 where an empty member filter would cause `grep` to fail with `grep: 001-2113[...]No such path or directory.`

### Checklist
* [x] have tested my change
* [x] eslint is not complaining
