### PR TITLE
Reconnect to previous IBM i when FS reopens

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
 		"theme": "dark"
 	},
 	"activationEvents": [
-		"onStartupFinished"
+		"onStartupFinished",
+		"onFileSystem:member",
+		"onFileSystem:streamfile"
 	],
 	"main": "./dist/extension.js",
 	"contributes": {

--- a/src/filesystems/ifsFs.ts
+++ b/src/filesystems/ifsFs.ts
@@ -10,14 +10,14 @@ export class IFSFS implements vscode.FileSystemProvider {
     return { dispose: () => { } };
   }
 
-  async readFile(uri: vscode.Uri, retry?: boolean): Promise<Uint8Array> {
+  async readFile(uri: vscode.Uri, retrying?: boolean): Promise<Uint8Array> {
     const contentApi = instance.getContent();
     if (contentApi) {
       const fileContent = await contentApi.downloadStreamfile(uri.path);
       return new Uint8Array(Buffer.from(fileContent, `utf8`));
     }
     else {
-      if (retry) {
+      if (retrying) {
         throw new Error("Not connected to IBM i");
       }
       else {

--- a/src/filesystems/ifsFs.ts
+++ b/src/filesystems/ifsFs.ts
@@ -10,14 +10,20 @@ export class IFSFS implements vscode.FileSystemProvider {
     return { dispose: () => { } };
   }
 
-  async readFile(uri: vscode.Uri): Promise<Uint8Array> {
+  async readFile(uri: vscode.Uri, retry?: boolean): Promise<Uint8Array> {
     const contentApi = instance.getContent();
     if (contentApi) {
       const fileContent = await contentApi.downloadStreamfile(uri.path);
       return new Uint8Array(Buffer.from(fileContent, `utf8`));
     }
     else {
-      throw new Error("Not connected to IBM i");
+      if (retry) {
+        throw new Error("Not connected to IBM i");
+      }
+      else {
+        await vscode.commands.executeCommand(`code-for-ibmi.connectToPrevious`);
+        return this.readFile(uri, true);
+      }
     }
   }
 

--- a/src/filesystems/qsys/QSysFs.ts
+++ b/src/filesystems/qsys/QSysFs.ts
@@ -90,7 +90,7 @@ export class QSysFS implements vscode.FileSystemProvider {
         }
     }
 
-    async readFile(uri: vscode.Uri, retry?: boolean): Promise<Uint8Array> {
+    async readFile(uri: vscode.Uri, retrying?: boolean): Promise<Uint8Array> {
         const contentApi = instance.getContent();
         const connection = instance.getConnection();
         if (connection && contentApi) {
@@ -106,7 +106,7 @@ export class QSysFS implements vscode.FileSystemProvider {
             }
         }
         else {
-            if (retry) {
+            if (retrying) {
                 throw new Error("Not connected to IBM i");
             }
             else{

--- a/src/filesystems/qsys/QSysFs.ts
+++ b/src/filesystems/qsys/QSysFs.ts
@@ -90,7 +90,7 @@ export class QSysFS implements vscode.FileSystemProvider {
         }
     }
 
-    async readFile(uri: vscode.Uri): Promise<Uint8Array> {
+    async readFile(uri: vscode.Uri, retry?: boolean): Promise<Uint8Array> {
         const contentApi = instance.getContent();
         const connection = instance.getConnection();
         if (connection && contentApi) {
@@ -106,7 +106,13 @@ export class QSysFS implements vscode.FileSystemProvider {
             }
         }
         else {
-            throw new Error("Not connected to IBM i");
+            if (retry) {
+                throw new Error("Not connected to IBM i");
+            }
+            else{
+                await vscode.commands.executeCommand(`code-for-ibmi.connectToPrevious`);
+                return this.readFile(uri, true);                
+            }            
         }
     }
 

--- a/src/views/ConnectionBrowser.ts
+++ b/src/views/ConnectionBrowser.ts
@@ -26,10 +26,10 @@ export class ObjectBrowserProvider {
         }
       }),
 
-      vscode.commands.registerCommand(`code-for-ibmi.connectToPrevious`, () => {
+      vscode.commands.registerCommand(`code-for-ibmi.connectToPrevious`, async () => {
         const lastConnection = GlobalStorage.get().getLastConnections()?.[0];
         if (lastConnection) {
-          vscode.commands.executeCommand(`code-for-ibmi.connectTo`, lastConnection.name);
+          return await vscode.commands.executeCommand(`code-for-ibmi.connectTo`, lastConnection.name);
         }
       }),
 


### PR DESCRIPTION
### Changes
Fixes https://github.com/halcyon-tech/vscode-ibmi/issues/1267

Opening VSCode with `member://` or `streamfile://` documents left opened on closing will now force the extension to reconnect before reading the files.

The process will try to reconnect once and throw an error if it fails to reconnect.

### Checklist
* [x] have tested my change
* [x] eslint is not complaining