### PR TITLE
Fixed member opening after create/copy operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"icon": "icon.png",
 	"displayName": "Code for IBM i",
 	"description": "Maintain your RPGLE, CL, COBOL, C/CPP on IBM i right from Visual Studio Code.",
-	"version": "1.7.11",
+	"version": "1.7.12",
 	"keywords": [
 		"ibmi",
 		"rpgle",

--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -282,7 +282,7 @@ export namespace CompileTools {
             case `member`:
               const memberDetail = connection.parserMemberPath(uri.path);
               evfeventInfo.library = memberDetail.library;
-              evfeventInfo.object = memberDetail.member;
+              evfeventInfo.object = memberDetail.name;
               evfeventInfo.extension = memberDetail.extension;
               evfeventInfo.asp = memberDetail.asp;
 
@@ -292,8 +292,8 @@ export namespace CompileTools {
               variables.set(`&OPENSPFL`, memberDetail.file.toLowerCase());
               variables.set(`&OPENSPF`, memberDetail.file);
 
-              variables.set(`&OPENMBRL`, memberDetail.member.toLowerCase());
-              variables.set(`&OPENMBR`, memberDetail.member);
+              variables.set(`&OPENMBRL`, memberDetail.name.toLowerCase());
+              variables.set(`&OPENMBR`, memberDetail.name);
 
               variables.set(`&EXTL`, memberDetail.extension.toLowerCase());
               variables.set(`&EXT`, memberDetail.extension);

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -851,7 +851,8 @@ export default class IBMi {
       throw new Error(`Invalid Source File name: ${file}`);
     }
 
-    if (!basename.includes(`.`) || !basename.substring(basename.lastIndexOf('.') + 1)) {
+    //Having a blank extension is allowed but the . in the path is required
+    if (!basename.includes(`.`)) {
       throw new Error(`Source Type extension is required.`);
     }
     const name = basename.substring(0, basename.lastIndexOf(`.`));

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -837,7 +837,7 @@ export default class IBMi {
       throw new Error(`Invalid Source File name: ${file}`);
     }
 
-    if (!basename.includes(`.`)) {
+    if (!basename.includes(`.`) || !basename.substring(basename.lastIndexOf('.') + 1)) {
       throw new Error(`Source Type extension is required.`);
     }
     const name = basename.substring(0, basename.lastIndexOf(`.`));

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -5,17 +5,11 @@ import { ConnectionConfiguration } from "./Configuration";
 
 import { Tools } from './Tools';
 import path from 'path';
-import { ConnectionData, CommandData, StandardIO, CommandResult } from "../typings";
+import { ConnectionData, CommandData, StandardIO, CommandResult, IBMiMember } from "../typings";
 import * as configVars from './configVars';
 import { instance } from "../instantiate";
-import IBMiContent from "./IBMiContent";
 
-export interface MemberParts {
-  asp?: string
-  library: string
-  file: string
-  member: string
-  extension: string
+export interface MemberParts extends IBMiMember {
   basename: string
 }
 
@@ -846,11 +840,11 @@ export default class IBMi {
     if (!basename.includes(`.`)) {
       throw new Error(`Source Type extension is required.`);
     }
-    const member = basename.substring(0, basename.lastIndexOf(`.`));
+    const name = basename.substring(0, basename.lastIndexOf(`.`));
     const extension = basename.substring(basename.lastIndexOf(`.`) + 1).trim();
 
-    if (!validQsysName.test(member)) {
-      throw new Error(`Invalid Source Member name: ${member}`);
+    if (!validQsysName.test(name)) {
+      throw new Error(`Invalid Source Member name: ${name}`);
     }
     // The extension/source type has nearly the same naming rules as
     // the objects, except that a period is not allowed.  We can reuse
@@ -866,7 +860,7 @@ export default class IBMi {
       file,
       extension,
       basename,
-      member,
+      name,
       asp
     };
   }

--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -44,7 +44,7 @@ export async function initialize(context: ExtensionContext) {
         case `member`:
           const memberPath = connection.parserMemberPath(uri.path);
           qualifiedPath.library = memberPath.library;
-          qualifiedPath.object = memberPath.member;
+          qualifiedPath.object = memberPath.name;
           break;
         case `streamfile`:
         case `file`:

--- a/src/filesystems/ifs.js
+++ b/src/filesystems/ifs.js
@@ -7,6 +7,10 @@ module.exports = class qsysFs {
     this.emitter = new vscode.EventEmitter();
     this.onDidChangeFile = this.emitter.event;
   }
+
+  watch(uri, options) {
+    return { dispose: () => { } };
+  }
   
   /**
    * 
@@ -49,5 +53,17 @@ module.exports = class qsysFs {
    */
   rename(oldUri, newUri, options) {
     console.log({oldUri, newUri, options});
+  }
+
+  readDirectory(uri) {
+    throw new Error(`Method not implemented.`);
+  }
+
+  createDirectory(uri) {
+    throw new Error(`Method not implemented.`);
+  }
+
+  delete(uri, options,) {
+    throw new Error(`Method not implemented.`);
   }
 }

--- a/src/filesystems/qsys/QSysFs.ts
+++ b/src/filesystems/qsys/QSysFs.ts
@@ -94,7 +94,7 @@ export class QSysFS implements vscode.FileSystemProvider {
         const contentApi = instance.getContent();
         const connection = instance.getConnection();
         if (connection && contentApi) {
-            const { asp, library, file, member } = connection.parserMemberPath(uri.path);
+            const { asp, library, file, name: member } = connection.parserMemberPath(uri.path);
             const memberContent = this.extendedMemberSupport ?
                 await this.extendedContent.downloadMemberContentWithDates(asp, library, file, member) :
                 await contentApi.downloadMemberContent(asp, library, file, member);
@@ -114,7 +114,7 @@ export class QSysFS implements vscode.FileSystemProvider {
         const contentApi = instance.getContent();
         const connection = instance.getConnection();
         if (connection && contentApi) {
-            const { asp, library, file, member } = connection.parserMemberPath(uri.path);
+            const { asp, library, file, name: member } = connection.parserMemberPath(uri.path);
             this.extendedMemberSupport ?
                 await this.extendedContent.uploadMemberContentWithDates(asp, library, file, member, content.toString()) :
                 await contentApi.uploadMemberContent(asp, library, file, member, content);

--- a/src/filesystems/qsys/sourceDateHandler.ts
+++ b/src/filesystems/qsys/sourceDateHandler.ts
@@ -116,7 +116,7 @@ export class SourceDateHandler {
     if (this.enabled && document.uri.scheme === `member` && document.isClosed) {
       const connection = instance.getConnection();
       if (connection) {
-        const { library, file, member } = connection.parserMemberPath(document.uri.path);
+        const { library, file, name: member } = connection.parserMemberPath(document.uri.path);
 
         const alias = getAliasName(library, file, member);
         this.baseDates.delete(alias);
@@ -164,7 +164,7 @@ export class SourceDateHandler {
     const connection = instance.getConnection();
     if (connection) {
       const path = event.document.uri.path;
-      const { library, file, member } = connection.parserMemberPath(path);
+      const { library, file, name: member } = connection.parserMemberPath(path);
 
       const alias = getAliasName(library, file, member);
       const sourceDates = this.baseDates.get(alias);
@@ -262,7 +262,7 @@ export class SourceDateHandler {
       const connection = instance.getConnection();
       if (connection) {
         const path = editor.document.uri.path;
-        const { library, file, member } = connection.parserMemberPath(path);
+        const { library, file, name: member } = connection.parserMemberPath(path);
 
         const alias = getAliasName(library, file, member);;
 
@@ -319,7 +319,7 @@ export class SourceDateHandler {
     if (connection) {
       const lengthDiags: vscode.Diagnostic[] = [];
       const path = connection.parserMemberPath(document.uri.path);
-      const lib = path.library, file = path.file, fullName = path.member;
+      const lib = path.library, file = path.file, fullName = path.name;
       const alias = getAliasName(lib, file, fullName);
       const recordLength = this.recordLengths.get(alias);
 
@@ -346,7 +346,7 @@ export class SourceDateHandler {
 
       if (connection && config && config.sourceDateGutter) {
         const path = document.uri.path;
-        const { library, file, member } = connection.parserMemberPath(path);
+        const { library, file, name: member } = connection.parserMemberPath(path);
         const alias = getAliasName(library, file, member);;
 
         const sourceDates = this.baseDates.get(alias);

--- a/src/filesystems/qsys/sourceDateHandler.ts
+++ b/src/filesystems/qsys/sourceDateHandler.ts
@@ -310,7 +310,9 @@ export class SourceDateHandler {
         this._diffRefreshGutter(document);
       }
 
-      this.lineEditedBefore = currentEditingLine || 0;
+      if (event.contentChanges.length > 0) {
+        this.lineEditedBefore = currentEditingLine || 0;
+      }
     }
   }
 

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -61,14 +61,13 @@ export async function disconnect(): Promise<boolean> {
     if (!document.isClosed && [`member`, `streamfile`].includes(document.uri.scheme)) {
       if (document.isDirty) {
         if (doDisconnect) {
-          await Promise.all([
-            vscode.window.showErrorMessage(`Cannot disconnect while files have not been saved.`),
-            vscode.window.showTextDocument(document)
-          ]);
-
-          doDisconnect = false;
+          if(await vscode.window.showTextDocument(document).then(() => vscode.window.showErrorMessage(`Cannot disconnect while files have not been saved.`, 'Disconnect anyway'))){
+            break;
+          }
+          else{
+            doDisconnect = false;
+          }
         }
-
       } else {
         await vscode.window.showTextDocument(document);
         await vscode.commands.executeCommand(`workbench.action.closeActiveEditor`);
@@ -79,7 +78,7 @@ export async function disconnect(): Promise<boolean> {
   if (doDisconnect) {
     const connection = instance.getConnection();
     if (connection) {
-      connection.end();
+      await connection.end();
     }
   }
 

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -416,8 +416,6 @@ async function onConnected(context: vscode.ExtensionContext) {
 }
 
 async function onDisconnected() {
-  vscode.workspace.openTextDocument()
-
   // Close the tabs with no dirty editors
   vscode.window.tabGroups.all
   .filter(group => !group.tabs.some(tab => tab.isDirty))

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -419,8 +419,10 @@ async function onConnected(context: vscode.ExtensionContext) {
 }
 
 async function onDisconnected() {
-  // Close the tabs
-  vscode.window.tabGroups.all.forEach(group => {
+  // Close the tabs with no dirty editors
+  vscode.window.tabGroups.all
+  .filter(group => !group.tabs.some(tab => tab.isDirty))
+  .forEach(group => {
     vscode.window.tabGroups.close(group);
   });
 

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -94,8 +94,8 @@ export interface IBMiMember {
   file: string
   name: string
   extension: string
-  recordLength: number
-  text: string
+  recordLength?: number
+  text?: string
   asp?: string
 }
 


### PR DESCRIPTION
### Changes
The member URI used to open the created/copied was wrong and prevented it from being opened right after its creation.
The commands now use `vscode.open` and `getMemberUri` to open the new member.

Member copy/creation process has been enhanced:
- Target name/path gets validated by vscode `showInput` API
- User can choose to retry in case of failure
- The process runs with a progress notification

### Checklist
* [x] have tested my change
