### PR TITLE
Fix: Only show debug button for certain sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -1553,7 +1553,7 @@
 			"editor/title": [
 				{
 					"command": "code-for-ibmi.debug.activeEditor",
-					"when": "code-for-ibmi:connected == true && !inDebugMode",
+					"when": "code-for-ibmi:connected == true && !inDebugMode && editorLangId =~ /^rpgle$|^rpg$|^cobol$|^cl$/",
 					"group": "navigation@1"
 				},
 				{


### PR DESCRIPTION
### Changes

Only show debug button for certain sources.

Issue: https://github.com/halcyon-tech/vscode-ibmi/issues/1062

### Checklist

* [X] have tested my change
* [X] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [X] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [X] **for feature PRs**: PR only includes one feature enhancement.
