### PR TITLE
Fix for 1.77.0: Include unused methods in IFS FS provider

### DIFF
--- a/src/filesystems/ifs.js
+++ b/src/filesystems/ifs.js
@@ -7,6 +7,10 @@ module.exports = class qsysFs {
     this.emitter = new vscode.EventEmitter();
     this.onDidChangeFile = this.emitter.event;
   }
+
+  watch(uri, options) {
+    return { dispose: () => { } };
+  }
   
   /**
    * 
@@ -49,5 +53,17 @@ module.exports = class qsysFs {
    */
   rename(oldUri, newUri, options) {
     console.log({oldUri, newUri, options});
+  }
+
+  readDirectory(uri) {
+    throw new Error(`Method not implemented.`);
+  }
+
+  createDirectory(uri) {
+    throw new Error(`Method not implemented.`);
+  }
+
+  delete(uri, options,) {
+    throw new Error(`Method not implemented.`);
   }
 }


### PR DESCRIPTION
### Changes

* Adds missing methods to IFS file system provider that are now required in 1.77.0
* Copied directory from `QSysFs.ts` which does the exact same thing

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
