### PR TITLE
Fix stat on empty or specially named directories

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -574,7 +574,7 @@ export default class IBMiContent {
     if (STAT && SORT) {
       fileListResult = (await this.ibmi.sendCommand({
         command: `${STAT} --dereference --printf="%A\t%h\t%U\t%G\t%s\t%Y\t%n\n" * .* ${sort.order === `date` ? `| ${SORT} --key=6` : ``} ${(sort.order === `date` && !sort.ascending) ? ` --reverse` : ``}`,
-        directory: `${Tools.escapePath(remotePath)}`
+        directory: `${remotePath}`
       }));
     
       if (fileListResult.code === 0) {
@@ -598,6 +598,11 @@ export default class IBMiContent {
             });
           };
         });
+      } else {
+        // Ignore error on empty directories...
+        if (fileListResult.stderr.includes(`No such file or directory`)) {
+          fileListResult.code = 0;
+        }
       }
 
     } else {


### PR DESCRIPTION
### Changes

This PR will fix running the `stat` command on directories, which are empty or has special characters in the name, e.g. `$`.
The error was introduced in PR #1153, and caused the following error in VS Code:

![billede](https://user-images.githubusercontent.com/13275072/234395874-32695f6d-1427-4ae7-9206-d4571e7139de.png)

### Checklist

* [x] have tested my change
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
