### PR TITLE
Fix library list validation: find all invalid libraries

### DIFF
--- a/src/views/libraryListView.js
+++ b/src/views/libraryListView.js
@@ -274,7 +274,7 @@ module.exports = class libraryListProvider {
       command: [
         `liblist -d ` + connection.defaultUserLibraries.join(` `).replace(/\$/g, `\\$`),
         ...newLibl.map(lib => `liblist -a ` + lib.replace(/\$/g, `\\$`))
-      ].join(` && `)
+      ].join(`; `)
     });
 
     if (result.stderr) {


### PR DESCRIPTION

### Changes

This PR will fix validation of the library list. Previously it would stop after first invalid library, but this fix will find all the invalid libraries in the list - as was intended...

### Checklist

* [x] have tested my change
* [x] eslint is not complaining
