### PR TITLE
runSQL API support comments not starting in position 0 of a line

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -186,8 +186,10 @@ export default class IBMiContent {
       // Well, the fun part about db2 is that it always writes to standard out.
       // It does not write to standard error at all.
 
-      // We join all new lines together
-      //statement = statement.replace(/\n/g, ` `);
+      // if comments present in sql statement, sql string needs to be checked
+      if (statement.search(`-- `) > -1) {
+        statement = this.fixCommentsInSQLString(statement);
+      }
 
       const output = await this.ibmi.sendCommand({
         command: `LC_ALL=EN_US.UTF-8 system "call QSYS/QZDFMDB2 PARM('-d' '-i' '-t')"`,
@@ -484,6 +486,34 @@ export default class IBMiContent {
       throw new Error(fileListResult.stderr);
     }
 
+  }
+
+  /**
+   * Fix Comments in an SQL string so that the comments always start at position 0 of the line.
+   * Required to work with QZDFMDB2.
+   * @param inSql; sql statement
+   * @returns correctly formattted sql string containing comments
+   */
+  private fixCommentsInSQLString(inSql: string): string {
+    const newLine: string = `\n`;
+    let parsedSql: string = ``;
+
+    inSql.split(newLine)
+      .forEach(item => {
+        let goodLine = item + newLine;
+
+        const pos = item.search(`-- `);
+        if (pos > 0) {
+          goodLine = item.slice(0, pos) + 
+                     newLine +
+                     item.slice(pos) +
+                     newLine;
+        }
+        parsedSql += goodLine;
+        
+      });
+
+    return parsedSql;
   }
 
   /**

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -187,7 +187,7 @@ export default class IBMiContent {
       // It does not write to standard error at all.
 
       // if comments present in sql statement, sql string needs to be checked
-      if (statement.search(`-- `) > -1) {
+      if (statement.search(`--`) > -1) {
         statement = this.fixCommentsInSQLString(statement);
       }
 
@@ -502,7 +502,7 @@ export default class IBMiContent {
       .forEach(item => {
         let goodLine = item + newLine;
 
-        const pos = item.search(`-- `);
+        const pos = item.search(`--`);
         if (pos > 0) {
           goodLine = item.slice(0, pos) + 
                      newLine +


### PR DESCRIPTION
### Changes

address issue #599.  Fixes SQL Statement if comments start anywhere besides position 0 in a line.

Tested:
<img width="514" alt="image" src="https://user-images.githubusercontent.com/6051612/228415819-1bfbb5f1-d9da-4c5e-9a41-b2a1007c9aad.png">

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [x] **for feature PRs**: PR only includes one feature enhancement.
