### PR TITLE
Issue reporting enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1506,15 +1506,15 @@
 		"views": {
 			"ibmi-explorer": [
 				{
+					"id": "helpView",
+					"name": "Help and Support",
+					"when": "!code-for-ibmi:helpViewDisabled"
+				},
+				{
 					"id": "connectionBrowser",
 					"name": "Servers",
 					"when": "code-for-ibmi:connected == false && code-for-ibmi:connectionBrowserDisabled !== true"
-				},
-				{
-					"id": "helpView",
-					"name": "Help and Support",
-					"when": "code-for-ibmi:connected && code-for-ibmi:helpViewDisabled !== true"
-				},
+				},				
 				{
 					"id": "profilesView",
 					"name": "Profiles",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,29 +1,29 @@
 // The module 'vscode' contains the VS Code extensibility API
-import { ExtensionContext, window, commands, workspace } from "vscode";
+import { ExtensionContext, commands, window, workspace } from "vscode";
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 
-import { instance, loadAllofExtension } from './instantiate';
 import { CustomUI } from "./api/CustomUI";
+import { instance, loadAllofExtension } from './instantiate';
 
-import { ObjectBrowserProvider } from "./views/ConnectionBrowser";
-import IBMi from "./api/IBMi";
-import { ConnectionConfiguration, GlobalConfiguration } from "./api/Configuration";
-import { CodeForIBMi, ConnectionData } from "./typings";
-import * as Sandbox from "./sandbox";
-import { Deployment } from "./api/local/deployment";
-import { parseErrors } from "./api/errors/handler";
-import { GlobalStorage } from "./api/Storage";
 import { CompileTools } from "./api/CompileTools";
-import { HelpView } from "./views/helpView";
-import { ProfilesView } from "./views/ProfilesView";
+import { ConnectionConfiguration, GlobalConfiguration } from "./api/Configuration";
+import IBMi from "./api/IBMi";
+import { GlobalStorage } from "./api/Storage";
 import * as Debug from './api/debug';
+import { parseErrors } from "./api/errors/handler";
+import { Deployment } from "./api/local/deployment";
+import { IFSFS } from "./filesystems/ifsFs";
+import * as Sandbox from "./sandbox";
+import { initialise } from "./testing";
+import { CodeForIBMi, ConnectionData } from "./typings";
+import { ObjectBrowserProvider } from "./views/ConnectionBrowser";
+import { LibraryListProvider } from "./views/LibraryListView";
+import { ProfilesView } from "./views/ProfilesView";
+import { HelpView } from "./views/helpView";
 import IFSBrowser from "./views/ifsBrowser";
 import ObjectBrowser from "./views/objectBrowser";
-import { initialise } from "./testing";
-import { IFSFS } from "./filesystems/ifsFs";
-import { LibraryListProvider } from "./views/LibraryListView";
 
 export async function activate(context: ExtensionContext): Promise<CodeForIBMi> {
   // Use the console to output diagnostic information (console.log) and errors (console.error)
@@ -49,7 +49,7 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
     ),
     window.registerTreeDataProvider(
       `helpView`,
-      new HelpView(context)
+      new HelpView()
     ),
     window.registerTreeDataProvider(
       `libraryListView`,

--- a/src/views/helpView.ts
+++ b/src/views/helpView.ts
@@ -14,9 +14,9 @@ export class HelpView {
 
   public async getChildren(): Promise<HelpItem[]> {
     return [
-      new HelpOpenUrkItem(`book`, `Get started`, `https://halcyon-tech.github.io/vscode-ibmi/#/`),
-      new HelpOpenUrkItem(`output`, `Open official Forum`, `https://github.com/halcyon-tech/vscode-ibmi/discussions`),
-      new HelpOpenUrkItem(`eye`, `Review Issues`, `https://github.com/halcyon-tech/vscode-ibmi/issues/`),
+      new HelpOpenUrlItem(`book`, `Get started`, `https://halcyon-tech.github.io/vscode-ibmi/#/`),
+      new HelpOpenUrlItem(`output`, `Open official Forum`, `https://github.com/halcyon-tech/vscode-ibmi/discussions`),
+      new HelpOpenUrlItem(`eye`, `Review Issues`, `https://github.com/halcyon-tech/vscode-ibmi/issues/`),
       new HelpIssueItem(),
     ];
   }
@@ -31,7 +31,7 @@ class HelpItem extends vscode.TreeItem {
   }
 }
 
-class HelpOpenUrkItem extends HelpItem {
+class HelpOpenUrlItem extends HelpItem {
   constructor(icon: string, text: string, url: string) {
     super(icon, text);
 
@@ -62,11 +62,29 @@ function openNewIssue() {
     `Code for IBM i version: ${code4ibmi?.packageJSON.version}`,
     `${vscode.env.appName} version: ${vscode.version}`,
     `Platform: ${process.platform}`,
+    getExtensions(true),
+    ``,
+    getExtensions(false),
     ``,
     getRemoteSection(),
   ].join(`\n`);
 
   vscode.commands.executeCommand(`vscode.open`, `https://github.com/halcyon-tech/vscode-ibmi/issues/new?body=${encodeURIComponent(issueUrl)}`);
+}
+
+function getExtensions(active: boolean) {
+  return ['<details>',
+    `<summary>${active? 'Active' : 'Disabled'} extensions</summary>`,
+    '',
+    `\`\`\``,
+    ...vscode.extensions.all.filter(extension => extension.isActive === active)
+      .map(extension => extension.packageJSON)
+      .map(p => `${p.displayName} (${p.name}): ${p.version}`)
+      .sort(),
+    `\`\`\``,
+    `</details>`
+  ]
+    .join("\n");
 }
 
 function getRemoteSection() {

--- a/src/views/helpView.ts
+++ b/src/views/helpView.ts
@@ -57,26 +57,41 @@ class HelpIssueItem extends HelpItem {
 
 async function openNewIssue() {
   const code4ibmi = vscode.extensions.getExtension("halcyontechltd.code-for-ibmi");
-  const issueUrl = [
+  const issue = [
     `Issue text goes here.`,
     ``,
-    `Code for IBM i version: ${code4ibmi?.packageJSON.version}`,
-    `${vscode.env.appName} version: ${vscode.version}`,
-    `Platform: ${process.platform}_${process.arch}`,
+    `<hr />`,
+    ``,
+    '|Context|Version|',
+    '|-|-|',
+    `|Code for IBM i version|${code4ibmi?.packageJSON.version}|`,
+    `|${vscode.env.appName} version|${vscode.version}|`,
+    `|Operating System|${process.platform}_${process.arch}|`,
+    ``,
     getExtensions(true),
+    ``,
+    `<hr />`,
     ``,
     await getRemoteSection(),
   ].join(`\n`);
 
-  vscode.commands.executeCommand(`vscode.open`, `https://github.com/halcyon-tech/vscode-ibmi/issues/new?body=${encodeURIComponent(issueUrl)}`);
+  let issueUrl = encodeURIComponent(issue);
+  if (issueUrl.length > 8130) {
+    //Empirically tested: issueUrl must not exceed 8130 characters
+    issueUrl = issueUrl.substring(0, 8130);
+  }
+
+  vscode.commands.executeCommand(`vscode.open`, `https://github.com/halcyon-tech/vscode-ibmi/issues/new?body=${issueUrl}`);
 }
 
 function getExtensions(active: boolean) {
   return createSection(
     `${active ? 'Active' : 'Disabled'} extensions`,
     `\`\`\``,
-    ...vscode.extensions.all.filter(extension => extension.isActive === active)
+    ...vscode.extensions.all
+      .filter(extension => extension.isActive === active)
       .map(extension => extension.packageJSON)
+      .filter(p => p.name !== "code-for-ibmi")
       .map(p => `${p.displayName} (${p.name}): ${p.version}`)
       .sort(),
     `\`\`\``,
@@ -86,27 +101,47 @@ function getExtensions(active: boolean) {
 async function getRemoteSection() {
   const connection = instance.getConnection();
   const config = instance.getConfig();
-  if (connection && config) {
-    return [
-      createSection(`Remote system`,
-        `* QCCSID: ${connection?.qccsid || '?'}`,
-        `* Enabled features:`,
-      ...Object.keys(connection?.remoteFeatures || {}).filter(f => connection?.remoteFeatures[f]).map(f =>`  * ${f}`).sort(),
-      `* SQL enabled: ${config ? config.enableSQL : '?'}`,
-      `* Source dates enabled: ${config ? config.enableSourceDates : '?'}`),
-      ``,
-    createSection(`Shell env`, `\`\`\`bash`, ...await getEnv(connection), `\`\`\``,),
-      ``,
-    createSection(`Variants`,
-      `\`\`\`json`,
-     JSON.stringify(connection?.variantChars || {}, null, 2),
-      `\`\`\``),
-    ``,
-    createSection(`Errors`,
-      `\`\`\`json`,
-      JSON.stringify(connection?.lastErrors || [], null, 2),
-      `\`\`\``)
-    ].join("\n");
+  const content = instance.getContent();
+  if (connection && config && content) {    
+      return await vscode.window.withProgress({
+        location: vscode.ProgressLocation.Notification,
+        title: `Gathering issue details...`,
+      }, async progress => {
+        const [osVersion] = await content.runSQL(
+          `SELECT PTF_GROUP_TARGET_RELEASE as OS, PTF_GROUP_LEVEL AS TR ` +
+          `FROM QSYS2.GROUP_PTF_INFO ` +
+          `WHERE PTF_GROUP_DESCRIPTION = 'TECHNOLOGY REFRESH' AND PTF_GROUP_STATUS = 'INSTALLED' ` +
+          `ORDER BY PTF_GROUP_TARGET_RELEASE, PTF_GROUP_LEVEL DESC ` +
+          `LIMIT 1`
+        );
+        
+        return [
+          createSection(`Remote system`,
+            '|Setting|Value|',
+            '|-|-|',
+            `|IBM i OS|${osVersion?.OS || '?'}|`,
+            `|Tech Refresh|${osVersion?.TR || '?'}|`,
+            `|QCCSID|${connection.qccsid || '?'}|`,
+            `|SQL|${config.enableSQL ? 'Enabled' : 'Disabled'}`,
+            `|Source dates|${config.enableSourceDates ? 'Enabled' : 'Disabled'}`,
+            '',
+            `* Enabled features:`,
+            ...Object.keys(connection?.remoteFeatures || {}).filter(f => connection?.remoteFeatures[f]).map(f => `  * ${f}`).sort(),
+          ),
+          ``,
+          createSection(`Shell env`, `\`\`\`bash`, ...await getEnv(connection), `\`\`\``,),
+          ``,
+          createSection(`Variants`,
+            `\`\`\`json`,
+            JSON.stringify(connection?.variantChars || {}, null, 2),
+            `\`\`\``),
+          ``,
+          createSection(`Errors`,
+            `\`\`\`json`,
+            JSON.stringify(connection?.lastErrors || [], null, 2),
+            `\`\`\``)
+        ].join("\n");
+    });
   }
   else {
     return "*_Not connected_*";
@@ -126,10 +161,13 @@ async function getEnv(connection: IBMi) {
 }
 
 function createSection(summary: string, ...details: string[]) {
-  return ['<details>',
+  return [
+    '',
+    '<details>',
     `<summary>${summary}</summary>`,
     '',
     ...details,
-    `</details>`
+    `</details>`,
+    ''
   ].join("\n");
 }

--- a/src/views/helpView.ts
+++ b/src/views/helpView.ts
@@ -1,69 +1,97 @@
 
 import vscode from 'vscode';
-import {instance} from '../instantiate';
+import { instance } from '../instantiate';
 
 export class HelpView {
-  private _extension_version: string;
 
-  constructor(context: vscode.ExtensionContext) {
-    this._extension_version = context.extension.packageJSON.version;
+  constructor() {
+    vscode.commands.registerCommand("code-for-ibmi.openNewIssue", openNewIssue)
   }
 
-  public getTreeItem(element : vscode.TreeItem) : vscode.TreeItem {
+  public getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
     return element;
   }
 
-  public async getChildren() : Promise<HelpItem[]>{
-    const connection = instance.getConnection();
-    const config = instance.getConfig();
-
-    const issueUrl = [
-      `Issue text goes here.`,
-      ``,
-      `Code for IBM i version: ${this._extension_version}`,
-      `${vscode.env.appName} version: ${vscode.version}`,
-      `Platform: ${process.platform}`,
-      ``,
-      `* QCCSID: ${connection?.qccsid || '?'}`,
-      `* Features:`,
-      ...Object.keys(connection?.remoteFeatures || {}).map(
-        (feature) => `   * ${feature}: ${connection?.remoteFeatures[feature] !== undefined}`
-      ),
-      `* SQL enabled: ${config ? config.enableSQL : '?'}`,
-      `* Source dates enabled: ${config ? config.enableSourceDates : '?'}`,
-      ``,
-      `Variants`,
-      `\`\`\`json`,
-      JSON.stringify(connection?.variantChars || {}, null, 2),
-      `\`\`\``,
-      ``,
-      `Errors:`,
-      `\`\`\`json`,
-      JSON.stringify(connection?.lastErrors || [], null, 2),
-      `\`\`\``,
-    ].join(`\n`);
-
+  public async getChildren(): Promise<HelpItem[]> {
     return [
-      new HelpItem(`book`, `Get started`, `https://halcyon-tech.github.io/vscode-ibmi/#/`),
-      new HelpItem(`output`, `Open official Forum`, `https://github.com/halcyon-tech/vscode-ibmi/discussions`),
-      new HelpItem(`eye`, `Review Issues`, `https://github.com/halcyon-tech/vscode-ibmi/issues/`),
-      new HelpItem(`bug`, `Report an Issue`, `https://github.com/halcyon-tech/vscode-ibmi/issues/new?body=${encodeURIComponent(issueUrl)}`),
+      new HelpOpenUrkItem(`book`, `Get started`, `https://halcyon-tech.github.io/vscode-ibmi/#/`),
+      new HelpOpenUrkItem(`output`, `Open official Forum`, `https://github.com/halcyon-tech/vscode-ibmi/discussions`),
+      new HelpOpenUrkItem(`eye`, `Review Issues`, `https://github.com/halcyon-tech/vscode-ibmi/issues/`),
+      new HelpIssueItem(),
     ];
   }
 }
 
 class HelpItem extends vscode.TreeItem {
-  constructor(icon : string, text: string, url: string) {
+  constructor(icon: string, readonly text: string) {
     super(text, vscode.TreeItemCollapsibleState.None);
 
-    this.contextValue = `hitSource`;
-    
+    this.contextValue = `helpItem`;
     this.iconPath = new vscode.ThemeIcon(icon);
+  }
+}
+
+class HelpOpenUrkItem extends HelpItem {
+  constructor(icon: string, text: string, url: string) {
+    super(icon, text);
 
     this.command = {
       command: `vscode.open`,
       title: text,
       arguments: [vscode.Uri.parse(url)]
     };
+  }
+}
+
+class HelpIssueItem extends HelpItem {
+  constructor() {
+    super(`bug`, `Report an Issue`);
+
+    this.command = {
+      command: "code-for-ibmi.openNewIssue",
+      title: this.text
+    };
+  }
+}
+
+function openNewIssue() {
+  const code4ibmi = vscode.extensions.getExtension("halcyontechltd.code-for-ibmi");
+  const issueUrl = [
+    `Issue text goes here.`,
+    ``,
+    `Code for IBM i version: ${code4ibmi?.packageJSON.version}`,
+    `${vscode.env.appName} version: ${vscode.version}`,
+    `Platform: ${process.platform}`,
+    ``,
+    getRemoteSection(),
+  ].join(`\n`);
+
+  vscode.commands.executeCommand(`vscode.open`, `https://github.com/halcyon-tech/vscode-ibmi/issues/new?body=${encodeURIComponent(issueUrl)}`);
+}
+
+function getRemoteSection() {
+  const connection = instance.getConnection();
+  const config = instance.getConfig();
+  if (connection && config) {
+    return [`* QCCSID: ${connection?.qccsid || '?'}`,
+      `* Features:`,
+    ...Object.keys(connection?.remoteFeatures || {}).map(
+      (feature) => `   * ${feature}: ${connection?.remoteFeatures[feature] !== undefined}`
+    ),
+    `* SQL enabled: ${config ? config.enableSQL : '?'}`,
+    `* Source dates enabled: ${config ? config.enableSourceDates : '?'}`,
+      ``,
+      `Variants`,
+      `\`\`\`json`,
+    JSON.stringify(connection?.variantChars || {}, null, 2),
+      `\`\`\``,
+      ``,
+      `Errors:`,
+      `\`\`\`json`,
+    JSON.stringify(connection?.lastErrors || [], null, 2),
+      `\`\`\``].join("\n");
+  }
+  else {
+    return "*_Not connected_*";
   }
 }

--- a/src/views/helpView.ts
+++ b/src/views/helpView.ts
@@ -73,24 +73,22 @@ function openNewIssue() {
 }
 
 function getExtensions(active: boolean) {
-  return ['<details>',
-    `<summary>${active? 'Active' : 'Disabled'} extensions</summary>`,
-    '',
+  return createSection(
+    `${active ? 'Active' : 'Disabled'} extensions`,
     `\`\`\``,
     ...vscode.extensions.all.filter(extension => extension.isActive === active)
-      .map(extension => extension.packageJSON)
-      .map(p => `${p.displayName} (${p.name}): ${p.version}`)
-      .sort(),
+    .map(extension => extension.packageJSON)
+    .map(p => `${p.displayName} (${p.name}): ${p.version}`)
+    .sort(),
     `\`\`\``,
-    `</details>`
-  ]
-    .join("\n");
+  );
 }
 
 function getRemoteSection() {
   const connection = instance.getConnection();
   const config = instance.getConfig();
   if (connection && config) {
+    //getOutput(connection.outputChannel?.name || "", connection.outputChannel!);
     return [`* QCCSID: ${connection?.qccsid || '?'}`,
       `* Features:`,
     ...Object.keys(connection?.remoteFeatures || {}).map(
@@ -107,9 +105,26 @@ function getRemoteSection() {
       `Errors:`,
       `\`\`\`json`,
     JSON.stringify(connection?.lastErrors || [], null, 2),
-      `\`\`\``].join("\n");
+      `\`\`\``]
+      .join("\n");
   }
   else {
     return "*_Not connected_*";
   }
+}
+
+function getOutput(title: string, output: vscode.OutputChannel) {
+  return createSection(
+    title,
+    output.name
+  );
+}
+
+function createSection(summary: string, ...details: string[]) {
+  return ['<details>',
+    `<summary>${summary}</summary>`,
+    '',
+    ...details,
+    `</details>`
+  ].join("\n");
 }


### PR DESCRIPTION
### Changes

#### Issue reporting template reorganization
- The `Help & Support` view is now always displayed (not only when connected)
- Issue template's content depends on the extension connection status
- The template now organize information in collapsed sections to improve readability
![image](https://github.com/halcyon-tech/vscode-ibmi/assets/11096890/d1559601-34eb-40cd-a33d-180d0a4670ff)
- Some data are now listed in tables to improve readability

#### New information added to the report:
- Platform's architecture
- List of active extensions
- IBM i OS version and TR number
- Shell `env` output

### Checklist

* [x] have tested my change
* [x] updated relevant documentation