### PR TITLE
Refresh all valid views when connected to a new system

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -102,6 +102,15 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
     initialise(context);
   }
 
+  instance.onEvent(`connected`, () => {
+    Promise.all([
+      commands.executeCommand("code-for-ibmi.refreshObjectBrowser"),
+      commands.executeCommand("code-for-ibmi.refreshLibraryListView"),
+      commands.executeCommand("code-for-ibmi.refreshIFSBrowser"),
+      commands.executeCommand("code-for-ibmi.refreshProfileView")
+    ]);
+  })
+
   return { instance, customUI: () => new CustomUI(), deploy: Deployment.deploy, evfeventParser: parseErrors };
 }
 


### PR DESCRIPTION
### Changes

Fixes a bug where profiles were not being refreshed after disconnect and connecting to a new system, which was resulting in the incorrect - fixing #1239.

This may also fix #1221, but I am unsure as I can't test that.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
