### PR TITLE
Exclude src/, types/ and tsconfig.json from vsix

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,6 +7,9 @@ vsc-extension-quickstart.md
 **/jsconfig.json
 **/*.map
 **/.eslintrc.json
+**/tsconfig.json
+src/**
+types/**
 docs/**
 .github/**
 node_modules


### PR DESCRIPTION
### Changes
Updated .vscodeignore to exclude the following folders/files from the vsix build:
- `src/`
- `types/`
- `tsconfig.json`

This reduces the size of the vsix from ~400KB to ~200KB.

### Checklist
* [x] have tested my change