### PR TITLE
Fix Quick Connect with undefined values

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -471,8 +471,8 @@ export default class IBMi {
 
         // Check for installed components?
         // For Quick Connect to work here, 'remoteFeatures' MUST have all features defined and no new properties may be added!
-        if (quickConnect === true && cachedServerSettings?.remoteFeatures && Object.keys(cachedServerSettings.remoteFeatures).sort().toString() === Object.keys(this.remoteFeatures).sort().toString()) {
-          this.remoteFeatures = cachedServerSettings.remoteFeatures;
+        if (quickConnect === true && cachedServerSettings?.remoteFeaturesKeys && cachedServerSettings.remoteFeaturesKeys === Object.keys(this.remoteFeatures).sort().toString()) {
+          Object.assign(this.remoteFeatures, cachedServerSettings.remoteFeatures);
         } else {
           progress.report({
             message: `Checking installed components on host IBM i.`
@@ -712,6 +712,7 @@ export default class IBMi {
           aspInfo: this.aspInfo,
           qccsid: this.qccsid,
           remoteFeatures: this.remoteFeatures,
+          remoteFeaturesKeys: Object.keys(this.remoteFeatures).sort().toString(),
           variantChars: {
             american: this.variantChars.american,
             local: this.variantChars.local,

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -91,7 +91,8 @@ export default class IBMi {
       'QZDFMDB2.PGM': undefined,
       'startDebugService.sh': undefined,
       attr: undefined,
-      iconv: undefined
+      iconv: undefined,
+      tar: undefined,
     };
 
     this.variantChars = {

--- a/src/api/Storage.ts
+++ b/src/api/Storage.ts
@@ -38,6 +38,7 @@ export type CachedServerSettings = {
   aspInfo: { [id: number]: string };
   qccsid: number | null;
   remoteFeatures: { [name: string]: string | undefined };
+  remoteFeaturesKeys: string | null;
   variantChars: { american: string, local: string };
   badDataAreasChecked: boolean | null
 } | undefined;


### PR DESCRIPTION
### Changes

This PR will fix the Quick Connect test for remote features.

When any remote features were missing on the system and had the value `undefined`, the cached values for remote features did not include the key for the missing feature. And then the test for matching keys did not work, and the remote features were always searched for on the system.

In this PR the keys for all remote features are cached in addition to the values, and the test has been changed to be on the cached keys and not keys in the cached remote features.

This way any future change to the remote features will still initiate a search on the system, while Quick Connect will work correctly when there is no change to the remote features.

The error was discovered after the `tar` feature was added in #1265 by @sebjulliand - it was not added to the `remoteFeatures` object and thus was not cached, and the search for remote features was always run. This has been fixed as well.

### Checklist

* [x] have tested my change
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
