### PR TITLE
New "Open terminal here" action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1433,6 +1433,11 @@
 				"command": "code-for-ibmi.cl.runSelected",
 				"title": "Run selected CL command",
 				"category": "IBM i"
+			},
+			{
+				"command": "code-for-ibmi.openTerminalHere",
+				"title": "Open PASE terminal here",
+				"category": "IBM i"
 			}
 		],
 		"keybindings": [
@@ -1644,6 +1649,10 @@
 				{
 					"command": "code-for-ibmi.cl.runSelected",
 					"when": "code-for-ibmi:connected && editorLangId === cl"
+				},
+				{
+					"command": "code-for-ibmi.openTerminalHere",
+					"when": "never"
 				}
 			],
 			"view/title": [
@@ -2057,14 +2066,19 @@
 					"group": "3_ifsStuff@3"
 				},
 				{
+					"command": "code-for-ibmi.openTerminalHere",
+					"when": "view == ifsBrowser",
+					"group": "4_ifsStuff@3"
+				},
+				{
 					"command": "code-for-ibmi.moveIFSShortcutToTop",
 					"when": "view == ifsBrowser && viewItem == shortcut",
-					"group": "4_ifsStuff@1"
+					"group": "5_ifsStuff@1"
 				},
 				{
 					"command": "code-for-ibmi.moveIFSShortcutToBottom",
 					"when": "view == ifsBrowser && viewItem == shortcut",
-					"group": "4_ifsStuff@4"
+					"group": "5_ifsStuff@4"
 				},
 				{
 					"command": "code-for-ibmi.downloadStreamfile",

--- a/package.json
+++ b/package.json
@@ -1436,7 +1436,7 @@
 			},
 			{
 				"command": "code-for-ibmi.openTerminalHere",
-				"title": "Open PASE terminal here",
+				"title": "Open terminal here",
 				"category": "IBM i"
 			}
 		],

--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -1,21 +1,20 @@
 
-import vscode, { InlineValueVariableLookup, window } from 'vscode';
 import path from 'path';
+import vscode, { window } from 'vscode';
 
-import { ConnectionConfiguration, GlobalConfiguration } from './Configuration';
-import { CustomUI, Field } from './CustomUI';
-import { getEnvConfig } from './local/env';
+import { GlobalConfiguration } from './Configuration';
+import { CustomUI } from './CustomUI';
 import { getLocalActions, getiProjActions } from './local/actions';
+import { getEnvConfig } from './local/env';
 
-import { Deployment } from './local/deployment';
-import { parseErrors } from './errors/handler';
-import { GitExtension } from './import/git';
-import Instance from './Instance';
-import { Action, CommandResult, FileError, RemoteCommand, StandardIO } from '../typings';
-import IBMi, { MemberParts } from './IBMi';
-import { Tools } from './Tools';
 import { parseFSOptions } from '../filesystems/qsys/QSysFs';
 import { instance } from '../instantiate';
+import { Action, CommandResult, FileError, RemoteCommand, StandardIO } from '../typings';
+import IBMi from './IBMi';
+import Instance from './Instance';
+import { Tools } from './Tools';
+import { parseErrors } from './errors/handler';
+import { Deployment } from './local/deployment';
 
 export interface ILELibrarySettings {
   currentLibrary: string;
@@ -197,8 +196,9 @@ export namespace CompileTools {
   }
 
   export async function runAction(instance: Instance, uri: vscode.Uri) {
-    const connection = instance.getConnection();
+    const connection = instance.getConnection();    
     const config = instance.getConfig();
+    const content = instance.getContent();
 
     const uriOptions = parseFSOptions(uri);
 
@@ -214,7 +214,7 @@ export namespace CompileTools {
 
     const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
 
-    if (connection && config) {
+    if (connection && config && content) {
       const extension = uri.path.substring(uri.path.lastIndexOf(`.`) + 1).toUpperCase();
       const fragment = uri.fragment.toUpperCase();
 
@@ -491,13 +491,11 @@ export namespace CompileTools {
                   async (downloadPath) => {
                     const localPath = vscode.Uri.parse(path.posix.join(localDir, downloadPath)).fsPath;
                     const remotePath = path.posix.join(remoteDir, downloadPath);
-                    const isDirectoryCall = (await connection.sendCommand({
-                      command: `cd ${remotePath}`
-                    }));
-                    if (isDirectoryCall.code === 1) {
-                      return client.getFile(localPath, remotePath);
+                    
+                    if (await content.isDirectory(remotePath)) {
+                      return client.getDirectory(localPath, remotePath);                      
                     } else {
-                      return client.getDirectory(localPath, remotePath);
+                      return client.getFile(localPath, remotePath);
                     }
                   }
                 );

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -1,14 +1,14 @@
 import { default as IBMi } from './IBMi';
 
-import path from 'path';
-import util from 'util';
-import tmp from 'tmp';
 import { parse } from 'csv-parse/sync';
-import { Tools } from './Tools';
-import { ObjectTypes } from '../schemas/Objects';
 import fs from 'fs';
-import { ConnectionConfiguration } from './Configuration';
+import path from 'path';
+import tmp from 'tmp';
+import util from 'util';
+import { ObjectTypes } from '../schemas/Objects';
 import { IBMiError, IBMiFile, IBMiMember, IBMiObject, IFSFile, QsysPath } from '../typings';
+import { ConnectionConfiguration } from './Configuration';
+import { Tools } from './Tools';
 const tmpFile = util.promisify(tmp.file);
 const readFileAsync = util.promisify(fs.readFile);
 const writeFileAsync = util.promisify(fs.writeFile);
@@ -733,5 +733,16 @@ export default class IBMiContent {
     let dateString: string = (century === `1` ? `20` : `19`).concat(YYMMDD).concat(HHMMSS);
     [, year, month, day, hours, minutes, seconds] = /(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/.exec(dateString) || [];
     return new Date(Number(year), Number(month)-1, Number(day), Number(hours), Number(minutes), Number(seconds));
+  }
+
+  /**
+   * Return `true` if `remotePath` denotes a directory
+   * 
+   * @param remotePath: a remote IFS path
+   */
+  async isDirectory(remotePath : string){
+    return (await this.ibmi.sendCommand({
+      command: `cd ${remotePath}`
+    })).code === 0;
   }
 }

--- a/src/api/Terminal.ts
+++ b/src/api/Terminal.ts
@@ -77,9 +77,6 @@ export namespace Terminal {
     channel.stdout.on(`data`, (data: any) => {
       writeEmitter.fire(String(data))
     });
-    channel.stderr.on(`data`, (data: any) => {
-      writeEmitter.fire(String(data))
-    });
 
     const emulatorTerminal = vscode.window.createTerminal({
       name: `IBM i ${terminalSettings.type}`,

--- a/src/api/Terminal.ts
+++ b/src/api/Terminal.ts
@@ -10,7 +10,7 @@ function getOrDefaultToUndefined(value: string) {
 }
 
 export namespace Terminal {
-  enum TerminalType {
+  export enum TerminalType {
     PASE = "PASE",
     _5250 = "5250"
   }
@@ -30,127 +30,127 @@ export namespace Terminal {
     connectionString?: string
   }
 
-  export function selectAndOpen(instance: Instance) {
+  export async function selectAndOpen(instance: Instance, openType?: TerminalType) {
     const connection = instance.getConnection();
     const configuration = instance.getConfig();
     if (connection && configuration) {
-      vscode.window.showQuickPick(typeItems, {
+      const type = openType || (await vscode.window.showQuickPick(typeItems, {
         placeHolder: `Select a terminal type`
-      })
-        .then(async typeItem => {
-          if (typeItem) {
-            const terminalSettings: TerminalSettings = {
-              type: typeItem.type,
-              connectionString: configuration.connectringStringFor5250
-            };
+      }))?.type;
 
-            if (terminalSettings.type === TerminalType._5250) {
-              if (!connection.remoteFeatures.tn5250) {
-                vscode.window.showErrorMessage(`5250 terminal is not supported. Please install tn5250 via yum on the remote system.`);
-                return;
-              }
+      if (type) {
+        const terminalSettings: TerminalSettings = {
+          type,
+          connectionString: configuration.connectringStringFor5250
+        };
 
-              terminalSettings.encoding = getOrDefaultToUndefined(configuration.encodingFor5250);
-              terminalSettings.terminal = getOrDefaultToUndefined(configuration.terminalFor5250);
-
-              if (configuration.setDeviceNameFor5250) {
-                terminalSettings.name = await vscode.window.showInputBox({
-                  prompt: `Enter a device name for the terminal.`,
-                  value: ``,
-                  placeHolder: `Blank for default.`
-                }) || undefined;
-              }
-
-              // This makes it so the function keys continue to work in the terminal instead of sending them as VS Code commands
-              vscode.workspace.getConfiguration().update(`terminal.integrated.sendKeybindingsToShell`, true, true);
-            }
-
-            createTerminal(connection, terminalSettings);
+        if (terminalSettings.type === TerminalType._5250) {
+          if (!connection.remoteFeatures.tn5250) {
+            vscode.window.showErrorMessage(`5250 terminal is not supported. Please install tn5250 via yum on the remote system.`);
+            return;
           }
-        });
+
+          terminalSettings.encoding = getOrDefaultToUndefined(configuration.encodingFor5250);
+          terminalSettings.terminal = getOrDefaultToUndefined(configuration.terminalFor5250);
+
+          if (configuration.setDeviceNameFor5250) {
+            terminalSettings.name = await vscode.window.showInputBox({
+              prompt: `Enter a device name for the terminal.`,
+              value: ``,
+              placeHolder: `Blank for default.`
+            }) || undefined;
+          }
+
+          // This makes it so the function keys continue to work in the terminal instead of sending them as VS Code commands
+          vscode.workspace.getConfiguration().update(`terminal.integrated.sendKeybindingsToShell`, true, true);
+        }
+
+        return createTerminal(connection, terminalSettings);
+      }
     }
   }
 
-  function createTerminal(connection: IBMi, terminalSettings: TerminalSettings) {
+  async function createTerminal(connection: IBMi, terminalSettings: TerminalSettings) {
     const writeEmitter = new vscode.EventEmitter<string>();
 
-    connection.client.requestShell().then(channel => {
-      channel.stdout.on(`data`, (data: any) => {
-        writeEmitter.fire(String(data))
-      });
-      channel.stderr.on(`data`, (data: any) => {
-        writeEmitter.fire(String(data))
-      });
+    const channel = await connection.client.requestShell();
+    channel.stdout.on(`data`, (data: any) => {
+      writeEmitter.fire(String(data))
+    });
+    channel.stderr.on(`data`, (data: any) => {
+      writeEmitter.fire(String(data))
+    });
 
-      const emulatorTerminal = vscode.window.createTerminal({
-        name: `IBM i ${terminalSettings.type}`,
-        pty: {
-          onDidWrite: writeEmitter.event,
-          open: () => { },
-          close: () => {
-            channel.close();
-          },
-          handleInput: (data: string) => {
-            if (terminalSettings.type === TerminalType._5250) {
-              const buffer = Buffer.from(data);
-
-              switch (buffer[0]) {
-                case 127: //Backspace
-                  //Move back one, space, move back again - deletes a character
-                  channel.stdin.write(Buffer.from([
-                    27, 79, 68, //Move back one
-                    27, 91, 51, 126 //Delete character
-                  ]));
-                  break;
-                default:
-                  channel.stdin.write(data);
-                  break;
-              }
-            } else {
-              channel.stdin.write(data);
-            }
-          },
-          setDimensions: (dim: vscode.TerminalDimensions) => {
-            channel.setWindow(dim.rows, dim.columns, `500`, `500`);
-          },
+    const emulatorTerminal = vscode.window.createTerminal({
+      name: `IBM i ${terminalSettings.type}`,
+      
+      pty: {
+        onDidWrite: writeEmitter.event,
+        open: () => { },
+        close: () => {
+          channel.close();
         },
-      });
-      channel.on(`close`, () => {
-        channel.destroy();
-        writeEmitter.dispose();
-      });
-      channel.on(`exit`, (code: number, signal: any, coreDump: boolean, desc: string) => {
-        writeEmitter.fire(`----------\r\n`);
-        if (code === 0) {
-          writeEmitter.fire(`Completed successfully.\r\n`);
-        }
-        else if (code) {
-          writeEmitter.fire(`Exited with error code ${code}.\r\n`);
-        }
-        else {
-          writeEmitter.fire(`Exited with signal ${signal}.\r\n`);
-        }
-      });
-      channel.on(`error`, (err: Error) => {
-        vscode.window.showErrorMessage(`Connection error: ${err.message}`);
-        emulatorTerminal.dispose();
-        channel.destroy();
-      });
+        handleInput: (data: string) => {
+          if (terminalSettings.type === TerminalType._5250) {
+            const buffer = Buffer.from(data);
 
-      emulatorTerminal.show();
-
-      if (terminalSettings.type === TerminalType._5250) {
-        channel.stdin.write([
-          `TERM=xterm /QOpenSys/pkgs/bin/tn5250`,
-          terminalSettings.encoding ? `map=${terminalSettings.encoding}` : ``,
-          terminalSettings.terminal ? `env.TERM=${terminalSettings.terminal}` : ``,
-          terminalSettings.name ? `env.DEVNAME=${terminalSettings.name}` : ``,
-          terminalSettings.connectionString || `localhost`,
-          `\n`
-        ].join(` `));
-      } else {
-        channel.stdin.write(`echo "Terminal started. Thanks for using Code for IBM i"\n`);
+            switch (buffer[0]) {
+              case 127: //Backspace
+                //Move back one, space, move back again - deletes a character
+                channel.stdin.write(Buffer.from([
+                  27, 79, 68, //Move back one
+                  27, 91, 51, 126 //Delete character
+                ]));
+                break;
+              default:
+                channel.stdin.write(data);
+                break;
+            }
+          } else {
+            channel.stdin.write(data);
+          }
+        },
+        setDimensions: (dim: vscode.TerminalDimensions) => {
+          channel.setWindow(dim.rows, dim.columns, `500`, `500`);
+        },
+      },
+    });
+    channel.on(`close`, () => {
+      channel.destroy();
+      writeEmitter.dispose();
+    });
+    channel.on(`exit`, (code: number, signal: any, coreDump: boolean, desc: string) => {
+      writeEmitter.fire(`----------\r\n`);
+      if (code === 0) {
+        writeEmitter.fire(`Completed successfully.\r\n`);
+      }
+      else if (code) {
+        writeEmitter.fire(`Exited with error code ${code}.\r\n`);
+      }
+      else {
+        writeEmitter.fire(`Exited with signal ${signal}.\r\n`);
       }
     });
+    channel.on(`error`, (err: Error) => {
+      vscode.window.showErrorMessage(`Connection error: ${err.message}`);
+      emulatorTerminal.dispose();
+      channel.destroy();
+    });
+
+    emulatorTerminal.show();
+    if (terminalSettings.type === TerminalType._5250) {
+      channel.stdin.write([
+        `TERM=xterm /QOpenSys/pkgs/bin/tn5250`,
+        terminalSettings.encoding ? `map=${terminalSettings.encoding}` : ``,
+        terminalSettings.terminal ? `env.TERM=${terminalSettings.terminal}` : ``,
+        terminalSettings.name ? `env.DEVNAME=${terminalSettings.name}` : ``,
+        terminalSettings.connectionString || `localhost`,
+        `\n`
+      ].join(` `));
+    } else {
+      channel.stdin.write(`echo "Terminal started. Thanks for using Code for IBM i"\n`);
+    }
+
+    return emulatorTerminal;
   }
 }

--- a/src/api/Terminal.ts
+++ b/src/api/Terminal.ts
@@ -1,5 +1,6 @@
 
 import vscode from 'vscode';
+import { instance } from '../instantiate';
 import IBMi from './IBMi';
 import Instance from './Instance';
 
@@ -147,6 +148,8 @@ export namespace Terminal {
     } else {
       channel.stdin.write(`echo "Terminal started. Thanks for using Code for IBM i"\n`);
     }
+
+    instance.onEvent('disconnected', () => emulatorTerminal.dispose());
 
     return emulatorTerminal;
   }


### PR DESCRIPTION
### Changes
This PR adds an `Open PASE terminal here` action in the IFS browser.

It can be run on any element. It will open a PASE terminal and change the current directory for the one selected in the browser. If it's run on a file, it will open on the file's parent directory.
If a PASE terminal is already open, it will reuse it instead of creating a new one.

![open_here](https://github.com/halcyon-tech/vscode-ibmi/assets/11096890/4f300da8-6d28-48d5-bc69-93615de4f1a9)

The PR also makes terminals opened by Code for IBM i to be closed when disconnecting.

### Checklist
* [x] have tested my change
* [x] updated relevant documentation
* [x] eslint is not complaining
* [x] **for feature PRs**: PR only includes one feature enhancement.
