### PR TITLE
Fixed CustomUI export

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -97,7 +97,7 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
   Sandbox.handleStartup();
   Sandbox.registerUriHandler(context);
 
-  return { instance, CustomUI, Field, baseContext: context, deploy: Deployment.deploy, evfeventParser: parseErrors };
+  return { instance, customUI: () => new CustomUI(), baseContext: context, deploy: Deployment.deploy, evfeventParser: parseErrors };
 }
 
 // this method is called when your extension is deactivated

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -1,12 +1,12 @@
 import { ExtensionContext, Uri } from "vscode";
 import Instance from "./api/Instance";
 import { Ignore } from 'ignore'
+import { CustomUI, Field } from "./api/CustomUI";
 
 export interface CodeForIBMi {
   instance: Instance,
   baseContext: ExtensionContext,
-  CustomUI: object, //CustomUI: typeof CustomUI
-  Field: object //Field: typeof Field;
+  customUI: () => CustomUI,
   deploy: (parameters: DeploymentParameters) => Promise<boolean>
   evfeventParser: (lines: string[]) => Map<string, FileError[]>
 }


### PR DESCRIPTION
### Changes
Changes the way `CustomUI` is exposed through the API.
A call to `api.customUI` will provide a new instance of `CustomUI` to play with.

#### Example:
```typescript
async function helloUI(codei: CodeForIBMi) {
	const customUI = codei.customUI();
	const page = await customUI
		.addHeading("Hi there", 1)
		.addCheckbox("check", "This is fine", "Maybe...")
		.addInput("txt", "A message", "Obviously")
		.addButtons({ id: "save", label: "Save" })
		.loadPage<any>("Hello");

	if (page?.data) {
		page.panel.dispose();
		vscode.window.showInformationMessage(page.data.txt);
	};
}
```


### Checklist
* [x] have tested my change