### PR TITLE
Fix use of filter parameter on Uris

### DIFF
--- a/src/api/Search.ts
+++ b/src/api/Search.ts
@@ -1,4 +1,5 @@
 
+import { isProtectedFilter } from '../filesystems/qsys/QSysFs';
 import { GlobalConfiguration } from './Configuration';
 import Instance from './Instance';
 import { Tools } from './Tools';
@@ -9,7 +10,7 @@ export namespace Search {
   export interface Result {
     path: string
     lines: Line[]
-    filter?: string
+    readonly?: boolean
     label?: string
   }
 
@@ -88,7 +89,8 @@ export namespace Search {
   }
 
   function parseGrepOutput(output: string, filter?: string, pathTransformer?: (path: string) => string): Result[] {
-    const results: Result[] = []
+    const results: Result[] = [];
+    const readonly = isProtectedFilter(filter);
     for (const line of output.split('\n')) {
       if (!line.startsWith(`Binary`)) {
         const parts = line.split(`:`); //path:line
@@ -98,7 +100,7 @@ export namespace Search {
           result = {
             path,
             lines: [],
-            filter
+            readonly,
           };
           results.push(result);
         }

--- a/src/filesystems/qsys/QSysFs.ts
+++ b/src/filesystems/qsys/QSysFs.ts
@@ -22,16 +22,16 @@ export function getUriFromPath(path: string, options?: QsysFsOptions) {
 
 export function getFilePermission(uri: vscode.Uri): FilePermission | undefined {
     const fsOptions = parseFSOptions(uri);
-    if (instance.getConfig()?.readOnlyMode || fsOptions.readonly || isProtectedFilter(fsOptions.filter)) {
+    if (instance.getConfig()?.readOnlyMode || fsOptions.readonly) {
         return FilePermission.Readonly;
     }
 }
 
-function parseFSOptions(uri: vscode.Uri): QsysFsOptions {
+export function parseFSOptions(uri: vscode.Uri): QsysFsOptions {
     return parse(uri.query);
 }
 
-function isProtectedFilter(filter?: string): boolean {
+export function isProtectedFilter(filter?: string): boolean {
     return filter && instance.getConfig()?.objectFilters.find(f => f.name === filter)?.protected || false;
 }
 

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -125,7 +125,6 @@ export interface FileError {
 }
 
 export interface QsysFsOptions {
-  filter?: string
   readonly?: boolean
 }
 

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -1157,7 +1157,7 @@ class Member extends vscode.TreeItem {
 
     this.contextValue = `member${filter.protected ? `_readonly` : ``}`;
     this.description = member.text;
-    this.resourceUri = getMemberUri(member, { filter: filter.name });
+    this.resourceUri = getMemberUri(member, filter.protected ? {readonly: true} : undefined);
     this.path = this.resourceUri.path;
     this.tooltip = `${this.resourceUri.path}${member.text ? `\n(${member.text})` : ``}`;
     this.command = {

--- a/src/views/searchView.ts
+++ b/src/views/searchView.ts
@@ -62,7 +62,7 @@ export class SearchView implements TreeDataProvider<any> {
 
 class HitSource extends vscode.TreeItem {
   private readonly _path: string;
-  private readonly _filter?: string;
+  private readonly _readonly?: boolean;
 
   constructor(readonly result: Search.Result, readonly term: string) {
     super(result.label ? result.label : path.posix.basename(result.path), vscode.TreeItemCollapsibleState.Expanded);
@@ -72,17 +72,17 @@ class HitSource extends vscode.TreeItem {
     this.iconPath = vscode.ThemeIcon.File;
     this.description = `${hits} hit${hits === 1 ? `` : `s`}`;
     this._path = result.path;
-    this._filter = result.filter;
+    this._readonly = result.readonly;
     this.tooltip = result.path;
   }
 
   async getChildren() : Promise<LineHit[]> {
-    return this.result.lines.map(line => new LineHit(this.term, this._path, line, this._filter));
+    return this.result.lines.map(line => new LineHit(this.term, this._path, line, this._readonly));
   }
 }
 
 class LineHit extends vscode.TreeItem {
-  constructor(term: string, readonly path: string, line: Search.Line, filter?: string) {
+  constructor(term: string, readonly path: string, line: Search.Line, readonly?: boolean) {
     const highlights: [number, number][] = [];
 
     const upperContent = line.content.trim().toUpperCase();
@@ -113,7 +113,7 @@ class LineHit extends vscode.TreeItem {
     this.command = {
       command: `code-for-ibmi.openEditable`,
       title: `Open`,
-      arguments: [this.path, line.number - 1, { filter } as QsysFsOptions]
+      arguments: [this.path, line.number - 1, (readonly ? {readonly: true} : undefined)]
     };
   }
 }


### PR DESCRIPTION
### Changes

* Solves issue that filter query parameter was causing diagnostics to no longer match up (#1173)
* Fixes consistent use of readonly flag where `filter` had a second implication (go and find out if this filter is readonly or not)
* No longer allow readonly sources/objects to have Actions run against them

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
