### PR TITLE
Rename old member to name where applicable

### DIFF
--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -314,11 +314,11 @@ module.exports = class ObjectBrowser {
 
           if (result === `Yes`) {
             const connection = getInstance().getConnection();
-            const { library, file, member } = connection.parserMemberPath(node.path);
+            const { library, file, name } = connection.parserMemberPath(node.path);
 
             try {
               await connection.remoteCommand(
-                `RMVM FILE(${library}/${file}) MBR(${member})`,
+                `RMVM FILE(${library}/${file}) MBR(${name})`,
               );
 
               vscode.window.showInformationMessage(`Deleted ${node.path}.`);
@@ -430,11 +430,11 @@ module.exports = class ObjectBrowser {
 
         if (originPath) {
           const connection = getInstance().getConnection();
-          const { asp, library, file, member } = connection.parserMemberPath(node.path);
+          const { asp, library, file, name } = connection.parserMemberPath(node.path);
           const data = fs.readFileSync(originPath[0].fsPath, `utf8`);
 
           try {
-            contentApi.uploadMemberContent(asp, library, file, member, data);
+            contentApi.uploadMemberContent(asp, library, file, name, data);
             vscode.window.showInformationMessage(`Member was uploaded.`);
           } catch (e) {
             vscode.window.showErrorMessage(`Error uploading content to member! ${e}`);


### PR DESCRIPTION
### Changes

Looks like we missed a couple of places where `member` was renamed to `name`. Found it when deleting a member tonight!

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
