### PR TITLE
Fix display of empty and non-existing directories

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -455,8 +455,8 @@ export default class IBMiContent {
 
     const library = lib.toUpperCase();
     const sourceFile = spf.toUpperCase();
-    let member = (mbr !== `*` ? mbr : null);
-    let memberExt = (ext !== `*` ? ext : null);
+    let member = (mbr !== `*` ? mbr.toUpperCase() : null);
+    let memberExt = (ext !== `*` ? ext.toUpperCase() : null);
 
     let results: Tools.DB2Row[];
 

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -749,7 +749,7 @@ export default class IBMiContent {
    */
   getDspfdDate(century: string = `0`, YYMMDD: string = `010101`, HHMMSS: string = `000000`): Date {
     let year: string, month: string, day: string, hours: string, minutes: string, seconds: string;
-    let dateString: string = (century === `1` ? `20` : `19`).concat(YYMMDD).concat(HHMMSS);
+    let dateString: string = (century === `1` ? `20` : `19`).concat(YYMMDD.padStart(6, `0`)).concat(HHMMSS.padStart(6, `0`));
     [, year, month, day, hours, minutes, seconds] = /(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/.exec(dateString) || [];
     return new Date(Date.UTC(Number(year), Number(month) - 1, Number(day), Number(hours), Number(minutes), Number(seconds)));
   }

--- a/src/testing/connection.ts
+++ b/src/testing/connection.ts
@@ -2,6 +2,7 @@ import assert from "assert";
 import { TestSuite } from ".";
 import { instance } from "../instantiate";
 import { commands } from "vscode";
+import { CommandResult } from "../typings";
 
 export const ConnectionSuite: TestSuite = {
   name: `Connection tests`,
@@ -144,16 +145,20 @@ export const ConnectionSuite: TestSuite = {
 
     {name: `runCommand API compared to code-for-ibmi.runCommand (deprecated)`, test: async () => {
       const connection = instance.getConnection();
+      let resultA: CommandResult | null | undefined;
+      let resultB: CommandResult | null | undefined;
   
-      const resultA = await connection?.runCommand({
+      resultA = await connection?.runCommand({
         command: `DSPLIBL`,
         environment: `ile`
       });
-  
-      const resultB = await commands.executeCommand(`code-for-ibmi.runCommand`, {
+      resultA!.stdout = resultA!.stdout.split(`\n`).slice(1).join(`\n`); // Ignore first line, contains timestamp...
+
+      resultB = await commands.executeCommand(`code-for-ibmi.runCommand`, {
         command: `DSPLIBL`,
         environment: `ile`
       });
+      resultB!.stdout = resultB!.stdout.split(`\n`).slice(1).join(`\n`); // Ignore first line, contains timestamp...
 
       assert.deepStrictEqual(resultA, resultB);
     }},

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -190,16 +190,12 @@ export const ContentSuite: TestSuite = {
       assert.strictEqual(qsysLib?.type, `directory`);
     }},
 
-    {name: `Test getFileList`, test: async () => {
+    {name: `Test getFileList (non-existing file)`, test: async () => {
       const content = instance.getContent();
-  
-      const objects = await content?.getFileList(`/`);
 
-      const qsysLib = objects?.find(obj => obj.name === `QSYS.LIB`);
+      const objects = await content?.getFileList(`/tmp/${Date.now()}`);
 
-      assert.strictEqual(qsysLib?.name, `QSYS.LIB`);
-      assert.strictEqual(qsysLib?.path, `/QSYS.LIB/`);
-      assert.strictEqual(qsysLib?.type, `directory`);
+      assert.strictEqual(objects?.length, 0);
     }},
 
     {name: `Test getObjectList (all objects)`, test: async () => {

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -244,12 +244,14 @@ export const ContentSuite: TestSuite = {
 
     {name: `getMemberList (SQL, no filter)`, test: async () => {
       const content = instance.getContent();
-  
-      const members = await content?.getMemberList(`qsysinc`, `mih`);
 
-      assert.strictEqual(members?.length, 148);
+      let members = await content?.getMemberList(`qsysinc`, `mih`, `*inxen`);
 
-      const actbpgm = members.find(mbr => mbr.name === `ACTBPGM`);
+      assert.strictEqual(members?.length, 3);
+
+      members = await content?.getMemberList(`qsysinc`, `mih`);
+
+      const actbpgm = members?.find(mbr => mbr.name === `ACTBPGM`);
 
       assert.strictEqual(actbpgm?.name, `ACTBPGM`);
       assert.strictEqual(actbpgm?.extension, `C`);

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -186,8 +186,9 @@ export const ContentSuite: TestSuite = {
       const qsysLib = objects?.find(obj => obj.name === `QSYS.LIB`);
 
       assert.strictEqual(qsysLib?.name, `QSYS.LIB`);
-      assert.strictEqual(qsysLib?.path, `/QSYS.LIB/`);
+      assert.strictEqual(qsysLib?.path, `/QSYS.LIB`);
       assert.strictEqual(qsysLib?.type, `directory`);
+      assert.strictEqual(qsysLib?.owner, `qsys`);
     }},
 
     {name: `Test getFileList (non-existing file)`, test: async () => {

--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -87,6 +87,7 @@ module.exports = class IFSBrowser {
 
       vscode.commands.registerCommand(`code-for-ibmi.addIFSShortcut`, async (node) => {
         const config = getInstance().getConfig();
+        const content = getInstance().getContent();
 
         let newDirectory;
 
@@ -102,7 +103,9 @@ module.exports = class IFSBrowser {
           if (newDirectory) {
             newDirectory = newDirectory.trim();
 
-            if (!shortcuts.includes(newDirectory)) {
+            if (await content.isDirectory(newDirectory) !== true) {
+              throw(`${newDirectory} is not a directory.`);
+            } else if (!shortcuts.includes(newDirectory)) {
               shortcuts.push(newDirectory);
               config.ifsShortcuts = shortcuts;
               await ConnectionConfiguration.update(config);
@@ -111,7 +114,7 @@ module.exports = class IFSBrowser {
             }
           }
         } catch (e) {
-          console.log(e);
+          vscode.window.showErrorMessage(`Error creating IFS shortcut! ${e}`);
         }
       }),
 


### PR DESCRIPTION
### Changes

This PR will fix the display of non-existing and empty directories in the IFS browser. Now errors will be caught for `stat` output:

![billede](https://github.com/halcyon-tech/vscode-ibmi/assets/13275072/b094db6d-414e-4782-83a0-5fc83b40c8b3)

And the list of files will only be generated when the directory has content (`stdout` is not blank).

![billede](https://github.com/halcyon-tech/vscode-ibmi/assets/13275072/eced7a9d-2771-4ecf-b0c8-9ee7ba24d401)

The PR was created to fix issue #1325.

Additional tests and fixes:
- Test for getting non-existing IFS file
- Fix test getFileList for QSYS.LIB (path was not valid, owner was added)
- Fix test of runCommand API
- Allow lowercase member and extension in getMemberList (previously only library and sourcefile were uppercased)
- Fix test of getMemberList (SQL, no filter) (number of members in QSYSINC/MIH varied across releases)
- Pad member dates and times with zeros (non-SQL) (made timestamp creation fail)
- Test for valid directory when creating IFS shortcut (as suggested by @sebjulliand)

### Checklist

* [x] have tested my change
* [x] eslint is not complaining
