### PR TITLE
Fix/sql large docs

### DIFF
--- a/src/filesystems/qsys/QSysFs.ts
+++ b/src/filesystems/qsys/QSysFs.ts
@@ -95,7 +95,7 @@ export class QSysFS implements vscode.FileSystemProvider {
             const memberContent = this.extendedMemberSupport ?
                 await this.extendedContent.downloadMemberContentWithDates(asp, library, file, member) :
                 await contentApi.downloadMemberContent(asp, library, file, member);
-            if (memberContent) {
+            if (memberContent !== undefined) {
                 return new Uint8Array(Buffer.from(memberContent, `utf8`));
             }
             else {

--- a/src/filesystems/qsys/extendedContent.ts
+++ b/src/filesystems/qsys/extendedContent.ts
@@ -129,7 +129,12 @@ export class ExtendedIBMiContent {
         //We assume the alias still exists....
         const query: string[] = [];
 
-        const rowGroups = sliceUp(rows, 5000);
+        // Row length is the length of the SLQ string used to insert each row
+        const rowLength = recordLength + 55;
+        // 450000 is just below the maxiumu length for each insert.
+        const perInsert = Math.floor(450000 / rowLength);
+
+        const rowGroups = sliceUp(rows, perInsert);
         rowGroups.forEach(rowGroup => {
           query.push(`insert into ${aliasPath} values ${rowGroup.join(`,`)};`);
         });


### PR DESCRIPTION
### Changes

Fixes issue opened [as discussion item here](https://github.com/halcyon-tech/vscode-ibmi/discussions/1162).

* Allows empty documents to be opened
* Fixes bug when saving large text documents (80 characters per line * 3000 lines) with source dates enabled

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
