### PR TITLE
Fixed filter's member type field not duplicated when copying

### DIFF
--- a/src/webviews/filters/index.js
+++ b/src/webviews/filters/index.js
@@ -37,6 +37,7 @@ module.exports = class FiltersUI {
           object: filter.object,
           types: [...filter.types],
           member: filter.member,
+          memberType: filter.memberType,
           protected: filter.protected
         }
         existingConfigIndex = -1;
@@ -51,6 +52,7 @@ module.exports = class FiltersUI {
         object: `*`,
         types: [`*SRCPF`],
         member: `*`,
+        memberType: `*`,
         protected: false
       }
     }


### PR DESCRIPTION
### Changes
Fixed issue https://github.com/halcyon-tech/vscode-ibmi/issues/1138
Filter's `memberType` field was not assigned when copying to a new filter.

### Checklist
* [x] have tested my change
* [x] eslint is not complaining