### PR TITLE
Proposal: test cases UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1500,6 +1500,11 @@
 					"id": "ifsBrowser",
 					"name": "IFS Browser",
 					"when": "code-for-ibmi:connected && code-for-ibmi:ifsBrowserDisabled !== true"
+				},
+				{
+					"id": "testingView",
+					"name": "Test cases",
+					"when": "code-for-ibmi:connected && code-for-ibmi:testing"
 				}
 			],
 			"ibmi-search": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -102,7 +102,7 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
   console.log(`Developer environment: ${process.env.DEV}`);
   if (process.env.DEV) {
     // Run tests if not in production build
-    initialise();
+    initialise(context);
   }
 
   return { instance, customUI: () => new CustomUI(), deploy: Deployment.deploy, evfeventParser: parseErrors };

--- a/src/testing/connection.ts
+++ b/src/testing/connection.ts
@@ -2,128 +2,131 @@ import assert from "assert";
 import { TestSuite } from ".";
 import { instance } from "../instantiate";
 
-export const ConnectionSuite: TestSuite = [
-  {name: `Test sendCommand`, test: async () => {
-    const connection = instance.getConnection();
-
-    const result = await connection?.sendCommand({
-      command: `echo "Hello world"`,
-    });
-
-    assert.strictEqual(result?.code, 0);
-    assert.strictEqual(result?.stdout, `Hello world`);
-  }},
-
-  {name: `Test sendCommand home directory`, test: async () => {
-    const connection = instance.getConnection();
-
-    const resultA = await connection?.sendCommand({
-      command: `pwd`,
-      directory: `/QSYS.LIB`
-    });
-
-    assert.strictEqual(resultA?.code, 0);
-    assert.strictEqual(resultA?.stdout, `/QSYS.LIB`);
-
-    const resultB = await connection?.sendCommand({
-      command: `pwd`,
-      directory: `/home`
-    });
-
-    assert.strictEqual(resultB?.code, 0);
-    assert.strictEqual(resultB?.stdout, `/home`);
-
-    const resultC = await connection?.sendCommand({
-      command: `pwd`,
-      directory: `/badnaughty`
-    });
-
-    assert.notStrictEqual(resultC?.stdout, `/badnaughty`);
-  }},
-
-  {name: `Test sendCommand with environment variables`, test: async () => {
-    const connection = instance.getConnection();
-
-    const result = await connection?.sendCommand({
-      command: `echo "$vara $varB $VARC"`,
-      env: {
-        vara: `Hello`,
-        varB: `world`,
-        VARC: `cool`
+export const ConnectionSuite: TestSuite = {
+  name: `Connection tests`,
+  tests: [
+    {name: `Test sendCommand`, test: async () => {
+      const connection = instance.getConnection();
+  
+      const result = await connection?.sendCommand({
+        command: `echo "Hello world"`,
+      });
+  
+      assert.strictEqual(result?.code, 0);
+      assert.strictEqual(result?.stdout, `Hello world`);
+    }},
+  
+    {name: `Test sendCommand home directory`, test: async () => {
+      const connection = instance.getConnection();
+  
+      const resultA = await connection?.sendCommand({
+        command: `pwd`,
+        directory: `/QSYS.LIB`
+      });
+  
+      assert.strictEqual(resultA?.code, 0);
+      assert.strictEqual(resultA?.stdout, `/QSYS.LIB`);
+  
+      const resultB = await connection?.sendCommand({
+        command: `pwd`,
+        directory: `/home`
+      });
+  
+      assert.strictEqual(resultB?.code, 0);
+      assert.strictEqual(resultB?.stdout, `/home`);
+  
+      const resultC = await connection?.sendCommand({
+        command: `pwd`,
+        directory: `/badnaughty`
+      });
+  
+      assert.notStrictEqual(resultC?.stdout, `/badnaughty`);
+    }},
+  
+    {name: `Test sendCommand with environment variables`, test: async () => {
+      const connection = instance.getConnection();
+  
+      const result = await connection?.sendCommand({
+        command: `echo "$vara $varB $VARC"`,
+        env: {
+          vara: `Hello`,
+          varB: `world`,
+          VARC: `cool`
+        }
+      });
+  
+      assert.strictEqual(result?.code, 0);
+      assert.strictEqual(result?.stdout, `Hello world cool`);
+    }},
+  
+    {name: `Test getTempRemote`, test: async () => {
+      const connection = instance.getConnection();
+  
+      const fileA = connection?.getTempRemote(`/some/file`);
+      const fileB = connection?.getTempRemote(`/some/badfile`);
+      const fileC = connection?.getTempRemote(`/some/file`);
+  
+      assert.strictEqual(fileA, fileC);
+      assert.notStrictEqual(fileA, fileB);
+    }},
+  
+    {name: `Test parserMemberPath (simple)`, test: async () => {
+      const connection = instance.getConnection();
+  
+      const memberA = connection?.parserMemberPath(`/thelib/thespf/thembr.mbr`);
+  
+      assert.strictEqual(memberA?.asp, undefined);
+      assert.strictEqual(memberA?.library, `THELIB`);
+      assert.strictEqual(memberA?.file, `THESPF`);
+      assert.strictEqual(memberA?.name, `THEMBR`);
+      assert.strictEqual(memberA?.extension, `MBR`);
+      assert.strictEqual(memberA?.basename, `THEMBR.MBR`);
+    }},
+  
+    {name: `Test parserMemberPath (ASP)`, test: async () => {
+      const connection = instance.getConnection();
+  
+      const memberA = connection?.parserMemberPath(`/theasp/thelib/thespf/thembr.mbr`);
+  
+      assert.strictEqual(memberA?.asp, `THEASP`);
+      assert.strictEqual(memberA?.library, `THELIB`);
+      assert.strictEqual(memberA?.file, `THESPF`);
+      assert.strictEqual(memberA?.name, `THEMBR`);
+      assert.strictEqual(memberA?.extension, `MBR`);
+      assert.strictEqual(memberA?.basename, `THEMBR.MBR`);
+    }},
+  
+    {name: `Test parserMemberPath (no root)`, test: async () => {
+      const connection = instance.getConnection();
+  
+      const memberA = connection?.parserMemberPath(`thelib/thespf/thembr.mbr`);
+  
+      assert.strictEqual(memberA?.asp, undefined);
+      assert.strictEqual(memberA?.library, `THELIB`);
+      assert.strictEqual(memberA?.file, `THESPF`);
+      assert.strictEqual(memberA?.name, `THEMBR`);
+      assert.strictEqual(memberA?.extension, `MBR`);
+      assert.strictEqual(memberA?.basename, `THEMBR.MBR`);
+    }},
+  
+    {name: `Test parserMemberPath (no extension)`, test: async () => {
+      const connection = instance.getConnection();
+  
+      try {
+        const memberA = connection?.parserMemberPath(`thelib/thespf/thembr`);
+      } catch (e: any) {
+        assert.strictEqual(e.message, `Source Type extension is required.`);
       }
-    });
-
-    assert.strictEqual(result?.code, 0);
-    assert.strictEqual(result?.stdout, `Hello world cool`);
-  }},
-
-  {name: `Test getTempRemote`, test: async () => {
-    const connection = instance.getConnection();
-
-    const fileA = connection?.getTempRemote(`/some/file`);
-    const fileB = connection?.getTempRemote(`/some/badfile`);
-    const fileC = connection?.getTempRemote(`/some/file`);
-
-    assert.strictEqual(fileA, fileC);
-    assert.notStrictEqual(fileA, fileB);
-  }},
-
-  {name: `Test parserMemberPath (simple)`, test: async () => {
-    const connection = instance.getConnection();
-
-    const memberA = connection?.parserMemberPath(`/thelib/thespf/thembr.mbr`);
-
-    assert.strictEqual(memberA?.asp, undefined);
-    assert.strictEqual(memberA?.library, `THELIB`);
-    assert.strictEqual(memberA?.file, `THESPF`);
-    assert.strictEqual(memberA?.name, `THEMBR`);
-    assert.strictEqual(memberA?.extension, `MBR`);
-    assert.strictEqual(memberA?.basename, `THEMBR.MBR`);
-  }},
-
-  {name: `Test parserMemberPath (ASP)`, test: async () => {
-    const connection = instance.getConnection();
-
-    const memberA = connection?.parserMemberPath(`/theasp/thelib/thespf/thembr.mbr`);
-
-    assert.strictEqual(memberA?.asp, `THEASP`);
-    assert.strictEqual(memberA?.library, `THELIB`);
-    assert.strictEqual(memberA?.file, `THESPF`);
-    assert.strictEqual(memberA?.name, `THEMBR`);
-    assert.strictEqual(memberA?.extension, `MBR`);
-    assert.strictEqual(memberA?.basename, `THEMBR.MBR`);
-  }},
-
-  {name: `Test parserMemberPath (no root)`, test: async () => {
-    const connection = instance.getConnection();
-
-    const memberA = connection?.parserMemberPath(`thelib/thespf/thembr.mbr`);
-
-    assert.strictEqual(memberA?.asp, undefined);
-    assert.strictEqual(memberA?.library, `THELIB`);
-    assert.strictEqual(memberA?.file, `THESPF`);
-    assert.strictEqual(memberA?.name, `THEMBR`);
-    assert.strictEqual(memberA?.extension, `MBR`);
-    assert.strictEqual(memberA?.basename, `THEMBR.MBR`);
-  }},
-
-  {name: `Test parserMemberPath (no extension)`, test: async () => {
-    const connection = instance.getConnection();
-
-    try {
-      const memberA = connection?.parserMemberPath(`thelib/thespf/thembr`);
-    } catch (e: any) {
-      assert.strictEqual(e.message, `Source Type extension is required.`);
-    }
-  }},
-
-  {name: `Test parserMemberPath (invalid length)`, test: async () => {
-    const connection = instance.getConnection();
-
-    try {
-      const memberA = connection?.parserMemberPath(`/thespf/thembr.mbr`);
-    } catch (e: any) {
-      assert.strictEqual(e.message, `Invalid path: /thespf/thembr.mbr. Use format LIB/SPF/NAME.ext`);
-    }
-  }},
-];
+    }},
+  
+    {name: `Test parserMemberPath (invalid length)`, test: async () => {
+      const connection = instance.getConnection();
+  
+      try {
+        const memberA = connection?.parserMemberPath(`/thespf/thembr.mbr`);
+      } catch (e: any) {
+        assert.strictEqual(e.message, `Invalid path: /thespf/thembr.mbr. Use format LIB/SPF/NAME.ext`);
+      }
+    }}
+  ]
+};

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,21 +1,32 @@
+import vscode from "vscode";
 import { env } from "process";
 import { instance } from "../instantiate";
 import { ConnectionSuite } from "./connection";
+import { TestSuitesTreeProvider } from "./testCasesTree";
 
-const suites = [
-  {name: `Connection tests`, tests: ConnectionSuite}
+const suites : TestSuite[] = [
+  ConnectionSuite
 ]
 
-export type TestSuite = TestCase[];
+export type TestSuite = {
+  name: string
+  tests: TestCase[]
+}
 
 export interface TestCase {
   name: string,
+  status?: "running" | "failed" | "pass"
+  failure?: string
   test: () => Promise<void>
 }
 
-export function initialise() {
+let testSuitesTreeProvider : TestSuitesTreeProvider;
+export function initialise(context: vscode.ExtensionContext) {
   if (env.testing === `true`) {
+    vscode.commands.executeCommand(`setContext`, `code-for-ibmi:testing`, true);
     instance.onEvent(`connected`, runTests);
+    testSuitesTreeProvider = new TestSuitesTreeProvider(suites);
+    context.subscriptions.push(vscode.window.registerTreeDataProvider("testingView", testSuitesTreeProvider));
   }
 }
 
@@ -23,9 +34,22 @@ async function runTests() {
   for (const suite of suites) {
     console.log(`Running suite ${suite.name} (${suite.tests.length})`);
     console.log();
-    for (const test of suite.tests) {
+    for (const test of suite.tests) {      
       console.log(`\tRunning ${test.name}`);
-      await test.test();
+      test.status = "running";
+      testSuitesTreeProvider.refresh();
+      try{
+        await test.test();
+        test.status = "pass";
+      }
+      catch(error: any){
+        console.log(error);
+        test.status = "failed";
+        test.failure = error.message;
+      }
+      finally{
+        testSuitesTreeProvider.refresh();
+      }
     }
   }
 }

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -25,6 +25,7 @@ export function initialise(context: vscode.ExtensionContext) {
   if (env.testing === `true`) {
     vscode.commands.executeCommand(`setContext`, `code-for-ibmi:testing`, true);
     instance.onEvent(`connected`, runTests);
+    instance.onEvent(`disconnected`, resetTests);
     testSuitesTreeProvider = new TestSuitesTreeProvider(suites);
     context.subscriptions.push(vscode.window.registerTreeDataProvider("testingView", testSuitesTreeProvider));
   }
@@ -51,5 +52,12 @@ async function runTests() {
         testSuitesTreeProvider.refresh();
       }
     }
-  }
+  }  
+}
+
+function resetTests(){
+  suites.flatMap(ts => ts.tests).forEach(tc => {
+    tc.status = undefined;
+    tc.failure = undefined;
+  });
 }

--- a/src/testing/testCasesTree.ts
+++ b/src/testing/testCasesTree.ts
@@ -1,0 +1,77 @@
+import vscode from "vscode";
+import { TestCase, TestSuite } from ".";
+
+export class TestSuitesTreeProvider implements vscode.TreeDataProvider<vscode.TreeItem>{
+    private readonly emitter: vscode.EventEmitter<vscode.TreeItem | undefined | null | void> = new vscode.EventEmitter();
+    readonly onDidChangeTreeData: vscode.Event<void | vscode.TreeItem | vscode.TreeItem[] | null | undefined> = this.emitter.event;
+
+    constructor(readonly testSuites: TestSuite[]) {
+
+    }
+
+    refresh(element?: TestSuiteItem) {
+        this.emitter.fire(element);
+    }
+
+    getTreeItem(element: vscode.TreeItem): vscode.TreeItem | Thenable<vscode.TreeItem> {
+        return element;
+    }
+
+    getChildren(element?: TestSuiteItem): vscode.ProviderResult<vscode.TreeItem[]> {
+        if (element) {
+            return element.getChilren();
+        }
+        else {
+            return this.testSuites.sort((ts1, ts2) => ts1.name.localeCompare(ts2.name)).map(ts => new TestSuiteItem(ts));
+        }
+    }
+}
+
+class TestSuiteItem extends vscode.TreeItem {
+    constructor(readonly testSuite: TestSuite) {
+        super(testSuite.name, vscode.TreeItemCollapsibleState.Expanded);
+        this.description = `${this.testSuite.tests.filter(tc => tc.status === "pass").length}/${this.testSuite.tests.length}`;
+        let color;
+        if (this.testSuite.tests.some(tc => tc.status === "failed")) {
+            color = "testing.iconFailed";
+        }
+        else if (this.testSuite.tests.some(tc => !tc.status)) {
+            color = "testing.iconQueued";
+        }
+        else {
+            color = "testing.iconPassed";
+        }
+        this.iconPath = new vscode.ThemeIcon("beaker", new vscode.ThemeColor(color));
+    }
+
+    getChilren() {
+        return this.testSuite.tests.map(tc => new TestCaseItem(tc));
+    }
+}
+
+class TestCaseItem extends vscode.TreeItem {
+    constructor(readonly testCase: TestCase) {
+        super(testCase.name, vscode.TreeItemCollapsibleState.None);
+        let icon;
+        let color;
+        switch (testCase.status) {
+            case "running":
+                color = "testing.runAction";
+                icon = "gear~spin";
+                break;
+            case "failed":
+                color = "testing.iconFailed";
+                icon = "close";
+                break;
+            case "pass":
+                color = "testing.iconPassed";
+                icon = "pass";
+                break;
+            default:
+                color = "testing.iconQueued";
+                icon = "watch";
+        }
+        this.iconPath = new vscode.ThemeIcon(icon, new vscode.ThemeColor(color));
+        this.tooltip = testCase.failure;
+    }
+}


### PR DESCRIPTION
### Changes
Added a Treeview to follow and check tests progress and results.
The tree refreshes after each test execution.
Colors and icons vary depending on the test results.

When all tests passed:
![Code_RIG7DjPEFT](https://user-images.githubusercontent.com/11096890/230871119-4f717f60-f7c6-4630-8e3a-fca09dd20100.gif)

When some tests failed:
![Code_TKp5vXggpx](https://user-images.githubusercontent.com/11096890/230871940-7113bd35-02e9-4661-bb97-816809448c1c.gif)

Hovering over a failed test will show the failed assertion in the tooltip:
![Code_10nC1vDKyB](https://user-images.githubusercontent.com/11096890/230870799-cefb3fcd-088e-446f-b983-7e553efe3b01.png)


### Checklist
* [x] have tested my change