### PR TITLE
Add Quick Connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -878,6 +878,11 @@
 				"icon": "$(remote)"
 			},
 			{
+				"command": "code-for-ibmi.connectToAndReload",
+				"title": "Connect and Reload Server Settings",
+				"category": "IBM i"
+			},
+			{
 				"command": "code-for-ibmi.refreshConnections",
 				"title": "Refresh Connections",
 				"category": "IBM i",
@@ -1521,6 +1526,10 @@
 					"when": "never"
 				},
 				{
+					"command": "code-for-ibmi.connectToAndReload",
+					"when": "never"
+				},
+				{
 					"command": "code-for-ibmi.disconnect",
 					"when": "code-for-ibmi:connected"
 				},
@@ -1726,6 +1735,11 @@
 					"command": "code-for-ibmi.connectTo",
 					"when": "view == connectionBrowser && viewItem == server",
 					"group": "inline"
+				},
+				{
+					"command": "code-for-ibmi.connectToAndReload",
+					"when": "view == connectionBrowser && viewItem == server",
+					"group": "3_connect@1"
 				},
 				{
 					"command": "code-for-ibmi.moveLibraryUp",

--- a/src/api/Configuration.ts
+++ b/src/api/Configuration.ts
@@ -45,6 +45,7 @@ export namespace ConnectionConfiguration {
     debugUpdateProductionFiles: boolean;
     debugEnableDebugTracing: boolean;
     readOnlyMode: boolean;
+    quickConnect: boolean;
     [name: string]: any;
   }
 
@@ -119,7 +120,8 @@ export namespace ConnectionConfiguration {
       debugIsSecure: (parameters.debugIsSecure === true),
       debugUpdateProductionFiles: (parameters.debugUpdateProductionFiles === true),
       debugEnableDebugTracing: (parameters.debugEnableDebugTracing === true),
-      readOnlyMode: (parameters.readOnlyMode === true)
+      readOnlyMode: (parameters.readOnlyMode === true),
+      quickConnect: (parameters.quickConnect === true)
     }
   }
 

--- a/src/api/Configuration.ts
+++ b/src/api/Configuration.ts
@@ -121,7 +121,7 @@ export namespace ConnectionConfiguration {
       debugUpdateProductionFiles: (parameters.debugUpdateProductionFiles === true),
       debugEnableDebugTracing: (parameters.debugEnableDebugTracing === true),
       readOnlyMode: (parameters.readOnlyMode === true),
-      quickConnect: (parameters.quickConnect === true)
+      quickConnect: (parameters.quickConnect === true || parameters.quickConnect === undefined)
     }
   }
 

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -88,7 +88,9 @@ export default class IBMi {
       'GENCMDXML.PGM': undefined,
       'GETNEWLIBL.PGM': undefined,
       'QZDFMDB2.PGM': undefined,
-      'startDebugService.sh': undefined
+      'startDebugService.sh': undefined,
+      attr: undefined,
+      iconv: undefined
     };
 
     this.variantChars = {
@@ -448,7 +450,8 @@ export default class IBMi {
         }
 
         // Check for installed components?
-        if (quickConnect === true && cachedServerSettings?.remoteFeatures) {
+        // For Quick Connect to work here, 'remoteFeatures' MUST have all features defined and no new properties may be added!
+        if (quickConnect === true && cachedServerSettings?.remoteFeatures && Object.keys(cachedServerSettings.remoteFeatures).sort().toString() === Object.keys(this.remoteFeatures).sort().toString()) {
           this.remoteFeatures = cachedServerSettings.remoteFeatures;
         } else {
           progress.report({

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -9,6 +9,8 @@ import { CompileTools } from "./CompileTools";
 import { ConnectionData, CommandData, StandardIO, CommandResult, IBMiMember, RemoteCommand } from "../typings";
 import * as configVars from './configVars';
 import { instance } from "../instantiate";
+import IBMiContent from "./IBMiContent";
+import { GlobalStorage, CachedServerSettings } from './Storage';
 
 export interface MemberParts extends IBMiMember {
   basename: string
@@ -160,6 +162,9 @@ export default class IBMi {
 
         //Load existing config
         this.config = await ConnectionConfiguration.load(this.currentConnectionName);
+
+        // Load cached server settings.
+        const cachedServerSettings: CachedServerSettings = GlobalStorage.get().getServerSettingsCache(this.currentConnectionName);
 
         progress.report({
           message: `Checking home directory.`
@@ -371,107 +376,116 @@ export default class IBMi {
             });
         }
 
-        progress.report({
-          message: `Checking for bad data areas.`
-        });
-
-        try {
-          await this.remoteCommand(
-            `CHKOBJ OBJ(QSYS/QCPTOIMPF) OBJTYPE(*DTAARA)`,
-            undefined
-          );
-
-          vscode.window.showWarningMessage(`The data area QSYS/QCPTOIMPF exists on this system and may impact Code for IBM i functionality.`, {
-            detail: `For V5R3, the code for the command CPYTOIMPF had a major design change to increase functionality and performance. The QSYS/QCPTOIMPF data area lets developers keep the pre-V5R2 version of CPYTOIMPF. Code for IBM i cannot function correctly while this data area exists.`,
-            modal: true,
-          }, `Delete`, `Read more`).then(choice => {
-            switch (choice) {
-              case `Delete`:
-                this.remoteCommand(
-                  `DLTOBJ OBJ(QSYS/QCPTOIMPF) OBJTYPE(*DTAARA)`
-                )
-                  .then(() => {
-                    vscode.window.showInformationMessage(`The data area QSYS/QCPTOIMPF has been deleted.`);
-                  })
-                  .catch(e => {
-                    vscode.window.showInformationMessage(`Failed to delete the data area QSYS/QCPTOIMPF. Code for IBM i may not work as intended.`);
-                  });
-                break;
-              case `Read more`:
-                vscode.env.openExternal(vscode.Uri.parse(`https://github.com/halcyon-tech/vscode-ibmi/issues/476#issuecomment-1018908018`));
-                break;
-            }
+        // Check for bad data areas?
+        if (this.config.quickConnect === true && cachedServerSettings?.badDataAreasChecked === true) {
+        } else {
+          progress.report({
+            message: `Checking for bad data areas.`
           });
-        } catch (e) {
-          // It doesn't exist, we're all good.
-        }
 
-        try {
-          await this.remoteCommand(
-            `CHKOBJ OBJ(QSYS/QCPFRMIMPF) OBJTYPE(*DTAARA)`,
-            undefined
-          );
-
-          vscode.window.showWarningMessage(`The data area QSYS/QCPFRMIMPF exists on this system and may impact Code for IBM i functionality.`, {
-            modal: false,
-          }, `Delete`, `Read more`).then(choice => {
-            switch (choice) {
-              case `Delete`:
-                this.remoteCommand(
-                  `DLTOBJ OBJ(QSYS/QCPFRMIMPF) OBJTYPE(*DTAARA)`
-                )
-                  .then(() => {
-                    vscode.window.showInformationMessage(`The data area QSYS/QCPFRMIMPF has been deleted.`);
-                  })
-                  .catch(e => {
-                    vscode.window.showInformationMessage(`Failed to delete the data area QSYS/QCPFRMIMPF. Code for IBM i may not work as intended.`);
-                  });
-                break;
-              case `Read more`:
-                vscode.env.openExternal(vscode.Uri.parse(`https://github.com/halcyon-tech/vscode-ibmi/issues/476#issuecomment-1018908018`));
-                break;
-            }
-          });
-        } catch (e) {
-          // It doesn't exist, we're all good.
-        }
-
-        progress.report({
-          message: `Checking installed components on host IBM i.`
-        });
-
-        // We need to check if our remote programs are installed.
-        remoteApps.push(
-          {
-            path: `/QSYS.lib/${this.config.tempLibrary.toUpperCase()}.lib/`,
-            names: [`GENCMDXML.PGM`, `GETNEWLIBL.PGM`],
-            specific: `GE*.PGM`
-          }
-        );
-
-        //Next, we see what pase features are available (installed via yum)
-        //This may enable certain features in the future.
-        for (const feature of remoteApps) {
           try {
-            progress.report({
-              message: `Checking installed components on host IBM i: ${feature.path}`
-            });
+            await this.remoteCommand(
+              `CHKOBJ OBJ(QSYS/QCPTOIMPF) OBJTYPE(*DTAARA)`,
+              undefined
+            );
 
-            const call = await this.paseCommand(`ls -p ${feature.path}${feature.specific || ``}`);
-            if (typeof call === `string`) {
-              const files = call.split(`\n`);
-
-              if (feature.specific) {
-                for (const name of feature.names)
-                  this.remoteFeatures[name] = files.find(file => file.includes(name));
-              } else {
-                for (const name of feature.names)
-                  if (files.includes(name))
-                    this.remoteFeatures[name] = feature.path + name;
+            vscode.window.showWarningMessage(`The data area QSYS/QCPTOIMPF exists on this system and may impact Code for IBM i functionality.`, {
+              detail: `For V5R3, the code for the command CPYTOIMPF had a major design change to increase functionality and performance. The QSYS/QCPTOIMPF data area lets developers keep the pre-V5R2 version of CPYTOIMPF. Code for IBM i cannot function correctly while this data area exists.`,
+              modal: true,
+            }, `Delete`, `Read more`).then(choice => {
+              switch (choice) {
+                case `Delete`:
+                  this.remoteCommand(
+                    `DLTOBJ OBJ(QSYS/QCPTOIMPF) OBJTYPE(*DTAARA)`
+                  )
+                    .then(() => {
+                      vscode.window.showInformationMessage(`The data area QSYS/QCPTOIMPF has been deleted.`);
+                    })
+                    .catch(e => {
+                      vscode.window.showInformationMessage(`Failed to delete the data area QSYS/QCPTOIMPF. Code for IBM i may not work as intended.`);
+                    });
+                  break;
+                case `Read more`:
+                  vscode.env.openExternal(vscode.Uri.parse(`https://github.com/halcyon-tech/vscode-ibmi/issues/476#issuecomment-1018908018`));
+                  break;
               }
-            }
+            });
           } catch (e) {
-            console.log(e);
+            // It doesn't exist, we're all good.
+          }
+
+          try {
+            await this.remoteCommand(
+              `CHKOBJ OBJ(QSYS/QCPFRMIMPF) OBJTYPE(*DTAARA)`,
+              undefined
+            );
+
+            vscode.window.showWarningMessage(`The data area QSYS/QCPFRMIMPF exists on this system and may impact Code for IBM i functionality.`, {
+              modal: false,
+            }, `Delete`, `Read more`).then(choice => {
+              switch (choice) {
+                case `Delete`:
+                  this.remoteCommand(
+                    `DLTOBJ OBJ(QSYS/QCPFRMIMPF) OBJTYPE(*DTAARA)`
+                  )
+                    .then(() => {
+                      vscode.window.showInformationMessage(`The data area QSYS/QCPFRMIMPF has been deleted.`);
+                    })
+                    .catch(e => {
+                      vscode.window.showInformationMessage(`Failed to delete the data area QSYS/QCPFRMIMPF. Code for IBM i may not work as intended.`);
+                    });
+                  break;
+                case `Read more`:
+                  vscode.env.openExternal(vscode.Uri.parse(`https://github.com/halcyon-tech/vscode-ibmi/issues/476#issuecomment-1018908018`));
+                  break;
+              }
+            });
+          } catch (e) {
+            // It doesn't exist, we're all good.
+          }
+        }
+
+        // Check for installed components?
+        if (this.config.quickConnect === true && cachedServerSettings?.remoteFeatures) {
+          this.remoteFeatures = cachedServerSettings.remoteFeatures;
+        } else {
+          progress.report({
+            message: `Checking installed components on host IBM i.`
+          });
+
+          // We need to check if our remote programs are installed.
+          remoteApps.push(
+            {
+              path: `/QSYS.lib/${this.config.tempLibrary.toUpperCase()}.lib/`,
+              names: [`GENCMDXML.PGM`, `GETNEWLIBL.PGM`],
+              specific: `GE*.PGM`
+            }
+          );
+
+          //Next, we see what pase features are available (installed via yum)
+          //This may enable certain features in the future.
+          for (const feature of remoteApps) {
+            try {
+              progress.report({
+                message: `Checking installed components on host IBM i: ${feature.path}`
+              });
+
+              const call = await this.paseCommand(`ls -p ${feature.path}${feature.specific || ``}`);
+              if (typeof call === `string`) {
+                const files = call.split(`\n`);
+
+                if (feature.specific) {
+                  for (const name of feature.names)
+                    this.remoteFeatures[name] = files.find(file => file.includes(name));
+                } else {
+                  for (const name of feature.names)
+                    if (files.includes(name))
+                      this.remoteFeatures[name] = feature.path + name;
+                }
+              }
+            } catch (e) {
+              console.log(e);
+            }
           }
         }
 
@@ -479,101 +493,112 @@ export default class IBMi {
           let statement;
           let output;
 
-          progress.report({
-            message: `Checking for ASP information.`
-          });
-
-          //This is mostly a nice to have. We grab the ASP info so user's do
-          //not have to provide the ASP in the settings.
-          try {
-            statement = `SELECT * FROM QSYS2.ASP_INFO`;
-            output = await this.paseCommand(`LC_ALL=EN_US.UTF-8 system "call QSYS/QZDFMDB2 PARM('-d' '-i')"`, undefined, 0, {
-              stdin: statement
+          // Check for ASP information?
+          if (this.config.quickConnect === true && cachedServerSettings?.aspInfo) {
+            this.aspInfo = cachedServerSettings.aspInfo;
+          } else {
+            progress.report({
+              message: `Checking for ASP information.`
             });
 
-            if (typeof output === `string`) {
-              const rows = Tools.db2Parse(output);
-              rows.forEach((row: any) => {
-                if (row.DEVICE_DESCRIPTION_NAME && row.DEVICE_DESCRIPTION_NAME !== `null`) {
-                  this.aspInfo[row.ASP_NUMBER] = row.DEVICE_DESCRIPTION_NAME;
-                }
+            //This is mostly a nice to have. We grab the ASP info so user's do
+            //not have to provide the ASP in the settings.
+            try {
+              statement = `SELECT * FROM QSYS2.ASP_INFO`;
+              output = await this.paseCommand(`LC_ALL=EN_US.UTF-8 system "call QSYS/QZDFMDB2 PARM('-d' '-i')"`, undefined, 0, {
+                stdin: statement
+              });
+
+              if (typeof output === `string`) {
+                const rows = Tools.db2Parse(output);
+                rows.forEach((row: any) => {
+                  if (row.DEVICE_DESCRIPTION_NAME && row.DEVICE_DESCRIPTION_NAME !== `null`) {
+                    this.aspInfo[row.ASP_NUMBER] = row.DEVICE_DESCRIPTION_NAME;
+                  }
+                });
+              }
+            } catch (e) {
+              //Oh well
+              progress.report({
+                message: `Failed to get ASP information.`
               });
             }
-          } catch (e) {
-            //Oh well
-            progress.report({
-              message: `Failed to get ASP information.`
-            });
           }
 
-          progress.report({
-            message: `Fetching conversion values.`
-          });
-
-          // Next, we're going to see if we can get the CCSID from the user or the system.
-          // Some things don't work without it!!!
-          try {
-            const CCSID_SYSVAL = -2;
-            statement = `select CHARACTER_CODE_SET_ID from table( QSYS2.QSYUSRINFO( USERNAME => upper('${this.currentUser}') ) )`;
-            output = await this.sendCommand({
-              command: `LC_ALL=EN_US.UTF-8 system "call QSYS/QZDFMDB2 PARM('-d' '-i')"`,
-              stdin: statement
+          // Fetch conversion values?
+          if (this.config.quickConnect === true && cachedServerSettings?.qccsid !== null && cachedServerSettings?.variantChars) {
+            this.qccsid = cachedServerSettings.qccsid;
+            this.variantChars = cachedServerSettings.variantChars;
+          } else {
+            progress.report({
+              message: `Fetching conversion values.`
             });
 
-            if (output.stdout) {
-              const [row] = Tools.db2Parse(output.stdout);
-              if (row && row.CHARACTER_CODE_SET_ID !== `null` && typeof row.CHARACTER_CODE_SET_ID === 'number') {
-                this.qccsid = row.CHARACTER_CODE_SET_ID;
-              }
-            }
-
-            if (this.qccsid === undefined || this.qccsid === CCSID_SYSVAL) {
-              statement = `select SYSTEM_VALUE_NAME, CURRENT_NUMERIC_VALUE from QSYS2.SYSTEM_VALUE_INFO where SYSTEM_VALUE_NAME = 'QCCSID'`;
+            // Next, we're going to see if we can get the CCSID from the user or the system.
+            // Some things don't work without it!!!
+            try {
+              const CCSID_SYSVAL = -2;
+              statement = `select CHARACTER_CODE_SET_ID from table( QSYS2.QSYUSRINFO( USERNAME => upper('${this.currentUser}') ) )`;
               output = await this.sendCommand({
                 command: `LC_ALL=EN_US.UTF-8 system "call QSYS/QZDFMDB2 PARM('-d' '-i')"`,
                 stdin: statement
               });
 
               if (output.stdout) {
-                const rows = Tools.db2Parse(output.stdout);
-                const ccsid = rows.find(row => row.SYSTEM_VALUE_NAME === `QCCSID`);
-                if (ccsid && typeof ccsid.CURRENT_NUMERIC_VALUE === 'number') {
-                  this.qccsid = ccsid.CURRENT_NUMERIC_VALUE;
+                const [row] = Tools.db2Parse(output.stdout);
+                if (row && row.CHARACTER_CODE_SET_ID !== `null` && typeof row.CHARACTER_CODE_SET_ID === 'number') {
+                  this.qccsid = row.CHARACTER_CODE_SET_ID;
                 }
               }
-            }
 
-            if (this.config.enableSQL && this.qccsid === 65535) {
-              this.config.enableSQL = false;
-              vscode.window.showErrorMessage(`QCCSID is set to 65535. Disabling SQL support.`);
-            }
+              if (this.qccsid === undefined || this.qccsid === CCSID_SYSVAL) {
+                statement = `select SYSTEM_VALUE_NAME, CURRENT_NUMERIC_VALUE from QSYS2.SYSTEM_VALUE_INFO where SYSTEM_VALUE_NAME = 'QCCSID'`;
+                output = await this.sendCommand({
+                  command: `LC_ALL=EN_US.UTF-8 system "call QSYS/QZDFMDB2 PARM('-d' '-i')"`,
+                  stdin: statement
+                });
 
-            progress.report({
-              message: `Fetching local encoding values.`
-            });
-
-            statement = `with VARIANTS ( HASH, AT, DOLLARSIGN ) as (`
-              + `  values ( cast( x'7B' as varchar(1) )`
-              + `         , cast( x'7C' as varchar(1) )`
-              + `         , cast( x'5B' as varchar(1) ) )`
-              + `)`
-              + `select HASH concat AT concat DOLLARSIGN as LOCAL`
-              + `  from VARIANTS; `;
-            output = await this.sendCommand({
-              command: `LC_ALL=EN_US.UTF-8 system "call QSYS/QZDFMDB2 PARM('-d' '-i')"`,
-              stdin: statement
-            });
-            if (output.stdout) {
-              const [row] = Tools.db2Parse(output.stdout);
-              if (row && row.LOCAL !== `null` && typeof row.LOCAL === 'string') {
-                this.variantChars.local = row.LOCAL;
+                if (output.stdout) {
+                  const rows = Tools.db2Parse(output.stdout);
+                  const ccsid = rows.find(row => row.SYSTEM_VALUE_NAME === `QCCSID`);
+                  if (ccsid && typeof ccsid.CURRENT_NUMERIC_VALUE === 'number') {
+                    this.qccsid = ccsid.CURRENT_NUMERIC_VALUE;
+                  }
+                }
               }
-            } else {
-              throw new Error(`There was an error running the SQL statement.`);
+
+              if (this.config.enableSQL && this.qccsid === 65535) {
+                this.config.enableSQL = false;
+                vscode.window.showErrorMessage(`QCCSID is set to 65535. Disabling SQL support.`);
+              }
+
+              progress.report({
+                message: `Fetching local encoding values.`
+              });
+
+              statement = `with VARIANTS ( HASH, AT, DOLLARSIGN ) as (`
+                + `  values ( cast( x'7B' as varchar(1) )`
+                + `         , cast( x'7C' as varchar(1) )`
+                + `         , cast( x'5B' as varchar(1) ) )`
+                + `)`
+                + `select HASH concat AT concat DOLLARSIGN as LOCAL`
+                + `  from VARIANTS; `;
+              output = await this.sendCommand({
+                command: `LC_ALL=EN_US.UTF-8 system "call QSYS/QZDFMDB2 PARM('-d' '-i')"`,
+                stdin: statement
+              });
+              if (output.stdout) {
+                const [row] = Tools.db2Parse(output.stdout);
+                if (row && row.LOCAL !== `null` && typeof row.LOCAL === 'string') {
+                  this.variantChars.local = row.LOCAL;
+                }
+              } else {
+                throw new Error(`There was an error running the SQL statement.`);
+              }
+            } catch (e) {
+              // Oh well!
+              console.log(e);
             }
-          } catch (e) {
-            // Oh well!
-            console.log(e);
           }
         } else {
           // Disable it if it's not found
@@ -657,6 +682,17 @@ export default class IBMi {
           await vscode.commands.executeCommand(`setContext`, `code-for-ibmi:connected`, true);
           instance.fire("connected");
         }
+
+        GlobalStorage.get().setServerSettingsCache(this.currentConnectionName, {
+          aspInfo: this.aspInfo,
+          qccsid: this.qccsid,
+          remoteFeatures: this.remoteFeatures,
+          variantChars: {
+            american: this.variantChars.american,
+            local: this.variantChars.local,
+          },
+          badDataAreasChecked: true
+        });
 
         return {
           success: true

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -382,6 +382,7 @@ export default class IBMi {
 
         // Check for bad data areas?
         if (quickConnect === true && cachedServerSettings?.badDataAreasChecked === true) {
+          // Do nothing, bad data areas are already checked.
         } else {
           progress.report({
             message: `Checking for bad data areas.`

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -107,7 +107,7 @@ export default class IBMi {
   /**
    * @returns {Promise<{success: boolean, error?: any}>} Was succesful at connecting or not.
    */
-  async connect(connectionObject: ConnectionData, reconnecting?: boolean): Promise<{ success: boolean, error?: any }> {
+  async connect(connectionObject: ConnectionData, reconnecting?: boolean, reloadServerSettings: boolean = false): Promise<{ success: boolean, error?: any }> {
     try {
       connectionObject.keepaliveInterval = 35000;
       // Make sure we're not passing any blank strings, as node_ssh will try to validate it
@@ -165,6 +165,8 @@ export default class IBMi {
 
         // Load cached server settings.
         const cachedServerSettings: CachedServerSettings = GlobalStorage.get().getServerSettingsCache(this.currentConnectionName);
+        // Reload server settings?
+        const quickConnect = (this.config.quickConnect === true && reloadServerSettings === false);
 
         progress.report({
           message: `Checking home directory.`
@@ -377,7 +379,7 @@ export default class IBMi {
         }
 
         // Check for bad data areas?
-        if (this.config.quickConnect === true && cachedServerSettings?.badDataAreasChecked === true) {
+        if (quickConnect === true && cachedServerSettings?.badDataAreasChecked === true) {
         } else {
           progress.report({
             message: `Checking for bad data areas.`
@@ -446,7 +448,7 @@ export default class IBMi {
         }
 
         // Check for installed components?
-        if (this.config.quickConnect === true && cachedServerSettings?.remoteFeatures) {
+        if (quickConnect === true && cachedServerSettings?.remoteFeatures) {
           this.remoteFeatures = cachedServerSettings.remoteFeatures;
         } else {
           progress.report({
@@ -494,7 +496,7 @@ export default class IBMi {
           let output;
 
           // Check for ASP information?
-          if (this.config.quickConnect === true && cachedServerSettings?.aspInfo) {
+          if (quickConnect === true && cachedServerSettings?.aspInfo) {
             this.aspInfo = cachedServerSettings.aspInfo;
           } else {
             progress.report({
@@ -526,7 +528,7 @@ export default class IBMi {
           }
 
           // Fetch conversion values?
-          if (this.config.quickConnect === true && cachedServerSettings?.qccsid !== null && cachedServerSettings?.variantChars) {
+          if (quickConnect === true && cachedServerSettings?.qccsid !== null && cachedServerSettings?.variantChars) {
             this.qccsid = cachedServerSettings.qccsid;
             this.variantChars = cachedServerSettings.variantChars;
           } else {

--- a/src/api/Storage.ts
+++ b/src/api/Storage.ts
@@ -92,7 +92,7 @@ export class GlobalStorage extends Storage {
   }
 
   async deleteServerSettingsCache(name: string) {
-    await this.set(SERVER_SETTINGS_CACHE_KEY(name)), undefined);
+    await this.set(SERVER_SETTINGS_CACHE_KEY(name), undefined);
   }}
 
 export class ConnectionStorage extends Storage {

--- a/src/api/Storage.ts
+++ b/src/api/Storage.ts
@@ -90,7 +90,10 @@ export class GlobalStorage extends Storage {
   async setServerSettingsCache(name: string, serverSettings: CachedServerSettings) {
     await this.set(SERVER_SETTINGS_CACHE_KEY.concat(`_${name}`), serverSettings);
   }
-}
+
+  async deleteServerSettingsCache(name: string) {
+    await this.set(SERVER_SETTINGS_CACHE_KEY.concat(`_${name}`), undefined);
+  }}
 
 export class ConnectionStorage extends Storage {
   private connectionName: string = "";

--- a/src/api/Storage.ts
+++ b/src/api/Storage.ts
@@ -4,7 +4,8 @@ const PREVIOUS_CUR_LIBS_KEY = `prevCurLibs`;
 const LAST_PROFILE_KEY = `currentProfile`;
 const SOURCE_LIST_KEY = `sourceList`;
 const DEPLOYMENT_KEY = `deployment`;
-const DEBUG_KEY = `debug`
+const DEBUG_KEY = `debug`;
+const SERVER_SETTINGS_CACHE_KEY = `serverSettingsCache`;
 
 export type PathContent = Record<string, string[]>;
 export type DeploymentPath = Record<string, string>;
@@ -32,6 +33,14 @@ export type LastConnection = {
   name: string
   timestamp: number
 };
+
+export type CachedServerSettings = {
+  aspInfo: { [id: number]: string };
+  qccsid: number | null;
+  remoteFeatures: { [name: string]: string | undefined };
+  variantChars: { american: string, local: string };
+  badDataAreasChecked: boolean | null
+} | undefined;
 
 export class GlobalStorage extends Storage {
   private static instance: GlobalStorage;
@@ -72,6 +81,14 @@ export class GlobalStorage extends Storage {
 
   async setLastConnections(lastConnections: LastConnection[]) {
     await this.set("lastConnections", lastConnections.sort((c1, c2) => c2.timestamp - c1.timestamp));
+  }
+
+  getServerSettingsCache(name: string) {
+    return this.get<CachedServerSettings>(SERVER_SETTINGS_CACHE_KEY.concat(`_${name}`));
+  }
+
+  async setServerSettingsCache(name: string, serverSettings: CachedServerSettings) {
+    await this.set(SERVER_SETTINGS_CACHE_KEY.concat(`_${name}`), serverSettings);
   }
 }
 

--- a/src/api/Storage.ts
+++ b/src/api/Storage.ts
@@ -5,7 +5,7 @@ const LAST_PROFILE_KEY = `currentProfile`;
 const SOURCE_LIST_KEY = `sourceList`;
 const DEPLOYMENT_KEY = `deployment`;
 const DEBUG_KEY = `debug`;
-const SERVER_SETTINGS_CACHE_KEY = `serverSettingsCache`;
+const SERVER_SETTINGS_CACHE_KEY = (name : string) => `serverSettingsCache_${name}`;
 
 export type PathContent = Record<string, string[]>;
 export type DeploymentPath = Record<string, string>;
@@ -84,15 +84,15 @@ export class GlobalStorage extends Storage {
   }
 
   getServerSettingsCache(name: string) {
-    return this.get<CachedServerSettings>(SERVER_SETTINGS_CACHE_KEY.concat(`_${name}`));
+    return this.get<CachedServerSettings>(SERVER_SETTINGS_CACHE_KEY(name));
   }
 
   async setServerSettingsCache(name: string, serverSettings: CachedServerSettings) {
-    await this.set(SERVER_SETTINGS_CACHE_KEY.concat(`_${name}`), serverSettings);
+    await this.set(SERVER_SETTINGS_CACHE_KEY(name), serverSettings);
   }
 
   async deleteServerSettingsCache(name: string) {
-    await this.set(SERVER_SETTINGS_CACHE_KEY.concat(`_${name}`), undefined);
+    await this.set(SERVER_SETTINGS_CACHE_KEY(name)), undefined);
   }}
 
 export class ConnectionStorage extends Storage {

--- a/src/views/ConnectionBrowser.ts
+++ b/src/views/ConnectionBrowser.ts
@@ -33,7 +33,7 @@ export class ObjectBrowserProvider {
         }
       }),
 
-      vscode.commands.registerCommand(`code-for-ibmi.connectTo`, async (name?: string | Server) => {
+      vscode.commands.registerCommand(`code-for-ibmi.connectTo`, async (name?: string | Server, reloadServerSettings?: boolean) => {
         if (!this._attemptingConnection) {
           this._attemptingConnection = true;
 
@@ -49,10 +49,10 @@ export class ObjectBrowserProvider {
 
           switch (typeof name) {
             case `string`: // Name of connection object
-              await Login.LoginToPrevious(name, context);
+              await Login.LoginToPrevious(name, context, reloadServerSettings);
               break;
             case `object`: // A Server object
-              await Login.LoginToPrevious(name.name, context);
+              await Login.LoginToPrevious(name.name, context, reloadServerSettings);
               break;
             default:
               vscode.window.showErrorMessage(`Use the Server Browser to select which system to connect to.`);
@@ -60,6 +60,13 @@ export class ObjectBrowserProvider {
           }
 
           this._attemptingConnection = false;
+        }
+      }),
+
+      vscode.commands.registerCommand(`code-for-ibmi.connectToAndReload`, async (server: Server) => {
+        if (!this._attemptingConnection && server) {
+          const reloadServerSettings = true;
+          vscode.commands.executeCommand(`code-for-ibmi.connectTo`, server.name, reloadServerSettings);
         }
       }),
 

--- a/src/views/ConnectionBrowser.ts
+++ b/src/views/ConnectionBrowser.ts
@@ -84,6 +84,9 @@ export class ObjectBrowserProvider {
               const newConnectionSettings = connectionSettings.filter(connection => connection.name !== server.name);
               await GlobalConfiguration.set(`connectionSettings`, newConnectionSettings);
 
+              // Also remove the cached connection settings
+              GlobalStorage.get().deleteServerSettingsCache(server.name);
+
               // Then remove the password
               context.secrets.delete(`${server.name}_password`);
 

--- a/src/webviews/login/index.ts
+++ b/src/webviews/login/index.ts
@@ -143,7 +143,7 @@ export class Login {
       }
 
       try {
-        const connected = await new IBMi().connect(connectionConfig, reloadServerSettings);
+        const connected = await new IBMi().connect(connectionConfig, undefined, reloadServerSettings);
         if (connected.success) {
           vscode.window.showInformationMessage(`Connected to ${connectionConfig.host}!`);
         } else {

--- a/src/webviews/login/index.ts
+++ b/src/webviews/login/index.ts
@@ -115,7 +115,7 @@ export class Login {
    * @param name Connection name
    * @param context
    */
-  static async LoginToPrevious(name: string, context: vscode.ExtensionContext) {
+  static async LoginToPrevious(name: string, context: vscode.ExtensionContext, reloadServerSettings?: boolean) {
     const connection = instance.getConnection();
     if (connection) {
       // If the user is already connected and trying to connect to a different system, disconnect them first
@@ -143,7 +143,7 @@ export class Login {
       }
 
       try {
-        const connected = await new IBMi().connect(connectionConfig);
+        const connected = await new IBMi().connect(connectionConfig, reloadServerSettings);
         if (connected.success) {
           vscode.window.showInformationMessage(`Connected to ${connectionConfig.host}!`);
         } else {

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -55,6 +55,7 @@ export class SettingsUI {
 
         const featuresTab = new Section();
         featuresTab
+          .addCheckbox(`quickConnect`, `Quick Connect`, `When enabled, server settings from previous connection will be used, resulting in much quicker connection. If server settings are changed, disable this setting at least once to pick up the new settings from the server.`, config.quickConnect)
           .addCheckbox(`enableSQL`, `Enable SQL`, `Must be enabled to make the use of SQL and is enabled by default. If you find SQL isn't working for some reason, disable this. If your QCCSID is 65535, it is recommend SQL is disabled. When disabled, will use import files where possible.`, config.enableSQL)
           .addCheckbox(`showDescInLibList`, `Show description of libraries in User Library List view`, `When enabled, library text and attribute will be shown in User Library List. It is recommended to also enable SQL for this.`, config.showDescInLibList)
           .addCheckbox(`autoConvertIFSccsid`, `Support EBCDIC streamfiles`, `Enable converting EBCDIC to UTF-8 when opening streamfiles. When disabled, assumes all streamfiles are in UTF8. When enabled, will open streamfiles regardless of encoding. May slow down open and save operations.<br><br>You can find supported CCSIDs with <code>/usr/bin/iconv -l</code>`, config.autoConvertIFSccsid)

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -168,7 +168,7 @@ export class SettingsUI {
           }
 
           Object.assign(config, data);
-          await ConnectionConfiguration.update(config);
+          await instance.setConfig(config);
 
           if (connection && restart) {
               vscode.window.showInformationMessage(`Some settings require a restart to take effect. Reload workspace now?`, `Reload`, `No`)

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -55,7 +55,7 @@ export class SettingsUI {
 
         const featuresTab = new Section();
         featuresTab
-          .addCheckbox(`quickConnect`, `Quick Connect`, `When enabled, server settings from previous connection will be used, resulting in much quicker connection. If server settings are changed, disable this setting at least once to pick up the new settings from the server.`, config.quickConnect)
+          .addCheckbox(`quickConnect`, `Quick Connect`, `When enabled, server settings from previous connection will be used, resulting in much quicker connection. If server settings are changed, right-click the connection in Connection Browser and select <code>Connect and Reload Server Settings</code> to refresh the cache.`, config.quickConnect)
           .addCheckbox(`enableSQL`, `Enable SQL`, `Must be enabled to make the use of SQL and is enabled by default. If you find SQL isn't working for some reason, disable this. If your QCCSID is 65535, it is recommend SQL is disabled. When disabled, will use import files where possible.`, config.enableSQL)
           .addCheckbox(`showDescInLibList`, `Show description of libraries in User Library List view`, `When enabled, library text and attribute will be shown in User Library List. It is recommended to also enable SQL for this.`, config.showDescInLibList)
           .addCheckbox(`autoConvertIFSccsid`, `Support EBCDIC streamfiles`, `Enable converting EBCDIC to UTF-8 when opening streamfiles. When disabled, assumes all streamfiles are in UTF8. When enabled, will open streamfiles regardless of encoding. May slow down open and save operations.<br><br>You can find supported CCSIDs with <code>/usr/bin/iconv -l</code>`, config.autoConvertIFSccsid)


### PR DESCRIPTION
### Changes

This PR will add a `Quick Connect` setting in the connection configuration to speed up connecting to the system:

![billede](https://user-images.githubusercontent.com/13275072/231269870-bbd9e207-a106-4131-9b47-a76ff6189552.png)

When selected, the following server settings are taken from the previous connection to the system:
- bad data areas
- all remote features
- ASP info
- CCSID
- encoding values for #@$

These values are stored in connection storage on each connection to the system. So if no previous connection has been done, even though the `Quick Connect` is checked, all settings will be retrieved from the server and stored in the connection configuration to be used on the next connection.

This setting is active by default. The user can disable it permanently in the configuration, or the user can reload all settings from server into cache by right-clicking on the connection and select `Connect and Reload Server Settings`.

If the remote feature keys do not match the keys in the cache, the remote features will be checked on the server disregarding this setting.

For more information, see issue #1122.


### Checklist

* [x] have tested my change
* [x] eslint is not complaining
* [x] **for feature PRs**: PR only includes one feature enhancement.
