### PR TITLE
Fixed Getting Started URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Maintain your RPGLE, CL, COBOL, C/CPP on IBM i right from Visual Studio Code. Ed
 
 * [Install from Marketplace](https://marketplace.visualstudio.com/items?itemName=HalcyonTechLtd.code-for-ibmi) 💻
 * [Watch some tutorials](https://www.youtube.com/playlist?list=PLNl31cqBafCp-ml8WqPeriHWLD1bkg7KL) 📺
-* [View our documentation](https://halcyon-tech.github.io/vscode-ibmi/#/) 📘
+* [View our documentation](https://halcyon-tech.github.io/docs/#/) 📘
 * [See previous releases](https://github.com/halcyon-tech/vscode-ibmi/releases) 🔎
 * Build from source (see below!) 🔨
-* [Use our IBM i API in your own extension](https://halcyon-tech.github.io/vscode-ibmi/#/pages/api/extending) 🛠
+* [Use our IBM i API in your own extension](https://halcyon-tech.github.io/docs/#/pages/api/extending) 🛠
 
 ![https://marketplace.visualstudio.com/items?itemName=HalcyonTechLtd.code-for-ibmi](https://img.shields.io/visual-studio-marketplace/v/HalcyonTechLtd.code-for-ibmi?style=flat-square) 
 ![https://marketplace.visualstudio.com/items?itemName=HalcyonTechLtd.code-for-ibmi](https://img.shields.io/visual-studio-marketplace/i/HalcyonTechLtd.code-for-ibmi?style=flat-square) 

--- a/src/views/helpView.ts
+++ b/src/views/helpView.ts
@@ -15,7 +15,7 @@ export class HelpView {
 
   public async getChildren(): Promise<HelpItem[]> {
     return [
-      new HelpOpenUrlItem(`book`, `Get started`, `https://halcyon-tech.github.io/vscode-ibmi/#/`),
+      new HelpOpenUrlItem(`book`, `Get started`, `https://halcyon-tech.github.io/docs/#/`),
       new HelpOpenUrlItem(`output`, `Open official Forum`, `https://github.com/halcyon-tech/vscode-ibmi/discussions`),
       new HelpOpenUrlItem(`eye`, `Review Issues`, `https://github.com/halcyon-tech/vscode-ibmi/issues/`),
       new HelpIssueItem(),


### PR DESCRIPTION
### Changes
Fixes https://github.com/halcyon-tech/vscode-ibmi/issues/1320
Fixed the `Getting Started` from the `Help and Support` view pointing to a wrong URL.
Fixed the `README` links as well.

### Checklist
* [x] have tested my change