### PR TITLE
Fix/workspace root level source files diagnostic

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,3 +44,4 @@ Thanks so much to everyone [who has contributed](https://github.com/halcyon-tech
 * [@steph-beneschan-256](https://github.com/steph-beneschan-256)
 * [@novy400](https://github.com/novy400)
 * [@beckhamrryyaann](https://github.com/beckhamrryyaann)
+* [@angelorpa](https://github.com/angelorpa)

--- a/src/api/Storage.ts
+++ b/src/api/Storage.ts
@@ -137,4 +137,9 @@ export class ConnectionStorage extends Storage {
   setDebugCommands(existingCommands: DebugCommands) {
     return this.set(DEBUG_KEY, existingCommands);
   }
+
+  getWorkspaceDeployPath(workspaceFolder : vscode.WorkspaceFolder){
+    const deployDirs = this.get<DeploymentPath>(DEPLOYMENT_KEY) || {};
+    return deployDirs[workspaceFolder.uri.fsPath].toLowerCase();
+  }
 }


### PR DESCRIPTION
### Changes

- add a the function getWorkspaceDeployPath to Storage.ts to get the remote deploy path for a local worksapace
- modify refreshDiagnostics function from CompileTools.ts to get the right diagnostic target file when this es located at workspace root directory level.

### Checklist

* [x] have tested my change
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [x] **for feature PRs**: PR only includes one feature enhancement.

### Test result images

compilation of a source file located at worksapce root directory level
![image](https://user-images.githubusercontent.com/10833316/227736712-2a403bb4-31fe-493d-b3de-dd898f9bf31d.png)

compilation of a source file located one level inside the root
![image](https://user-images.githubusercontent.com/10833316/227736863-b12c4565-87c7-4ad5-bb35-69769e57a69e.png)
