### PR TITLE
Source dates: Refresh same line after using spaces

### DIFF
--- a/src/filesystems/qsys/sourceDateHandler.ts
+++ b/src/filesystems/qsys/sourceDateHandler.ts
@@ -310,7 +310,9 @@ export class SourceDateHandler {
         this._diffRefreshGutter(document);
       }
 
-      this.lineEditedBefore = currentEditingLine || 0;
+      if (event.contentChanges.length > 0) {
+        this.lineEditedBefore = currentEditingLine || 0;
+      }
     }
   }
 


### PR DESCRIPTION
### Changes

Saw that the line wasn't refreshing if the first changed character was a space. This fixes that.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
