### PR TITLE
Ability to reload server settings via connectDirect

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,14 +60,14 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
       new ProfilesView(context)
     ),
     commands.registerCommand(`code-for-ibmi.connectDirect`,
-      async (connectionData: ConnectionData): Promise<boolean> => {
+      async (connectionData: ConnectionData, reloadSettings = false): Promise<boolean> => {
         const existingConnection = instance.getConnection();
 
         if (existingConnection) {
           return false;
         }
 
-        return (await new IBMi().connect(connectionData)).success;
+        return (await new IBMi().connect(connectionData, undefined, reloadSettings)).success;
       }
     ),
     workspace.onDidChangeConfiguration(async event => {


### PR DESCRIPTION
### Changes

Allow users to reload server settings via `connectDirect`

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
