### PR TITLE
Fixed dropped connection handling + allow force disconnection

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -109,7 +109,7 @@ export default class IBMi {
   /**
    * @returns {Promise<{success: boolean, error?: any}>} Was succesful at connecting or not.
    */
-  async connect(connectionObject: ConnectionData): Promise<{ success: boolean, error?: any }> {
+  async connect(connectionObject: ConnectionData, reconnecting?: boolean): Promise<{ success: boolean, error?: any }> {
     try {
       connectionObject.keepaliveInterval = 35000;
       // Make sure we're not passing any blank strings, as node_ssh will try to validate it
@@ -143,7 +143,7 @@ export default class IBMi {
           }, `Yes`);
 
           if (choice === `Yes`) {
-            this.connect(connectionObject);
+            this.connect(connectionObject, true);
           } else {
             vscode.commands.executeCommand(`code-for-ibmi.disconnect`);
           };
@@ -590,7 +590,7 @@ export default class IBMi {
         try {
           // make sure chsh and bash is installed
           if (this.remoteFeatures[`chsh`] &&
-              this.remoteFeatures[`bash`]) {
+            this.remoteFeatures[`bash`]) {
 
             const bashShellPath = '/QOpenSys/pkgs/bin/bash';
             const commandShellResult = await this.sendCommand({
@@ -602,7 +602,7 @@ export default class IBMi {
               if (userDefaultShell !== bashShellPath) {
 
                 vscode.window.showInformationMessage(`IBM recommends using bash as your default shell.`, `Set shell to bash`, `Read More`,).then(async choice => {
-                  switch (choice) { 
+                  switch (choice) {
                     case `Set shell to bash`:
                       const commandSetBashResult = await this.sendCommand({
                         command: `/QOpenSys/pkgs/bin/chsh -s /QOpenSys/pkgs/bin/bash`
@@ -650,10 +650,12 @@ export default class IBMi {
           vscode.window.showWarningMessage(`Code for IBM i may not function correctly until your user has a home directory. Please set a home directory using CHGUSRPRF USRPRF(${connectionObject.username.toUpperCase()}) HOMEDIR('/home/${connectionObject.username.toLowerCase()}')`);
         }
 
-        instance.setConnection(this);
-        vscode.workspace.getConfiguration().update(`workbench.editor.enablePreview`, false, true);
-        await vscode.commands.executeCommand(`setContext`, `code-for-ibmi:connected`, true);
-        instance.fire("connected");
+        if (!reconnecting) {
+          instance.setConnection(this);
+          vscode.workspace.getConfiguration().update(`workbench.editor.enablePreview`, false, true);
+          await vscode.commands.executeCommand(`setContext`, `code-for-ibmi:connected`, true);
+          instance.fire("connected");
+        }
 
         return {
           success: true
@@ -781,7 +783,7 @@ export default class IBMi {
   }
 
   async end() {
-    this.client.connection.removeAllListeners();
+    this.client.connection?.removeAllListeners();
     this.client.dispose();
 
     if (this.outputChannel) {

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -132,20 +132,25 @@ export default class IBMi {
         this.currentPort = connectionObject.port;
         this.currentUser = connectionObject.username;
 
-        this.outputChannel = vscode.window.createOutputChannel(`Code for IBM i: ${this.currentConnectionName}`);
+        if (!reconnecting) {
+          this.outputChannel = vscode.window.createOutputChannel(`Code for IBM i: ${this.currentConnectionName}`);
+        }
 
         let tempLibrarySet = false;
 
         const disconnected = async () => {
           const choice = await vscode.window.showWarningMessage(`Connection lost`, {
             modal: true,
-            detail: `Connection to ${this.currentConnectionName} has timed out. Would you like to reconnect?`
+            detail: `Connection to ${this.currentConnectionName} has dropped. Would you like to reconnect?`
           }, `Yes`);
 
+          let disconnect = true;
           if (choice === `Yes`) {
-            this.connect(connectionObject, true);
-          } else {
-            vscode.commands.executeCommand(`code-for-ibmi.disconnect`);
+            disconnect = !(await this.connect(connectionObject, true)).success;
+          }
+
+          if (disconnect) {
+            this.end();
           };
         };
 
@@ -666,6 +671,13 @@ export default class IBMi {
 
       if (this.client.isConnected()) {
         this.client.dispose();
+      }
+
+      if (reconnecting && await vscode.window.showWarningMessage(`Could not reconnect`, {
+        modal: true,
+        detail: `Reconnection to ${this.currentConnectionName} has failed. Would you like to try again?\n\n${e}`
+      }, `Yes`)) {
+        return this.connect(connectionObject, true);
       }
 
       return {

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -61,14 +61,13 @@ export async function disconnect(): Promise<boolean> {
     if (!document.isClosed && [`member`, `streamfile`].includes(document.uri.scheme)) {
       if (document.isDirty) {
         if (doDisconnect) {
-          await Promise.all([
-            vscode.window.showErrorMessage(`Cannot disconnect while files have not been saved.`),
-            vscode.window.showTextDocument(document)
-          ]);
-
-          doDisconnect = false;
+          if(await vscode.window.showTextDocument(document).then(() => vscode.window.showErrorMessage(`Cannot disconnect while files have not been saved.`, 'Disconnect anyway'))){
+            break;
+          }
+          else{
+            doDisconnect = false;
+          }
         }
-
       } else {
         await vscode.window.showTextDocument(document);
         await vscode.commands.executeCommand(`workbench.action.closeActiveEditor`);
@@ -79,7 +78,7 @@ export async function disconnect(): Promise<boolean> {
   if (doDisconnect) {
     const connection = instance.getConnection();
     if (connection) {
-      connection.end();
+      await connection.end();
     }
   }
 

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -416,8 +416,6 @@ async function onConnected(context: vscode.ExtensionContext) {
 }
 
 async function onDisconnected() {
-  vscode.workspace.openTextDocument()
-
   // Close the tabs with no dirty editors
   vscode.window.tabGroups.all
   .filter(group => !group.tabs.some(tab => tab.isDirty))

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -419,8 +419,10 @@ async function onConnected(context: vscode.ExtensionContext) {
 }
 
 async function onDisconnected() {
-  // Close the tabs
-  vscode.window.tabGroups.all.forEach(group => {
+  // Close the tabs with no dirty editors
+  vscode.window.tabGroups.all
+  .filter(group => !group.tabs.some(tab => tab.isDirty))
+  .forEach(group => {
     vscode.window.tabGroups.close(group);
   });
 


### PR DESCRIPTION
### Changes
- Fixed disconnection failing when connection was dropped unexpectedly
- Allow to try reconnecting at will; if re-connecting fails, the following modal dialog will show up:
![image](https://user-images.githubusercontent.com/11096890/228360146-a1964c9c-127c-4e6b-8437-db14ad0d9c52.png)
- Allow to force disconnection when dirty editors are still opened
![image](https://user-images.githubusercontent.com/11096890/228359661-9d30abae-f7b2-411f-9137-43b2aeabcd57.png)
- Keep dirty editors opened when disconnecting forcefully

### Checklist
* [x] have tested my change
