### PR TITLE
Fix check for existence of `.env` file

### DIFF
--- a/src/api/local/env.ts
+++ b/src/api/local/env.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 
 async function envExists(currentWorkspace: WorkspaceFolder) {
   const folderUri = currentWorkspace.uri;
-  const envUri = folderUri.with({ path: path.join(folderUri.path, `.env`) });
+  const envUri = folderUri.with({ path: path.join(folderUri.fsPath, `.env`) });
 
   try {
     await workspace.fs.stat(envUri);
@@ -21,7 +21,7 @@ export async function getEnvConfig(currentWorkspace: WorkspaceFolder) {
     let readData, readStr;
 
     // Then we get the local .env file
-    const envUri = folderUri.with({ path: path.join(folderUri.path, `.env`) });
+    const envUri = folderUri.with({ path: path.join(folderUri.fsPath, `.env`) });
     readData = await workspace.fs.readFile(envUri);
     readStr = Buffer.from(readData).toString(`utf8`);
 


### PR DESCRIPTION
### Changes

Change to use `fsPath` instead of `path` so check for `.env` file works on Windows

Description of change here.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
