### PR TITLE
Fix/actionsUI

### DIFF
--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -380,7 +380,7 @@ export namespace CompileTools {
           const command = replaceValues(chosenAction.command, variables);
           try {
             const commandResult = await runCommand(instance, {
-              environment: chosenAction.environment,
+              environment,
               command,
               env: Object.fromEntries(variables)
             });

--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -383,7 +383,8 @@ export namespace CompileTools {
               environment,
               command,
               env: Object.fromEntries(variables)
-            });
+            },
+              chosenAction.name);
 
             if (commandResult) {
               const possibleObject = getObjectFromCommand(commandResult.command);
@@ -471,7 +472,7 @@ export namespace CompileTools {
   /**
    * Execute a command
    */
-  export async function runCommand(instance: Instance, options: RemoteCommand): Promise<CommandResult | null> {
+  export async function runCommand(instance: Instance, options: RemoteCommand, title?: string): Promise<CommandResult | null> {
     const connection = instance.getConnection();
     const config = instance.getConfig();
     if (config && connection) {
@@ -485,7 +486,7 @@ export namespace CompileTools {
       if (commandString.startsWith(`?`)) {
         commandString = await vscode.window.showInputBox({ prompt: `Run Command`, value: commandString.substring(1) }) || '';
       } else {
-        commandString = await showCustomInputs(`Run Command`, commandString);
+        commandString = await showCustomInputs(`Run Command`, commandString, title);
       }
 
       if (commandString) {
@@ -580,7 +581,7 @@ export namespace CompileTools {
    * @param command action's command string
    * @return the new command
    */
-  async function showCustomInputs(name: string, command: string): Promise<string> {
+  async function showCustomInputs(name: string, command: string, title?: string): Promise<string> {
     const components = [];
     let loop = true;
 
@@ -613,6 +614,11 @@ export namespace CompileTools {
 
     if (components.length) {
       const commandUI = new CustomUI();
+
+      if (title) {
+        commandUI.addHeading(title, 2);
+      }
+
       for (const component of components) {
         if (component.initialValue.includes(`,`)) {
           //Select box

--- a/src/api/CustomUI.ts
+++ b/src/api/CustomUI.ts
@@ -46,7 +46,7 @@ export class Section {
     return this;
   }
 
-  addInput(id: string, label: string, description?: string, options?: { default?: string, readonly?: boolean, multiline?: boolean }) {
+  addInput(id: string, label: string, description?: string, options?: { default?: string, readonly?: boolean, rows?: number }) {
     const input = Object.assign(new Field('input', id, label, description), options);
     this.addField(input);
     return this;
@@ -281,11 +281,11 @@ export class CustomUI extends Section {
 
             for (const field of submitfields) {
                 const currentElement = document.getElementById(field);
-                if (currentElement.hasAttribute('multiline')) {
+                if (currentElement.hasAttribute('rows')) {
                   currentElement
                     .addEventListener('keyup', function(event) {
                         event.preventDefault();
-                        if (event.keyCode === 13 && event.shiftKey) {
+                        if (event.keyCode === 13 && event.altKey) {
                           doDone();
                         }
                     });
@@ -373,7 +373,7 @@ export class Field {
   public complexTabItems?: ComplexTab[];
   public default?: string;
   public readonly?: boolean;
-  public multiline?: boolean;
+  public rows?: number;
 
   constructor(readonly type: FieldType, readonly id: string, readonly label: string, readonly description?: string) {
 
@@ -427,11 +427,13 @@ export class Field {
           </vscode-tabs>`;
 
       case `input`:
+        const multiline = (this.rows || 1) > 1;
+        const tag = multiline ? "vscode-textarea" : "vscode-textfield";
         return /* html */`
           <vscode-form-group variant="settings-group">
               ${this.renderLabel()}
-              ${this.renderDescription()}
-              <vscode-textfield class="long-input" id="${this.id}" name="${this.id}" ${this.default ? `value="${this.default}"` : ``} ${this.readonly ? `readonly` : ``} ${this.multiline ? `multiline` : ``}></vscode-inputbox>
+              ${this.renderDescription()}              
+              <${tag} class="long-input" id="${this.id}" name="${this.id}" ${this.default ? `value="${this.default}"` : ``} ${this.readonly ? `readonly` : ``} ${multiline ? `rows="${this.rows}" resize="vertical"` : ''}></${tag}>
           </vscode-form-group>`;
 
       case `paragraph`:

--- a/src/api/CustomUI.ts
+++ b/src/api/CustomUI.ts
@@ -34,6 +34,11 @@ export interface ComplexTab {
 export class Section {
   readonly fields: Field[] = [];
 
+  addHeading(label: string, level: 1 | 2 | 3 | 4 | 5 | 6 = 1) {
+    this.addField(new Field(`heading`, level.toString(), label));
+    return this;
+  }
+
   addHorizontalRule() {
     this.addField(new Field('hr', '', ''));
     return this;
@@ -339,7 +344,7 @@ export class CustomUI extends Section {
   }
 }
 
-export type FieldType = "input" | "password" | "submit" | "buttons" | "checkbox" | "file" | "complexTabs" | "tabs" | "tree" | "select" | "paragraph" | "hr";
+export type FieldType = "input" | "password" | "submit" | "buttons" | "checkbox" | "file" | "complexTabs" | "tabs" | "tree" | "select" | "paragraph" | "hr" | "heading";
 
 export interface TreeListItemIcon {
   branch?: string;
@@ -391,6 +396,9 @@ export class Field {
           <vscode-form-group variant="settings-group">
             ${this.items?.map(item => /* html */`<vscode-button id="${item.id}" style="margin:3px">${item.label}</vscode-button>`).join(``)}
           </vscode-form-group>`;
+
+      case 'heading':
+        return /* html */ `<h${this.id}>${this.label}</h${this.id}>`;
 
       case `hr`:
         return /* html */ `<hr />`;

--- a/src/api/CustomUI.ts
+++ b/src/api/CustomUI.ts
@@ -215,6 +215,10 @@ export class CustomUI extends Section {
             .long-input {
               width: 100%;
             }
+
+            :root{
+              --dropdown-z-index: 666;
+            }
         </style>
     </head>
     

--- a/src/webviews/actions/index.js
+++ b/src/webviews/actions/index.js
@@ -146,7 +146,7 @@ module.exports = class SettingsUI {
         `command`,
         `Command to run`, 
         `Below are available variables based on the Type you have select below. You can specify different commands on each line. Each command run is stateless and run in their own job.`,
-        { multiline: true, default: currentAction.command}
+        { rows: 5, default: currentAction.command}
       )
       .addTabs([
         {


### PR DESCRIPTION
### Changes
Various fixes/enhancement on actions' UI reported/requested in https://github.com/halcyon-tech/vscode-ibmi/issues/1164:
- Command field is now a multi-line, resizable textarea
![image](https://user-images.githubusercontent.com/11096890/227385115-1a80efad-090d-49c5-8978-f63567f81663.png)
- Action name is now displayed when setting its inputs
![image](https://user-images.githubusercontent.com/11096890/227385276-bb95aa7b-48b1-4120-9343-067de98baa86.png)
- Dropdown's z-index has been maxed out to avoid this (could not reproduce it though):
![image](https://user-images.githubusercontent.com/11096890/227385336-0c59fe47-0692-4268-b138-25edc0003d5a.png) 
![image](https://user-images.githubusercontent.com/11096890/227385505-80493077-5f4e-496a-b790-9a03cf4279e4.png)



### Checklist
* [x] have tested my change