### PR TITLE
Remove outdated command APIs and expose `runCommand`

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -5,10 +5,10 @@ import { ConnectionConfiguration } from "./Configuration";
 
 import { Tools } from './Tools';
 import path from 'path';
-import { ConnectionData, CommandData, StandardIO, CommandResult } from "../typings";
+import { ConnectionData, CommandData, StandardIO, CommandResult, RemoteCommand } from "../typings";
 import * as configVars from './configVars';
 import { instance } from "../instantiate";
-import IBMiContent from "./IBMiContent";
+import { CompileTools } from "./CompileTools";
 
 export interface MemberParts {
   asp?: string
@@ -675,6 +675,7 @@ export default class IBMi {
   }
 
   /**
+   * @deprecated Use runCommand instead
    * @param {string} command 
    * @param {string} [directory] If not passed, will use current home directory
    */
@@ -684,6 +685,18 @@ export default class IBMi {
     command = command.replace(/\$/g, `\\$`).replace(/"/g, `\\"`);
 
     return this.paseCommand(`system "` + command + `"`, directory);
+  }
+
+  /**
+   * - Send PASE/QSH/ILE commands simply
+   * - Commands sent here end in the 'IBM i Output' channel
+   * - When sending `ile` commands:
+   *   By default, it will use the library list of the connection,
+   *   but `&LIBL` and `&CURLIB` can be passed in the property
+   *   `env` to customise them.
+   */
+  runCommand(data: RemoteCommand) {
+    return CompileTools.runCommand(instance, data);
   }
 
   async sendQsh(options: CommandData) {
@@ -713,6 +726,10 @@ export default class IBMi {
     }
   }
 
+  /**
+   * Send commands to pase through the SSH connection.
+   * Commands sent here end up in the 'Code for IBM i' output channel.
+   */
   async sendCommand(options: CommandData): Promise<CommandResult> {
     let commands: string[] = [];
     if (options.env) {

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -345,20 +345,6 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(`code-for-ibmi.launchTerminalPicker`, () => {
       Terminal.selectAndOpen(instance);
     }),
-
-    vscode.commands.registerCommand(`code-for-ibmi.runCommand`, (detail: RemoteCommand) => {
-      if (detail && detail.command) {
-        return CompileTools.runCommand(instance, detail);
-      }
-    }),
-    vscode.commands.registerCommand(`code-for-ibmi.runQuery`, (statement?: string) => {
-      const content = instance.getContent();
-      if (statement && content) {
-        return content.runSQL(statement);
-      } else {
-        return null;
-      }
-    }),
     vscode.commands.registerCommand(`code-for-ibmi.secret`, async (key: string, newValue: string) => {
       const connectionKey = `${instance.getConnection()!.currentConnectionName}_${key}`;
       if (newValue) {
@@ -369,16 +355,6 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
       const value = context.secrets.get(connectionKey);
       return value;
     }),
-    vscode.commands.registerCommand(`code-for-ibmi.launchUI`, <T>(title: string, fields: any[], callback: (page: Page<T>) => void) => {
-      if (title && fields && callback) {
-        const ui = new CustomUI();
-        fields.forEach(field => {
-          const uiField = new Field(field.type, field.id, field.label);
-          ui.addField(Object.assign(uiField, field));
-        });
-        ui.loadPage(title, callback);
-      }
-    })
   );
 
   (require(`./webviews/actions`)).init(context);


### PR DESCRIPTION
### Changes

* This exposes one of the last major APIs, `runCommand`. We have already exposed our SQL API and CustomUI API, so this one was missing.
* Along with adding this API, I have removed the old ways of invoking these APIs - which is what we used prior to our export API.
* The `code-for-ibmi.openErrors` will now allow a parameter so users can call this an API dynamically
* Our [extending doc](https://halcyon-tech.github.io/docs/#/pages/api/extending) really needs to some work, so I am going to work on that if it gets merged.

This could be a fairly breaking change, but one I'm willing to take for a big release like 2.0.0.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [x] **for feature PRs**: PR only includes one feature enhancement.
