### PR TITLE
Fix Changed deployment method for multi-folders workspaces

### DIFF
--- a/src/api/local/deployment.ts
+++ b/src/api/local/deployment.ts
@@ -209,8 +209,6 @@ export namespace Deployment {
           setDeployLocation(undefined, folder, buildPossibleDeploymentDirectory(folder));
         }
       }
-    } else {
-      vscode.window.showErrorMessage(`No location selected for deployment.`);
     }
   }
 

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -1,4 +1,4 @@
-import { ExtensionContext, Uri } from "vscode";
+import { ExtensionContext, Uri, WorkspaceFolder } from "vscode";
 import Instance from "./api/Instance";
 import { Ignore } from 'ignore'
 import { CustomUI, Field } from "./api/CustomUI";
@@ -14,7 +14,7 @@ export type DeploymentMethod = "all" | "staged" | "unstaged" | "changed" | "comp
 
 export interface DeploymentParameters {
   method: DeploymentMethod
-  localFolder: Uri
+  workspaceFolder: WorkspaceFolder
   remotePath: string
   ignoreRules?: Ignore
 }


### PR DESCRIPTION
### Changes
- Fix https://github.com/halcyon-tech/vscode-ibmi/issues/1262
- Offer to set a deploy directory when trying to deploy a project with no deployment  target
![image](https://user-images.githubusercontent.com/11096890/235302277-d8007814-529f-41ac-ba5c-e3e2c5816cf7.png)

The `FileSystemWatcher` used to watch files changed in the workspace would register each change globally, instead of registering them by workspace folder. Changes are now stored by workspace folders.

### Checklist
* [x] have tested my change
* [x] eslint is not complaining
