### PR TITLE
Fixed missing name attribute on select

### DIFF
--- a/src/api/CustomUI.ts
+++ b/src/api/CustomUI.ts
@@ -329,7 +329,7 @@ export class CustomUI extends Section {
                     }
                   });
                   `
-                })}
+    })}
             });
 
         }())
@@ -469,7 +469,7 @@ export class Field {
           <vscode-form-group variant="settings-group">
               ${this.renderLabel()}
               ${this.renderDescription()}
-              <vscode-single-select id="${this.id}">
+              <vscode-single-select id="${this.id}" name="${this.id}">
                   ${this.items?.map(item => /* html */`<vscode-option ${item.selected ? `selected` : ``} value="${item.value}" description="${item.text}">${item.description}</vscode-option>`)}
               </vscode-single-select>
           </vscode-form-group>`;


### PR DESCRIPTION
### Changes
The `name` attribute was missing on the UI `select` fields. It prevented value from being retrieved.

This PR fixes
- https://github.com/halcyon-tech/vscode-ibmi/issues/1166
- https://github.com/halcyon-tech/vscode-ibmi/issues/1167
- Every webview with a `select` input

### Checklist

* [x] have tested my change