### PR TITLE
Add legacy API commands back

### DIFF
--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -362,7 +362,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
     }),
 
     vscode.commands.registerCommand(`code-for-ibmi.runQuery`, (statement?: string) => {
-      console.log(`Command 'code-for-ibmi.runCommand' has been deprecated. There is no guarantee it will be available after 1.8.0. Use 'instance.getContent().runSQL' in the export API.`);
+      console.log(`Command 'code-for-ibmi.runQuery' has been deprecated. There is no guarantee it will be available after 1.8.0. Use 'instance.getContent().runSQL' in the export API.`);
       const content = instance.getContent();
       if (statement && content) {
         return content.runSQL(statement);

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -352,6 +352,36 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
       const value = context.secrets.get(connectionKey);
       return value;
     }),
+
+    // The follow commands are deprecated and to be removed for 1.9.0
+    vscode.commands.registerCommand(`code-for-ibmi.runCommand`, (detail: RemoteCommand) => {
+      console.log(`Command 'code-for-ibmi.runCommand' has been deprecated. There is no guarantee it will be available after 1.8.0. Use 'instance.getConnection().runCommand' in the export API.`);
+      if (detail && detail.command) {
+        return CompileTools.runCommand(instance, detail);
+      }
+    }),
+
+    vscode.commands.registerCommand(`code-for-ibmi.runQuery`, (statement?: string) => {
+      console.log(`Command 'code-for-ibmi.runCommand' has been deprecated. There is no guarantee it will be available after 1.8.0. Use 'instance.getContent().runSQL' in the export API.`);
+      const content = instance.getContent();
+      if (statement && content) {
+        return content.runSQL(statement);
+      } else {
+        return null;
+      }
+    }),
+
+    vscode.commands.registerCommand(`code-for-ibmi.launchUI`, <T>(title: string, fields: any[], callback: (page: Page<T>) => void) => {
+      console.log(`Command 'code-for-ibmi.runCommand' has been deprecated. There is no guarantee it will be available after 1.8.0. Use 'exports.customUI' in the export API.`);
+      if (title && fields && callback) {
+        const ui = new CustomUI();
+        fields.forEach(field => {
+          const uiField = new Field(field.type, field.id, field.label);
+          ui.addField(Object.assign(uiField, field));
+        });
+        ui.loadPage(title, callback);
+      }
+    })
   );
 
   (require(`./webviews/actions`)).init(context);

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -372,7 +372,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
     }),
 
     vscode.commands.registerCommand(`code-for-ibmi.launchUI`, <T>(title: string, fields: any[], callback: (page: Page<T>) => void) => {
-      console.log(`Command 'code-for-ibmi.runCommand' has been deprecated. There is no guarantee it will be available after 1.8.0. Use 'exports.customUI' in the export API.`);
+      console.log(`Command 'code-for-ibmi.launchUI' has been deprecated. There is no guarantee it will be available after 1.8.0. Use 'exports.customUI' in the export API.`);
       if (title && fields && callback) {
         const ui = new CustomUI();
         fields.forEach(field => {

--- a/src/testing/connection.ts
+++ b/src/testing/connection.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
 import { TestSuite } from ".";
 import { instance } from "../instantiate";
+import { commands } from "vscode";
 
 export const ConnectionSuite: TestSuite = {
   name: `Connection tests`,
@@ -139,6 +140,22 @@ export const ConnectionSuite: TestSuite = {
   
       assert.strictEqual(result?.code, 0);
       assert.strictEqual(result.stdout.includes(`Library List`), true);
+    }},
+
+    {name: `runCommand API compared to code-for-ibmi.runCommand (deprecated)`, test: async () => {
+      const connection = instance.getConnection();
+  
+      const resultA = await connection?.runCommand({
+        command: `DSPLIBL`,
+        environment: `ile`
+      });
+  
+      const resultB = await commands.executeCommand(`code-for-ibmi.runCommand`, {
+        command: `DSPLIBL`,
+        environment: `ile`
+      });
+
+      assert.deepStrictEqual(resultA, resultB);
     }},
 
     {name: `Test runCommand (ILE, custom libl)`, test: async () => {

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
 import { TestSuite } from ".";
 import { instance } from "../instantiate";
+import { commands } from "vscode";
 
 export const ContentSuite: TestSuite = {
   name: `Content API tests`,
@@ -38,6 +39,23 @@ export const ContentSuite: TestSuite = {
       ].join(`\n`));
 
       assert.strictEqual(rows?.length, 1);
+    }},
+
+    {name: `Compare runSQL and old runQuery (deprecated)`, test: async () => {
+      const content = instance.getContent();
+
+      const query = [
+        `-- myselect`,
+        `select *`,
+        `from qiws.qcustcdt --my table`,
+        `limit 1`,
+      ].join(`\n`);
+  
+      const rowsA = await content?.runSQL(query);
+
+      const rowsB = await commands.executeCommand(`code-for-ibmi.runQuery`, query);
+
+      assert.deepStrictEqual(rowsA, rowsB);
     }},
 
     {name: `Test getTable (SQL disabled)`, test: async () => {


### PR DESCRIPTION
### Changes

In a recent PR (#1158), I added `instance.getConnection().runCommand` and removed `code-for-ibmi.runCommand` from our provided commands. `runCommand` is vital to a couple of other extensions, and removing it without giving time to use the new API will cause extensions (like RPGLE and Db2 for i) will just stop working until they start using the new API.

This PR still releases the new API, will let other extensions continue to work, and give time to those maintainers to upgrade to the export APIs instead.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [x] **for feature PRs**: PR only includes one feature enhancement.
