### PR TITLE
Ability to rerun tests, markdown results

### DIFF
--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -27,7 +27,23 @@ export function initialise(context: vscode.ExtensionContext) {
     instance.onEvent(`connected`, runTests);
     instance.onEvent(`disconnected`, resetTests);
     testSuitesTreeProvider = new TestSuitesTreeProvider(suites);
-    context.subscriptions.push(vscode.window.registerTreeDataProvider("testingView", testSuitesTreeProvider));
+
+    context.subscriptions.push(
+      vscode.window.registerTreeDataProvider("testingView", testSuitesTreeProvider),
+      vscode.commands.registerCommand(`code-for-ibmi.testing.specific`, (suiteName: string, testName: string) => {
+        if (suiteName && testName) {
+          const suite = suites.find(suite => suite.name === suiteName);
+
+          if (suite) {
+            const testCase = suite.tests.find(testCase => testCase.name === testName);
+
+            if (testCase) {
+              runTest(testCase);
+            }
+          }
+        }
+      })
+    );
   }
 }
 
@@ -36,23 +52,30 @@ async function runTests() {
     console.log(`Running suite ${suite.name} (${suite.tests.length})`);
     console.log();
     for (const test of suite.tests) {      
-      console.log(`\tRunning ${test.name}`);
-      test.status = "running";
-      testSuitesTreeProvider.refresh();
-      try{
-        await test.test();
-        test.status = "pass";
-      }
-      catch(error: any){
-        console.log(error);
-        test.status = "failed";
-        test.failure = error.message;
-      }
-      finally{
-        testSuitesTreeProvider.refresh();
-      }
+      await runTest(test);
     }
   }  
+}
+
+async function runTest(test: TestCase) {
+  console.log(`\tRunning ${test.name}`);
+  test.status = "running";
+  testSuitesTreeProvider.refresh();
+
+  try {
+    await test.test();
+    test.status = "pass";
+  }
+
+  catch (error: any){
+    console.log(error);
+    test.status = "failed";
+    test.failure = error.message;
+  }
+
+  finally {
+    testSuitesTreeProvider.refresh();
+  }
 }
 
 function resetTests(){

--- a/src/testing/testCasesTree.ts
+++ b/src/testing/testCasesTree.ts
@@ -31,6 +31,7 @@ class TestSuiteItem extends vscode.TreeItem {
     constructor(readonly testSuite: TestSuite) {
         super(testSuite.name, vscode.TreeItemCollapsibleState.Expanded);
         this.description = `${this.testSuite.tests.filter(tc => tc.status === "pass").length}/${this.testSuite.tests.length}`;
+
         let color;
         if (this.testSuite.tests.some(tc => tc.status === "failed")) {
             color = "testing.iconFailed";
@@ -45,12 +46,12 @@ class TestSuiteItem extends vscode.TreeItem {
     }
 
     getChilren() {
-        return this.testSuite.tests.map(tc => new TestCaseItem(tc));
+        return this.testSuite.tests.map(tc => new TestCaseItem(this.label as string, tc));
     }
 }
 
 class TestCaseItem extends vscode.TreeItem {
-    constructor(readonly testCase: TestCase) {
+    constructor(suiteName: string, readonly testCase: TestCase) {
         super(testCase.name, vscode.TreeItemCollapsibleState.None);
         let icon;
         let color;
@@ -71,7 +72,18 @@ class TestCaseItem extends vscode.TreeItem {
                 color = "testing.iconQueued";
                 icon = "watch";
         }
+
         this.iconPath = new vscode.ThemeIcon(icon, new vscode.ThemeColor(color));
-        this.tooltip = testCase.failure;
+
+        if (testCase.failure)
+            this.tooltip = new vscode.MarkdownString(['```', testCase.failure, '```'].join(`\n`));
+
+        if (testCase.status !== `running`) {
+            this.command = {
+                command: `code-for-ibmi.testing.specific`,
+                arguments: [suiteName, testCase.name],
+                title: `Re-run test`
+            };
+        }
     }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,10 +11,10 @@ const isProduction = (npm_runner && npm_runner.includes(`production`));
 
 console.log(`Is production build: ${isProduction}`);
 
-let exclude = [];
+let exclude = undefined;
 
 if (isProduction) {
-  exclude.push(`./src/testing`);
+  exclude = path.resolve(__dirname, `src`, `testing`)
 }
 
 /**@type {webpack.Configuration}*/
@@ -46,7 +46,7 @@ const config = {
     rules: [
       {
         test: /\.ts$/,
-        exclude: path.resolve(__dirname, `src`, `testing`)
+        exclude
       },
       {
         test: /\.js$/,


### PR DESCRIPTION
### Changes

I found that I wanted to re-run failed tests so I could debug, so I added that.

* Tests are clickable when not  in the `running` state
   * Regarding the command, it is not required to add anything to `package.json` here since we aren't making it accessible from any UI elements (including the command palette)
* Test hover content is now in markdown to make it just that little easier to read

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [x] **for feature PRs**: PR only includes one feature enhancement.
