### PR TITLE
Do not allow the same webview to be opened multiple times

### DIFF
--- a/src/webviews/actions/index.js
+++ b/src/webviews/actions/index.js
@@ -51,11 +51,11 @@ module.exports = class SettingsUI {
         { id: `duplicateAction`, label: `Duplicate`}
       );
     
-    const {panel, data} = await ui.loadPage(`Work with Actions`);
-    if (data) {
-      panel.dispose();
+    const page = await ui.loadPage(`Work with Actions`);
+    if (page && page.data) {
+      page.panel.dispose();
 
-      switch (data.buttons) {
+      switch (page.data.buttons) {
       case `newAction`:
         this.WorkAction(-1);
         break;
@@ -63,7 +63,7 @@ module.exports = class SettingsUI {
         this.DuplicateAction();
         break;
       default:
-        this.WorkAction(Number(data.actions));
+        this.WorkAction(Number(page.data.actions));
         break;
       }
     }
@@ -218,8 +218,9 @@ module.exports = class SettingsUI {
       );
 
     while (stayOnPanel === true) {
-      const {panel, data} = await ui.loadPage(uiTitle);
-      if (data) {
+      const page = await ui.loadPage(uiTitle);
+      if (page && page.data) {        
+        const data = page.data;
         switch (data.buttons) {
         case `deleteAction`:
           const result = await vscode.window.showInformationMessage(`Are you sure you want to delete this action?`, { modal:true }, `Yes`, `No`)
@@ -262,7 +263,7 @@ module.exports = class SettingsUI {
         stayOnPanel=false;
       }
 
-      panel.dispose();
+      page.panel.dispose();
     }
 
     this.MainMenu();

--- a/src/webviews/variables/index.js
+++ b/src/webviews/variables/index.js
@@ -31,10 +31,11 @@ module.exports = class SettingsUI {
       ], `Create or maintain custom variables. Custom variables can be used in any Action in this connection.`)
       .addButtons({ id: `newVariable`, label: `New Variable` });
 
-    const { panel, data } = await ui.loadPage(`Work with Variables`);
-    if (data) {
-      panel.dispose();
-
+    const page = await ui.loadPage(`Work with Variables`);
+    if (page && page.data) {
+      page.panel.dispose();
+      
+      const data = page.data;
       switch (data.buttons) {
       case `newVariable`:
         this.WorkVariable(-1);
@@ -74,10 +75,11 @@ module.exports = class SettingsUI {
       .addInput(`value`, `Variable value`, ``, { default: currentVariable.value })
       .addButtons({ id: `save`, label: `Save` }, { id: `delete`, label: `Delete` });
 
-    const { panel, data } = await ui.loadPage(`Work with Variable`);
-    if (data) {
-      panel.dispose();
-
+    const page = await ui.loadPage(`Work with Variable`);
+    if (page && page.data) {
+      page.panel.dispose();
+      
+      const data = page.data;
       switch (data.buttons) {
       case `delete`:
         if (id >= 0) {


### PR DESCRIPTION
### Changes
This PR will keep track of opened webviews and prevent multiple occurrences of the same webview (i.e. with the same title) to be opened.
If a webview is already opened and a request to open it again is issued, the opened webview will be revealed.

### Checklist
* [x] have tested my change
* [x] updated relevant documentation
