### PR TITLE
Tests for IBMiContent

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -464,7 +464,7 @@ export default class IBMiContent {
 
       const statement = `
         SELECT
-          (b.avgrowsize - 12) as MBMXRL,
+          b.avgrowsize as MBMXRL,
           a.iasp_number as MBASP,
           cast(a.system_table_name as char(10) for bit data) AS MBFILE,
           cast(b.system_table_member as char(10) for bit data) as MBNAME,
@@ -522,7 +522,7 @@ export default class IBMiContent {
       file: String(result.MBFILE),
       name: String(result.MBNAME),
       extension: String(result.MBSEU2),
-      recordLength: Number(result.MBMXRL),
+      recordLength: Number(result.MBMXRL) - 12,
       text: `${result.MBMTXT || ``}${sourceFile === `*ALL` ? ` (${result.MBFILE})` : ``}`.trim()
     }));
   }

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -2,6 +2,13 @@ import { API, GitExtension } from "./import/git";
 import vscode from "vscode";
 
 export namespace Tools {
+  export class SqlError extends Error {
+    public sqlstate: string = "0";
+    constructor(message: string) {
+      super(message);
+    }
+  }
+
   export interface DB2Headers {
     name: string
     from: number
@@ -26,7 +33,7 @@ export namespace Tools {
 
     let headers: DB2Headers[];
 
-    let SQLSTATE;
+    let SQLSTATE: string;
 
     const rows: DB2Row[] = [];
 
@@ -48,7 +55,9 @@ export namespace Tools {
           }
 
           if (!SQLSTATE.startsWith(`01`)) {
-            throw new Error(`${data[index + 3]} (${SQLSTATE})`);
+            let sqlError = new SqlError(`${data[index + 3]} (${SQLSTATE})`);
+            sqlError.sqlstate = SQLSTATE;
+            throw sqlError;
           }
         }
         return;

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -69,5 +69,81 @@ export const ContentSuite: TestSuite = {
 
       assert.notStrictEqual(rows?.length, 0);
     }},
+
+    {name: `Test validateLibraryList`, test: async () => {
+      const content = instance.getContent();
+  
+      const badLibs = await content?.validateLibraryList([`QSYSINC`, `BEEPBOOP`]);
+
+      assert.strictEqual(badLibs?.includes(`BEEPBOOP`), true);
+      assert.strictEqual(badLibs?.includes(`QSYSINC`), false);
+    }},
+
+    {name: `Test getFileList`, test: async () => {
+      const content = instance.getContent();
+  
+      const objects = await content?.getFileList(`/`);
+
+      const qsysLib = objects?.find(obj => obj.name === `QSYS.LIB`);
+
+      assert.strictEqual(qsysLib?.name, `QSYS.LIB`);
+      assert.strictEqual(qsysLib?.path, `/QSYS.LIB/`);
+      assert.strictEqual(qsysLib?.type, `directory`);
+    }},
+
+    {name: `Test getFileList`, test: async () => {
+      const content = instance.getContent();
+  
+      const objects = await content?.getFileList(`/`);
+
+      const qsysLib = objects?.find(obj => obj.name === `QSYS.LIB`);
+
+      assert.strictEqual(qsysLib?.name, `QSYS.LIB`);
+      assert.strictEqual(qsysLib?.path, `/QSYS.LIB/`);
+      assert.strictEqual(qsysLib?.type, `directory`);
+    }},
+
+    {name: `Test getObjectList (all objects)`, test: async () => {
+      const content = instance.getContent();
+  
+      const objects = await content?.getObjectList({library: `QSYSINC`});
+
+      assert.notStrictEqual(objects?.length, 0);
+    }},
+
+    {name: `Test getObjectList (pgm filter)`, test: async () => {
+      const content = instance.getContent();
+  
+      const objects = await content?.getObjectList({library: `QSYSINC`, types: [`*PGM`]});
+
+      assert.notStrictEqual(objects?.length, 0);
+
+      const containsNonPgms = objects?.some(obj => obj.type !== `*PGM`);
+
+      assert.strictEqual(containsNonPgms, false);
+    }},
+
+    {name: `Test getObjectList (source files only)`, test: async () => {
+      const content = instance.getContent();
+  
+      const objects = await content?.getObjectList({library: `QSYSINC`, types: [`*SRCPF`]});
+
+      assert.notStrictEqual(objects?.length, 0);
+
+      const containsNonFiles = objects?.some(obj => obj.type !== `*FILE`);
+
+      assert.strictEqual(containsNonFiles, false);
+    }},
+
+    {name: `Test getObjectList (source files only, named filter)`, test: async () => {
+      const content = instance.getContent();
+  
+      const objects = await content?.getObjectList({library: `QSYSINC`, types: [`*SRCPF`], object: `MIH`});
+
+      assert.strictEqual(objects?.length, 1);
+
+      assert.strictEqual(objects[0].type, `*FILE`);
+      assert.strictEqual(objects[0].text, `DATA BASE FILE FOR C INCLUDES FOR MI`);
+    }},
   ]
 };

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -145,5 +145,61 @@ export const ContentSuite: TestSuite = {
       assert.strictEqual(objects[0].type, `*FILE`);
       assert.strictEqual(objects[0].text, `DATA BASE FILE FOR C INCLUDES FOR MI`);
     }},
+
+    {name: `getMemberList (SQL, no filter)`, test: async () => {
+      const content = instance.getContent();
+  
+      const members = await content?.getMemberList(`qsysinc`, `mih`);
+
+      assert.strictEqual(members?.length, 148);
+
+      const actbpgm = members.find(mbr => mbr.name === `ACTBPGM`);
+
+      assert.strictEqual(actbpgm?.name, `ACTBPGM`);
+      assert.strictEqual(actbpgm?.extension, `C`);
+      assert.strictEqual(actbpgm?.text, `ACTIVATE BOUND PROGRAM`);
+      assert.strictEqual(actbpgm?.library, `QSYSINC`);
+      assert.strictEqual(actbpgm?.file, `MIH`);
+    }},
+
+    {name: `getMemberList (SQL compared to nosql)`, test: async () => {
+      const config = instance.getConfig();
+      const content = instance.getContent();
+
+      assert.strictEqual(config!.enableSQL, true, `SQL must be enabled for this test`);
+  
+      // First we fetch the members in SQL mode
+      const membersA = await content?.getMemberList(`qsysinc`, `mih`);
+
+      config!.enableSQL = false;
+
+      // Then we fetch the members without SQL
+      const membersB = await content?.getMemberList(`qsysinc`, `mih`);
+
+      // Reset the config
+      config!.enableSQL = true;
+
+      assert.deepStrictEqual(membersA, membersB);
+    }},
+
+    {name: `getMemberList (name filter, SQL compared to nosql)`, test: async () => {
+      const config = instance.getConfig();
+      const content = instance.getContent();
+
+      assert.strictEqual(config!.enableSQL, true, `SQL must be enabled for this test`);
+  
+      // First we fetch the members in SQL mode
+      const membersA = await content?.getMemberList(`qsysinc`, `mih`, `C*`);
+
+      config!.enableSQL = false;
+
+      // Then we fetch the members without SQL
+      const membersB = await content?.getMemberList(`qsysinc`, `mih`, `C*`);
+
+      // Reset the config
+      config!.enableSQL = true;
+
+      assert.deepStrictEqual(membersA, membersB);
+    }},
   ]
 };

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -2,10 +2,12 @@ import vscode from "vscode";
 import { env } from "process";
 import { instance } from "../instantiate";
 import { ConnectionSuite } from "./connection";
+import { ContentSuite } from "./content";
 import { TestSuitesTreeProvider } from "./testCasesTree";
 
 const suites : TestSuite[] = [
-  ConnectionSuite
+  ConnectionSuite,
+  ContentSuite
 ]
 
 export type TestSuite = {


### PR DESCRIPTION
### Changes

* Tests for many methods in IBMiContent
* Fixes for:
   * Record length now corrected for member list when SQL disabled
   * `runSQL` now returns a `sqlstate` property (this is non-breaking)

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
