### PR TITLE
Fixed types generation

### DIFF
--- a/src/api/Storage.ts
+++ b/src/api/Storage.ts
@@ -18,7 +18,7 @@ abstract class Storage {
   }
 
   protected get<T>(key: string): T | undefined {
-    return this.globalState.get<T>(this.getStorageKey(key));
+    return this.globalState.get(this.getStorageKey(key)) as T | undefined;
   }
 
   protected async set(key: string, value: any) {


### PR DESCRIPTION
### Changes
Fixed types generation failing with:
```
src/api/Storage.ts:21:12 - error TS2347: Untyped function calls may not accept type arguments.

21     return this.globalState.get<T>(this.getStorageKey(key));
```

Why did it complain about this is beyond me (as it was syntaxically correct...).

### Checklist
* [x] have tested my change