### PR TITLE
Ensure that readonly is boolean

### DIFF
--- a/src/filesystems/qsys/QSysFs.ts
+++ b/src/filesystems/qsys/QSysFs.ts
@@ -28,7 +28,10 @@ export function getFilePermission(uri: vscode.Uri): FilePermission | undefined {
 }
 
 export function parseFSOptions(uri: vscode.Uri): QsysFsOptions {
-    return parse(uri.query);
+    const parameters = parse(uri.query);
+    return {
+        readonly: parameters.readonly === `true`
+    };
 }
 
 export function isProtectedFilter(filter?: string): boolean {


### PR DESCRIPTION
### Changes

Seems that `query` always return string values, so `false` as a string is a truthy value.

Solves #1185.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
