### PR TITLE
feat: Add versions and platform to issue

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,7 +49,7 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
     ),
     window.registerTreeDataProvider(
       `helpView`,
-      new HelpView()
+      new HelpView(context)
     ),
     window.registerTreeDataProvider(
       `libraryListView`,

--- a/src/views/helpView.ts
+++ b/src/views/helpView.ts
@@ -3,6 +3,11 @@ import vscode from 'vscode';
 import {instance} from '../instantiate';
 
 export class HelpView {
+  private _extension_version: string;
+
+  constructor(context: vscode.ExtensionContext) {
+    this._extension_version = context.extension.packageJSON.version;
+  }
 
   public getTreeItem(element : vscode.TreeItem) : vscode.TreeItem {
     return element;
@@ -14,6 +19,10 @@ export class HelpView {
 
     const issueUrl = [
       `Issue text goes here.`,
+      ``,
+      `Code for IBM i version: ${this._extension_version}`,
+      `${vscode.env.appName} version: ${vscode.version}`,
+      `Platform: ${process.platform}`,
       ``,
       `* QCCSID: ${connection?.qccsid || '?'}`,
       `* Features:`,


### PR DESCRIPTION
### Changes

This PR will add the versions of this extension, VS Code and the platform running it to the issue details, when a user created an issue on GitHub from the Help panel.

This could be the start of having more debug information available. We often ask the same questions to users creating issues, and it would be time-saving to have this information available from the beginning.

What else comes to mind? I think of the following:
- the help view should maybe always be present and not just when connected - the user may need help or guidance before connecting to any system.
- the last errors shown are from the connection time. These should always be updated, so we have the errors from the situation when the user is having trouble.

### Checklist

* [x] have tested my change
* [x] eslint is not complaining
* [x] **for feature PRs**: PR only includes one feature enhancement.
