### PR TITLE
Source date save now checks before using `TRANSLATE` scalar

### DIFF
--- a/src/filesystems/qsys/extendedContent.ts
+++ b/src/filesystems/qsys/extendedContent.ts
@@ -149,7 +149,7 @@ export class ExtendedIBMiContent {
         // Row length is the length of the SLQ string used to insert each row
         const rowLength = recordLength + 55;
         // 450000 is just below the maxiumu length for each insert.
-        const perInsert = Math.floor(450000 / rowLength);
+        const perInsert = Math.floor(400000 / rowLength);
 
         const rowGroups = sliceUp(rows, perInsert);
         rowGroups.forEach(rowGroup => {

--- a/src/filesystems/qsys/extendedContent.ts
+++ b/src/filesystems/qsys/extendedContent.ts
@@ -36,6 +36,7 @@ export class ExtendedIBMiContent {
     mbr = mbr.toUpperCase();
 
     if (config && content) {
+      const sourceColourSupport = GlobalConfiguration.get<boolean>(`showSeuColors`);
       const tempLib = config.tempLibrary;
       const alias = getAliasName(lib, spf, mbr);
       const aliasPath = `${tempLib}.${alias}`;
@@ -58,9 +59,15 @@ export class ExtendedIBMiContent {
         }
       }
 
-      let rows = await content.runSQL(
-        `select srcdat, rtrim(translate(srcdta, ${SEU_GREEN_UL_RI_temp}, ${SEU_GREEN_UL_RI})) as srcdta from ${aliasPath}`
-      );
+      let rows;
+      if (sourceColourSupport)
+        rows = await content.runSQL(
+          `select srcdat, rtrim(translate(srcdta, ${SEU_GREEN_UL_RI_temp}, ${SEU_GREEN_UL_RI})) as srcdta from ${aliasPath}`
+        );
+      else
+        rows = await content.runSQL(
+          `select srcdat, srcdta from ${aliasPath}`
+        );  
 
       if (rows.length === 0) {
         rows.push({

--- a/src/filesystems/qsys/extendedContent.ts
+++ b/src/filesystems/qsys/extendedContent.ts
@@ -146,7 +146,7 @@ export class ExtendedIBMiContent {
         //We assume the alias still exists....
         const query: string[] = [];
 
-        // Row length is the length of the SLQ string used to insert each row
+        // Row length is the length of the SQL string used to insert each row
         const rowLength = recordLength + 55;
         // 450000 is just below the maxiumu length for each insert.
         const perInsert = Math.floor(400000 / rowLength);


### PR DESCRIPTION
### Changes

SQL `TRANSLATE` is expensive when inserting a lot of data. This was very visible when working with large files. Translate is only required for source colour support, so therefore the save should only use translate when source colour is enabled.

I don't use source colours and this has sped up the save process significantly.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
