### PR TITLE
Use tarball to transfer files to deploy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "code-for-ibmi",
-	"version": "1.7.12",
+	"version": "1.8.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "code-for-ibmi",
-			"version": "1.7.12",
+			"version": "1.8.0",
 			"license": "MIT",
 			"dependencies": {
 				"@bendera/vscode-webview-elements": "^0.12.0",
@@ -14,6 +14,7 @@
 				"csv": "^6.2.1",
 				"ignore": "^5.1.9",
 				"node-ssh": "^11.1.1",
+				"tar": "^6.1.13",
 				"tmp": "^0.2.1",
 				"vscode-diff": "^2.0.2"
 			},
@@ -21,6 +22,7 @@
 				"@types/glob": "^7.1.3",
 				"@types/node": "^12.20.55",
 				"@types/source-map-support": "^0.5.6",
+				"@types/tar": "^6.1.4",
 				"@types/tmp": "^0.2.3",
 				"@types/vscode": "^1.66.0",
 				"esbuild-loader": "^3.0.1",
@@ -701,6 +703,16 @@
 				"source-map": "^0.6.0"
 			}
 		},
+		"node_modules/@types/tar": {
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/@types/tar/-/tar-6.1.4.tgz",
+			"integrity": "sha512-Cp4oxpfIzWt7mr2pbhHT2OTXGMAL0szYCzuf8lRWyIMCgsx6/Hfc3ubztuhvzXHXgraTQxyOCmmg7TDGIMIJJQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*",
+				"minipass": "^4.0.0"
+			}
+		},
 		"node_modules/@types/tmp": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
@@ -1203,6 +1215,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/chownr": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/chrome-trace-event": {
@@ -1806,6 +1826,28 @@
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
 		},
+		"node_modules/fs-minipass": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/fs-minipass/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2394,6 +2436,37 @@
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
 			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
 			"dev": true
+		},
+		"node_modules/minipass": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+			"integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/minizlib": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+			"dependencies": {
+				"minipass": "^3.0.0",
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/minizlib/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/mkdirp": {
 			"version": "0.5.6",
@@ -3051,6 +3124,33 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/tar": {
+			"version": "6.1.13",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
+			"integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
+			"dependencies": {
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.0.0",
+				"minipass": "^4.0.0",
+				"minizlib": "^2.1.1",
+				"mkdirp": "^1.0.3",
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/tar/node_modules/mkdirp": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/terser": {
 			"version": "5.15.0",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
@@ -3497,8 +3597,7 @@
 		"node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		}
 	},
 	"dependencies": {
@@ -3927,6 +4026,16 @@
 				"source-map": "^0.6.0"
 			}
 		},
+		"@types/tar": {
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/@types/tar/-/tar-6.1.4.tgz",
+			"integrity": "sha512-Cp4oxpfIzWt7mr2pbhHT2OTXGMAL0szYCzuf8lRWyIMCgsx6/Hfc3ubztuhvzXHXgraTQxyOCmmg7TDGIMIJJQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"minipass": "^4.0.0"
+			}
+		},
 		"@types/tmp": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
@@ -4329,6 +4438,11 @@
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
 			}
+		},
+		"chownr": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
 		},
 		"chrome-trace-event": {
 			"version": "1.0.3",
@@ -4804,6 +4918,24 @@
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
 		},
+		"fs-minipass": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+			"requires": {
+				"minipass": "^3.0.0"
+			},
+			"dependencies": {
+				"minipass": {
+					"version": "3.3.6",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+					"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				}
+			}
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5260,6 +5392,30 @@
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
 			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
 			"dev": true
+		},
+		"minipass": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+			"integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ=="
+		},
+		"minizlib": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+			"requires": {
+				"minipass": "^3.0.0",
+				"yallist": "^4.0.0"
+			},
+			"dependencies": {
+				"minipass": {
+					"version": "3.3.6",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+					"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				}
+			}
 		},
 		"mkdirp": {
 			"version": "0.5.6",
@@ -5760,6 +5916,26 @@
 			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
 			"dev": true
 		},
+		"tar": {
+			"version": "6.1.13",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
+			"integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
+			"requires": {
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.0.0",
+				"minipass": "^4.0.0",
+				"minizlib": "^2.1.1",
+				"mkdirp": "^1.0.3",
+				"yallist": "^4.0.0"
+			},
+			"dependencies": {
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+				}
+			}
+		},
 		"terser": {
 			"version": "5.15.0",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
@@ -6056,8 +6232,7 @@
 		"yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1406,7 +1406,7 @@
 				"title": "Collapse all",
 				"category": "IBM i",
 				"icon": "$(collapse-all)"
-			},			
+			},
 			{
 				"command": "code-for-ibmi.sortIFSFilesByDate",
 				"title": "Date",
@@ -2137,6 +2137,7 @@
 		"@types/glob": "^7.1.3",
 		"@types/node": "^12.20.55",
 		"@types/source-map-support": "^0.5.6",
+		"@types/tar": "^6.1.4",
 		"@types/tmp": "^0.2.3",
 		"@types/vscode": "^1.66.0",
 		"esbuild-loader": "^3.0.1",
@@ -2155,6 +2156,7 @@
 		"csv": "^6.2.1",
 		"ignore": "^5.1.9",
 		"node-ssh": "^11.1.1",
+		"tar": "^6.1.13",
 		"tmp": "^0.2.1",
 		"vscode-diff": "^2.0.2"
 	},

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -9,7 +9,6 @@ import { CompileTools } from "./CompileTools";
 import { ConnectionData, CommandData, StandardIO, CommandResult, IBMiMember, RemoteCommand } from "../typings";
 import * as configVars from './configVars';
 import { instance } from "../instantiate";
-import IBMiContent from "./IBMiContent";
 import { GlobalStorage, CachedServerSettings } from './Storage';
 
 export interface MemberParts extends IBMiMember {
@@ -19,11 +18,11 @@ export interface MemberParts extends IBMiMember {
 let remoteApps = [
   {
     path: `/QOpenSys/pkgs/bin/`,
-    names: [`git`, `grep`, `tn5250`, `md5sum`, `bash`, `chsh`, `stat`, `sort`]
+    names: [`git`, `grep`, `tn5250`, `md5sum`, `bash`, `chsh`, `stat`, `sort`, `tar`]
   },
   {
     path: `/usr/bin/`,
-    names: [`setccsid`, `iconv`, `attr`]
+    names: [`setccsid`, `iconv`, `attr`, `tar`]
   },
   {
     path: `/QSYS.LIB/`,

--- a/src/api/local/deployment.ts
+++ b/src/api/local/deployment.ts
@@ -536,7 +536,10 @@ export namespace Deployment {
 
       progress?.report({ message: `extracting deployment tarball to ${parameters.remotePath}...` });
       //Extract and remove tar's PaxHeader metadata folder
-      await connection.sendCommand({ command: `tar -xf ${remoteTarball} && rm -rf PaxHeader`, directory: parameters.remotePath });
+      const result = await connection.sendCommand({ command: `${connection.remoteFeatures.tar} -xf ${remoteTarball} && rm -rf PaxHeader`, directory: parameters.remotePath });
+      if(result.code !== 0){
+        throw new Error(`Tarball extraction failed: ${result.stderr}`)
+      }
 
       const entries: string[] = [];
       tar.t({ sync: true, file: localTarball.name, onentry: entry => entries.push(entry.path) });

--- a/src/api/local/deployment.ts
+++ b/src/api/local/deployment.ts
@@ -535,7 +535,8 @@ export namespace Deployment {
       deploymentLog.appendLine(`Uploaded deployment tarball as ${remoteTarball}`);
 
       progress?.report({ message: `extracting deployment tarball to ${parameters.remotePath}...` });
-      await connection.sendCommand({ command: `tar -xf ${remoteTarball}`, directory: parameters.remotePath });
+      //Extract and remove tar's PaxHeader metadata folder
+      await connection.sendCommand({ command: `tar -xf ${remoteTarball} && rm -rf PaxHeader`, directory: parameters.remotePath });
 
       const entries: string[] = [];
       tar.t({ sync: true, file: localTarball.name, onentry: entry => entries.push(entry.path) });

--- a/src/api/local/deployment.ts
+++ b/src/api/local/deployment.ts
@@ -15,12 +15,6 @@ import { DeploymentMethod, DeploymentParameters } from '../../typings';
 import { Tools } from '../Tools';
 
 export namespace Deployment {
-  interface Upload {
-    local: string
-    remote: string
-    uri: vscode.Uri
-  }
-
   interface MD5Entry {
     path: string
     md5: string
@@ -216,33 +210,56 @@ export namespace Deployment {
   export async function deploy(parameters: DeploymentParameters) {
     try {
       deploymentLog.clear();
+      deploymentLog.appendLine(`Deployment started using method "${parameters.method}"`);
+      deploymentLog.appendLine(``);
       button.text = BUTTON_WORKING;
 
-      await createRemoteDirectory(parameters.remotePath);
+      const name = basename(parameters.workspaceFolder.uri.path);
+      await vscode.window.withProgress({
+        location: vscode.ProgressLocation.Notification,
+        title: `Deploying ${name}`,
+      }, async (progress) => {
+        if (parameters.remotePath.startsWith(`/`)) {
+          progress.report({ message: `creating remote folder ${parameters.remotePath}...` });
+          await createRemoteDirectory(parameters.remotePath);
 
-      switch (parameters.method) {
-        case "unstaged":
-          await deployGit(parameters, 'working');
-          break;
+          progress.report({ message: `gathering files ("${parameters.method}" method)...` });
+          const files: vscode.Uri[] = [];
+          switch (parameters.method) {
+            case "unstaged":
+              files.push(...await deployGit(parameters, 'working'));
+              break;
 
-        case "staged":
-          await deployGit(parameters, 'staged');
-          break;
+            case "staged":
+              files.push(...await deployGit(parameters, 'staged'));
+              break;
 
-        case "changed":
-          await deployChanged(parameters);
-          break;
+            case "changed":
+              files.push(...await deployChanged(parameters));
+              break;
 
-        case "compare":
-          await deployCompare(parameters);
-          break;
+            case "compare":
+              files.push(...await deployCompare(parameters, progress));
+              break;
 
-        case "all":
-          await deployAll(parameters);
-          break;
-      }
+            case "all":
+              files.push(...await deployAll(parameters));
+              break;
+          }
 
-      deploymentLog.appendLine(`Deployment finished.`);
+          if (files.length) {
+            await sendCompressed(parameters, files, progress);
+          }
+          else {
+            deploymentLog.appendLine('No files to upload');
+          }
+        } else {
+          deploymentLog.appendLine(`Deployment cancelled. Not sure where to deploy workspace.`);
+          throw new Error("Invalid deployment path");
+        }
+      })
+      deploymentLog.appendLine('');
+      deploymentLog.appendLine(`Deployment finished`);
       vscode.window.showInformationMessage(`Deployment finished.`);
       workspaceChanges.get(parameters.workspaceFolder)?.clear();
       return true;
@@ -255,14 +272,6 @@ export namespace Deployment {
     finally {
       button.text = BUTTON_BASE;
     }
-  }
-
-  function getClient(): NodeSSH {
-    const client = getConnection().client;
-    if (!client) {
-      throw new Error("Please connect to an IBM i");
-    }
-    return client;
   }
 
   function getConnection(): IBMi {
@@ -279,44 +288,24 @@ export namespace Deployment {
     });
   }
 
-  async function deployChanged(parameters: DeploymentParameters) {
+  async function deployChanged(parameters: DeploymentParameters): Promise<vscode.Uri[]> {
     const changes = workspaceChanges.get(parameters.workspaceFolder);
-    if (changes && changes.size > 0) {
-      const changedFiles = Array.from(changes.values())
+    if (changes && changes.size) {
+      return Array.from(changes.values())
         .filter(uri => {
           // We don't want stuff in the gitignore
           const relative = toRelative(parameters.workspaceFolder.uri, uri);
           if (relative && parameters.ignoreRules) {
             return !parameters.ignoreRules.ignores(relative);
           }
-
-          // Bad way of checking if the file is a directory or not.
-          // putFiles below does not support directory creation.
-          const basename = path.basename(uri.path);
-          return !basename.includes(`.`);
         });
-
-      const uploads: Upload[] = changedFiles
-        .map(uri => {
-          const relative = toRelative(parameters.workspaceFolder.uri, uri);
-          const remote = path.posix.join(parameters.remotePath, relative);
-          deploymentLog.appendLine(`UPLOADING: ${uri.fsPath} -> ${remote}`);
-          return {
-            local: uri.fsPath,
-            remote,
-            uri
-          };
-        });
-
-      await getClient().putFiles(uploads, {
-        concurrency: 5
-      });
     } else {
       // Skip upload, but still run the Action
+      return [];
     }
   }
 
-  async function deployGit(parameters: DeploymentParameters, changeType: 'staged' | 'working') {
+  async function deployGit(parameters: DeploymentParameters, changeType: 'staged' | 'working'): Promise<vscode.Uri[]> {
     const useStagedChanges = (changeType == 'staged');
     const gitApi = Tools.getGitAPI();
 
@@ -337,27 +326,10 @@ export namespace Deployment {
         gitFiles = gitFiles.filter(change => change.status !== 6);
 
         if (gitFiles.length > 0) {
-          const uploads: Upload[] = gitFiles.map(change => {
-            const relative = toRelative(parameters.workspaceFolder.uri, change.uri);
-            const remote = path.posix.join(parameters.remotePath, relative);
-            deploymentLog.appendLine(`UPLOADING: ${change.uri.fsPath} -> ${remote}`);
-            return {
-              local: change.uri.fsPath,
-              remote,
-              uri: change.uri
-            };
-          });
-
-          vscode.window.showInformationMessage(`Deploying ${changeType} changes (${uploads.length}) to ${parameters.remotePath}`);
-          if (parameters.remotePath.startsWith(`/`)) {
-            await getClient().putFiles(uploads, {
-              concurrency: 5
-            });
-          } else {
-            throw new Error(`Unable to determine where to upload workspace.`)
-          }
+          return gitFiles.map(change => change.uri);
         } else {
           vscode.window.showWarningMessage(`No ${changeType} changes to deploy.`);
+          return [];
         }
       } else {
         throw new Error(`No repository found for ${parameters.workspaceFolder.uri.fsPath}`);
@@ -367,73 +339,50 @@ export namespace Deployment {
     }
   }
 
-  async function deployCompare(parameters: DeploymentParameters) {
+  async function deployCompare(parameters: DeploymentParameters, progress: vscode.Progress<{ message?: string }>): Promise<vscode.Uri[]> {
     if (getConnection().remoteFeatures.md5sum) {
       const isEmpty = (await getConnection().sendCommand({ directory: parameters.remotePath, command: `ls | wc -l` })).stdout === "0";
       if (isEmpty) {
         deploymentLog.appendLine("Remote directory is empty; switching to 'deploy all'");
-        await deployAll(parameters);
+        return await deployAll(parameters);
       }
       else {
-        const name = basename(parameters.workspaceFolder.uri.path);
-        await vscode.window.withProgress({
-          location: vscode.ProgressLocation.Notification,
-          title: `Synchronizing ${name}`,
-        }, async (progress) => {
-          deploymentLog.appendLine("Starting MD5 synchronization transfer");
-          progress.report({ message: `creating remote MD5 hash list` });
-          const md5sumOut = await getConnection().sendCommand({
-            directory: parameters.remotePath,
-            command: `/QOpenSys/pkgs/bin/md5sum $(find . -type f)`
-          });
-
-          const remoteMD5: MD5Entry[] = md5sumOut.stdout.split(`\n`).map(line => toMD5Entry(line.trim()));
-
-          progress.report({ message: `creating transfer list`, increment: 25 });
-          const localRoot = `${parameters.workspaceFolder.uri.fsPath}${parameters.workspaceFolder.uri.fsPath.startsWith('/') ? '/' : '\\'}`;
-          const localFiles = (await findFiles(parameters, "**/*", "**/.git*"))
-            .map(file => ({ uri: file, path: file.fsPath.replace(localRoot, '').replace(/\\/g, '/') }));
-
-          const uploads: { local: string, remote: string }[] = [];
-          for await (const file of localFiles) {
-            const remote = remoteMD5.find(e => e.path === file.path);
-            const md5 = md5Hash(file.uri);
-            if (!remote || remote.md5 !== md5) {
-              uploads.push({ local: file.uri.fsPath, remote: `${parameters.remotePath}/${file.path}` });
-            }
-          }
-
-          const toDelete: string[] = remoteMD5.filter(remote => !localFiles.some(local => remote.path === local.path))
-            .map(remote => remote.path);
-          if (toDelete.length) {
-            progress.report({ message: `deleting ${toDelete.length} remote file(s)`, increment: 25 });
-            deploymentLog.appendLine(`\nDeleted:\n\t${toDelete.join('\n\t')}\n`);
-            await getConnection().sendCommand({ directory: parameters.remotePath, command: `rm -f ${toDelete.join(' ')}` });
-          }
-          else {
-            progress.report({ increment: 25 });
-          }
-
-          if (uploads.length) {
-            //Create all missing folders at once
-            progress.report({ message: `creating remote folders`, increment: 10 });
-            const mkdirs = [...new Set(uploads.map(u => dirname(u.remote)))].map(folder => `[ -d ${folder} ] || mkdir -p ${folder}`).join(';');
-            await getConnection().sendCommand({ command: mkdirs });
-
-            progress.report({ message: `uploading ${uploads.length} file(s)`, increment: 15 });
-            deploymentLog.appendLine(`\nUploaded:\n\t${uploads.map(file => file.remote).join('\n\t')}\n`);
-            await getClient().putFiles(uploads, { concurrency: 5 });
-          }
-          else {
-            progress.report({ increment: 25 });
-          }
-
-          progress.report({ message: `removing empty folders under ${parameters.remotePath}`, increment: 20 });
-          //PASE's find doesn't support the -empty flag so rmdir is run on every directory; not very clean, but it works
-          await getConnection().sendCommand({ command: "find . -depth -type d -exec rmdir {} + 2>/dev/null", directory: parameters.remotePath });
-
-          progress.report({ increment: 5 });
+        deploymentLog.appendLine("Starting MD5 synchronization transfer");
+        progress.report({ message: `creating remote MD5 hash list` });
+        const md5sumOut = await getConnection().sendCommand({
+          directory: parameters.remotePath,
+          command: `/QOpenSys/pkgs/bin/md5sum $(find . -type f)`
         });
+
+        const remoteMD5: MD5Entry[] = md5sumOut.stdout.split(`\n`).map(line => toMD5Entry(line.trim()));
+
+        progress.report({ message: `creating transfer list` });
+        const localRoot = `${parameters.workspaceFolder.uri.fsPath}${parameters.workspaceFolder.uri.fsPath.startsWith('/') ? '/' : '\\'}`;
+        const localFiles = (await findFiles(parameters, "**/*", "**/.git*"))
+          .map(file => ({ uri: file, path: file.fsPath.replace(localRoot, '').replace(/\\/g, '/') }));
+
+        const uploads: vscode.Uri[] = [];
+        for await (const file of localFiles) {
+          const remote = remoteMD5.find(e => e.path === file.path);
+          const md5 = md5Hash(file.uri);
+          if (!remote || remote.md5 !== md5) {
+            uploads.push(file.uri);
+          }
+        }
+
+        const toDelete: string[] = remoteMD5.filter(remote => !localFiles.some(local => remote.path === local.path))
+          .map(remote => remote.path);
+        if (toDelete.length) {
+          progress.report({ message: `deleting ${toDelete.length} remote file(s)`, });
+          deploymentLog.appendLine(`\nDeleted:\n\t${toDelete.join('\n\t')}\n`);
+          await getConnection().sendCommand({ directory: parameters.remotePath, command: `rm -f ${toDelete.join(' ')}` });
+        }
+
+        progress.report({ message: `removing empty folders under ${parameters.remotePath}` });
+        //PASE's find doesn't support the -empty flag so rmdir is run on every directory; not very clean, but it works
+        await getConnection().sendCommand({ command: "find . -depth -type d -exec rmdir {} + 2>/dev/null", directory: parameters.remotePath });
+
+        return uploads;
       }
     }
     else {
@@ -441,57 +390,8 @@ export namespace Deployment {
     }
   }
 
-  async function deployAll(parameters: DeploymentParameters) {
-    const name = basename(parameters.workspaceFolder.uri.path);
-    await vscode.window.withProgress({
-      location: vscode.ProgressLocation.Notification,
-      title: `Deploying ${name}`,
-    }, async (progress) => {
-      progress.report({ message: `Deploying ${name}` });
-      if (parameters.remotePath.startsWith(`/`)) {
-        try {
-          const files = (await findFiles(parameters, "**/*", "**/.git*"))
-            .map(file => path.relative(parameters.workspaceFolder.uri.fsPath, file.fsPath));
-          const result = compress(parameters.workspaceFolder, files);
-          await getClient().putFile(result, '/tmp/deploy.tar.gz');
-          await getClient().putDirectory(parameters.workspaceFolder.uri.fsPath, parameters.remotePath, {
-            recursive: true,
-            concurrency: 5,
-            tick: (localPath, remotePath, error) => {
-              if (remotePath.startsWith('\\')) {
-                //On Windows, remotePath path separators are \
-                remotePath = remotePath.replace(/\\/g, '/');
-              }
-
-              if (error) {
-                progress.report({ message: `Failed to deploy ${localPath}` });
-                deploymentLog.appendLine(`FAILED: ${localPath} -> ${remotePath}: ${error.message}`);
-              } else {
-                progress.report({ message: `Deployed ${localPath}` });
-                deploymentLog.appendLine(`SUCCESS: ${localPath} -> ${remotePath}`);
-              }
-            },
-            validate: localPath => {
-              const relative = path.relative(parameters.workspaceFolder.uri.fsPath, localPath);
-              if (relative && parameters.ignoreRules) {
-                return !parameters.ignoreRules.ignores(relative);
-              }
-              else {
-                return true;
-              }
-            }
-          });
-
-          progress.report({ message: `Deployment finished.` });
-        } catch (e) {
-          progress.report({ message: `Deployment failed.` });
-          throw e;
-        }
-      } else {
-        deploymentLog.appendLine(`Deployment cancelled. Not sure where to deploy workspace.`);
-        throw new Error("Invalid deployment path");
-      }
-    });
+  async function deployAll(parameters: DeploymentParameters): Promise<vscode.Uri[]> {
+    return (await findFiles(parameters, "**/*", "**/.git*"));
   }
 
   async function setDeployLocation(node: any, workspaceFolder?: WorkspaceFolder, value?: string) {
@@ -610,24 +510,45 @@ export namespace Deployment {
           const relative = toRelative(parameters.workspaceFolder.uri, file);
           return !parameters.ignoreRules.ignores(relative);
         }
-        else {
-          return true;
-        }
       });
   }
-}
 
-function buildPossibleDeploymentDirectory(workspace: vscode.WorkspaceFolder) {
-  const user = instance.getConnection()?.currentUser;
-  //User should not be empty but we'll keep tmp as a fallback location
-  return user ? path.posix.join('/', 'home', user, 'builds', workspace.name) : path.posix.join('/', 'tmp', 'builds', workspace.name);
-}
+  function buildPossibleDeploymentDirectory(workspace: vscode.WorkspaceFolder) {
+    const user = instance.getConnection()?.currentUser;
+    //User should not be empty but we'll keep tmp as a fallback location
+    return user ? path.posix.join('/', 'home', user, 'builds', workspace.name) : path.posix.join('/', 'tmp', 'builds', workspace.name);
+  }
 
-function compress(workspaceFolder: vscode.WorkspaceFolder, files: string[]) {
-  const tarballFile = tmp.fileSync({ postfix: ".tar" }).name;
-  console.log("Tarball", tarballFile);
-  tar.create({ cwd: workspaceFolder.uri.fsPath, sync:true, file: tarballFile}, files);
-  console.log("Tarball created");
+  async function sendCompressed(parameters: DeploymentParameters, files: vscode.Uri[], progress: vscode.Progress<{ message?: string }>) {
+    const connection = getConnection();
+    const localTarball = tmp.fileSync({ postfix: ".tar" });
+    const remoteTarball = path.posix.join(getConnection().config?.tempDir || '/tmp', `deploy_${Tools.makeid()}.tar`);
+    try {
+      const toSend = files.map(file => path.relative(parameters.workspaceFolder.uri.fsPath, file.fsPath));
 
-  return tarballFile;
+      progress?.report({ message: `creating deployment tarball for ${toSend.length} file(s)...` });
+      tar.create({ cwd: parameters.workspaceFolder.uri.fsPath, sync: true, file: localTarball.name }, toSend);
+      deploymentLog.appendLine(`Created deployment tarball ${localTarball.name}`);
+
+      progress?.report({ message: `sending deployment tarball...` });
+      await connection.client.putFile(localTarball.name, remoteTarball);
+      deploymentLog.appendLine(`Uploaded deployment tarball as ${remoteTarball}`);
+
+      progress?.report({ message: `extracting deployment tarball to ${parameters.remotePath}...` });
+      await connection.sendCommand({ command: `tar -xf ${remoteTarball}`, directory: parameters.remotePath });
+
+      const entries: string[] = [];
+      tar.t({ sync: true, file: localTarball.name, onentry: entry => entries.push(entry.path) });
+      deploymentLog.appendLine(`${entries.length} file(s) uploaded to ${parameters.remotePath}`);
+      entries.sort().map(e => `\t${e}`).forEach(deploymentLog.appendLine);
+    }
+    finally {
+      deploymentLog.appendLine('');
+      await connection.sendCommand({ command: `rm ${remoteTarball}` })
+      deploymentLog.appendLine(`${remoteTarball} deleted`);
+
+      localTarball.removeCallback();
+      deploymentLog.appendLine(`${localTarball.name} deleted`);
+    }
+  }
 }


### PR DESCRIPTION
### Changes
Files to be deployed are put in a tarball (.tar archive) before being sent.
The benefits are:
- Faster deployment times, especially when deploying a lot of files
- Simpler deployment process (directory creations is handled by the `tar` command)
- File attributes and access permissions are kept during the transfer (if deploying from a POSIX os; not applicable for Windows)

Will fix https://github.com/halcyon-tech/vscode-ibmi/issues/1026

### Checklist
* [x] have tested my change
* [x] updated relevant documentation
* [x] **for feature PRs**: PR only includes one feature enhancement.
