### PR TITLE
Fix member hover change timestamp when using SQL

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -479,7 +479,7 @@ export default class IBMiContent {
           coalesce(b.partition_text, '') as MBMTXT,
           b.NUMBER_ROWS as MBNRCD,
           extract(epoch from (b.CREATE_TIMESTAMP - current_timezone))*1000 as CREATED,
-          extract(epoch from (b.LAST_CHANGE_TIMESTAMP - current_timezone))*1000 as CHANGED
+          extract(epoch from (b.LAST_SOURCE_UPDATE_TIMESTAMP - current_timezone))*1000 as CHANGED
         FROM qsys2.systables AS a
           JOIN qsys2.syspartitionstat AS b
             ON b.table_schema = a.table_schema AND

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -478,8 +478,8 @@ export default class IBMiContent {
           coalesce(cast(b.source_type as varchar(10) for bit data), '') as MBSEU2,
           coalesce(b.partition_text, '') as MBMTXT,
           b.NUMBER_ROWS as MBNRCD,
-          extract(epoch from (b.CREATE_TIMESTAMP - current_timezone))*1000 as CREATED,
-          extract(epoch from (b.LAST_SOURCE_UPDATE_TIMESTAMP - current_timezone))*1000 as CHANGED
+          extract(epoch from (b.CREATE_TIMESTAMP))*1000 as CREATED,
+          extract(epoch from (b.LAST_SOURCE_UPDATE_TIMESTAMP))*1000 as CHANGED
         FROM qsys2.systables AS a
           JOIN qsys2.syspartitionstat AS b
             ON b.table_schema = a.table_schema AND
@@ -749,7 +749,7 @@ export default class IBMiContent {
     let year: string, month: string, day: string, hours: string, minutes: string, seconds: string;
     let dateString: string = (century === `1` ? `20` : `19`).concat(YYMMDD).concat(HHMMSS);
     [, year, month, day, hours, minutes, seconds] = /(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/.exec(dateString) || [];
-    return new Date(Number(year), Number(month) - 1, Number(day), Number(hours), Number(minutes), Number(seconds));
+    return new Date(Date.UTC(Number(year), Number(month) - 1, Number(day), Number(hours), Number(minutes), Number(seconds)));
   }
 
   /**

--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -673,7 +673,7 @@ class Object extends vscode.TreeItem {
     this.path = path;
     this.tooltip = `${path}`
       .concat(`${size !== undefined ? `\nSize:\t\t${size}` : ``}`)
-      .concat(`${modified ? `\nModifed:\t${modified.toLocaleString()}` : ``}`)
+      .concat(`${modified ? `\nModifed:\t${new Date(modified.getTime()-modified.getTimezoneOffset()*60*1000).toISOString().slice(0,19).replace(`T`, ` `)}` : ``}`)
       .concat(`${owner ? `\nOwner:\t${owner.toUpperCase()}` : ``}`);
     this.parent = parent;
 

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -1195,8 +1195,8 @@ class Member extends vscode.TreeItem {
     this.tooltip = `${this.resourceUri.path}`
       .concat(`${member.text ? `\nText:\t\t${member.text}` : ``}`)
       .concat(`${member.lines != undefined ? `\nLines:\t${member.lines}` : ``}`)
-      .concat(`${member.created ? `\nCreated:\t${member.created.toLocaleString()}` : ``}`)
-      .concat(`${member.changed ? `\nChanged:\t${member.changed.toLocaleString()}` : ``}`);
+      .concat(`${member.created ? `\nCreated:\t${member.created.toISOString().slice(0,19).replace(`T`, ` `)}` : ``}`)
+      .concat(`${member.changed ? `\nChanged:\t${member.changed.toISOString().slice(0,19).replace(`T`, ` `)}` : ``}`);
     this.command = {
       command: `vscode.open`,
       title: `Open Member`,


### PR DESCRIPTION
### Changes

This PR will change the member change date and time to show LAST_SOURCE_UPDATE_TIMESTAMP instead of LAST_CHANGE_TIMESTAMP when using SQL - this is the same value as shown when SQL is disabled.

Times are now shown in ISO format `YYYY-MM-DD HH:MM:SS`.
Member timestamps have no timestamp, but the streamfile timestamp will consider the timezone.

### Checklist

* [x] have tested my change
* [x] eslint is not complaining