### PR TITLE
Add check for additional user content in shell output

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -183,7 +183,7 @@ export default class IBMi {
         });
         if (checkShellResult.stderr || checkShellResult.stdout.split(`\n`)[0] !== checkShellText) {
           await vscode.window.showErrorMessage(`Error in shell configuration!`, {
-            detail: `This extension will not function properly, since the output from shell commands have additional content. This can be caused by running commands like "echo" or other\ncommands creating output in your shell start script.\n\nCode for IBM i cannot function correctly and will exit.`,
+            detail: `This extension can not work with the shell configured on ${this.currentConnectionName},\nsince the output from shell commands have additional content.\nThis can be caused by running commands like "echo" or other\ncommands creating output in your shell start script.\n\nThe connection to ${this.currentConnectionName} will be aborted.`,
             modal: true
             });
           throw(`Shell config error, connection aborted.`);

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -172,6 +172,23 @@ export default class IBMi {
         // Reload server settings?
         const quickConnect = (this.config.quickConnect === true && reloadServerSettings === false);
 
+        // Check shell output for additional user text - this will confuse Code...
+        progress.report({
+          message: `Checking shell output.`
+        });
+
+        const checkShellText = `This should be the only text!`;
+        const checkShellResult = await this.sendCommand({
+          command: `echo "${checkShellText}"`
+        });
+        if (checkShellResult.stderr || checkShellResult.stdout.split(`\n`)[0] !== checkShellText) {
+          await vscode.window.showErrorMessage(`Error in shell configuration!`, {
+            detail: `This extension will not function properly, since the output from shell commands have additional content. This can be caused by running commands like "echo" or other\ncommands creating output in your shell start script.\n\nCode for IBM i cannot function correctly and will exit.`,
+            modal: true
+            });
+          throw(`Shell config error, connection aborted.`);
+        }
+
         progress.report({
           message: `Checking home directory.`
         });


### PR DESCRIPTION
### Changes

This PR will add a check for additional user content in the output from shell commands during connection, thus eliminating issues like #1255 and others with similar root cause.

If the user has a shell start script with `echo` or any other command, that sends output to stdout, then Code will not be able to interpret the output correctly, and the user will see some mysterious errors - see #1255. This new check will ensure no such additional user content is present, else an error will be issued and the connection attempt aborted.

![billede](https://user-images.githubusercontent.com/13275072/236079410-598398d9-e30d-4843-9b88-38eeb2b03ac1.png)

![billede](https://user-images.githubusercontent.com/13275072/236075941-c9cb729f-7a9c-4082-8acf-be282af5756b.png)

![billede](https://user-images.githubusercontent.com/13275072/236075975-fdc18d81-6a95-4164-accd-5f2863f3bf38.png)


### Checklist

* [x] have tested my change
* [x] eslint is not complaining
* [x] **for feature PRs**: PR only includes one feature enhancement.
