### PR TITLE
Upgrade node-ssh to 13.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
 	"name": "code-for-ibmi",
-	"version": "1.8.0",
+	"version": "1.9.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "code-for-ibmi",
-			"version": "1.8.0",
+			"version": "1.9.1",
 			"license": "MIT",
 			"dependencies": {
 				"@bendera/vscode-webview-elements": "^0.12.0",
 				"@types/tmp": "^0.2.3",
 				"csv": "^6.2.1",
 				"ignore": "^5.1.9",
-				"node-ssh": "^11.1.1",
+				"node-ssh": "^13.1.0",
 				"tar": "^6.1.13",
 				"tmp": "^0.2.1",
 				"vscode-diff": "^2.0.2"
@@ -703,6 +703,19 @@
 				"source-map": "^0.6.0"
 			}
 		},
+		"node_modules/@types/ssh2": {
+			"version": "1.11.11",
+			"resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.11.11.tgz",
+			"integrity": "sha512-LdnE7UBpvHCgUznvn2fwLt2hkaENcKPFqOyXGkvyTLfxCXBN6roc1RmECNYuzzbHePzD3PaAov5rri9hehzx9Q==",
+			"dependencies": {
+				"@types/node": "^18.11.18"
+			}
+		},
+		"node_modules/@types/ssh2/node_modules/@types/node": {
+			"version": "18.16.16",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
+			"integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g=="
+		},
 		"node_modules/@types/tar": {
 			"version": "6.1.4",
 			"resolved": "https://registry.npmjs.org/@types/tar/-/tar-6.1.4.tgz",
@@ -1164,6 +1177,15 @@
 				"node": ">=0.2.0"
 			}
 		},
+		"node_modules/buildcheck": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
+			"integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
+			"optional": true,
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1288,6 +1310,20 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
 			"dev": true
+		},
+		"node_modules/cpu-features": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.8.tgz",
+			"integrity": "sha512-BbHBvtYhUhksqTjr6bhNOjGgMnhwhGTQmOoZGD+K7BCaQDCuZl/Ve1ZxUSMRwVC4D/rkCPQ2MAIeYzrWyK7eEg==",
+			"hasInstallScript": true,
+			"optional": true,
+			"dependencies": {
+				"buildcheck": "~0.0.6",
+				"nan": "^2.17.0"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
@@ -2145,6 +2181,17 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -2486,6 +2533,12 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
+		"node_modules/nan": {
+			"version": "2.17.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+			"integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+			"optional": true
+		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -2505,18 +2558,20 @@
 			"dev": true
 		},
 		"node_modules/node-ssh": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/node-ssh/-/node-ssh-11.1.1.tgz",
-			"integrity": "sha512-B3Tb3t54nCj2PyA8vnUMeH19Z2hybJzg5n4t9mRCOTfVGwGlJrv0frDjhPjisTAg3JplJiSxzfImOTMvFPkraQ==",
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/node-ssh/-/node-ssh-13.1.0.tgz",
+			"integrity": "sha512-GLcw49yFd9+rUpP+FgX6wrF/N90cmuDl2n0i8d3L828b6riRjkb9w3SS+XvviRWbrAhLxuMKywFqxvQDZQ1bug==",
 			"dependencies": {
+				"@types/ssh2": "^1.11.9",
+				"is-stream": "^2.0.0",
 				"make-dir": "^3.1.0",
 				"sb-promise-queue": "^2.1.0",
 				"sb-scandir": "^3.1.0",
 				"shell-escape": "^0.2.0",
-				"ssh2": "^0.8.9"
+				"ssh2": "^1.11.0"
 			},
 			"engines": {
-				"node": ">= 8"
+				"node": ">= 10"
 			}
 		},
 		"node_modules/once": {
@@ -2970,41 +3025,26 @@
 			"dev": true
 		},
 		"node_modules/ssh2": {
-			"version": "0.8.9",
-			"resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.9.tgz",
-			"integrity": "sha512-GmoNPxWDMkVpMFa9LVVzQZHF6EW3WKmBwL+4/GeILf2hFmix5Isxm7Amamo8o7bHiU0tC+wXsGcUXOxp8ChPaw==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.13.0.tgz",
+			"integrity": "sha512-CIZBFRRY1y9mAZSqBGFE4EB4dNJad2ysT2PqO8OpkiI3UTB/gUZwE5EaN16qVyQ6s/M7EgC/iaV/MnjdlvnuzA==",
+			"hasInstallScript": true,
 			"dependencies": {
-				"ssh2-streams": "~0.4.10"
+				"asn1": "^0.2.6",
+				"bcrypt-pbkdf": "^1.0.2"
 			},
 			"engines": {
-				"node": ">=5.2.0"
-			}
-		},
-		"node_modules/ssh2-streams": {
-			"version": "0.4.10",
-			"resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.10.tgz",
-			"integrity": "sha512-8pnlMjvnIZJvmTzUIIA5nT4jr2ZWNNVHwyXfMGdRJbug9TpI3kd99ffglgfSWqujVv/0gxwMsDn9j9RVst8yhQ==",
-			"dependencies": {
-				"asn1": "~0.2.0",
-				"bcrypt-pbkdf": "^1.0.2",
-				"streamsearch": "~0.1.2"
+				"node": ">=10.16.0"
 			},
-			"engines": {
-				"node": ">=5.2.0"
+			"optionalDependencies": {
+				"cpu-features": "~0.0.7",
+				"nan": "^2.17.0"
 			}
 		},
 		"node_modules/stream-transform": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-3.2.0.tgz",
 			"integrity": "sha512-M22v88wNknyJiIyHYoiIYI5RPl/R7tkf92j1YNkmrbe5XRGHW0jW8n458j1njOrR4Edcj8bwbpSV0iLIWon1hg=="
-		},
-		"node_modules/streamsearch": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-			"integrity": "sha512-jos8u++JKm0ARcSUTAZXOVC0mSox7Bhn6sBgty73P1f3JGf7yG2clTbBNHUdde/kdvP2FESam+vM6l8jBrNxHA==",
-			"engines": {
-				"node": ">=0.8.0"
-			}
 		},
 		"node_modules/string_decoder": {
 			"version": "1.1.1",
@@ -4026,6 +4066,21 @@
 				"source-map": "^0.6.0"
 			}
 		},
+		"@types/ssh2": {
+			"version": "1.11.11",
+			"resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.11.11.tgz",
+			"integrity": "sha512-LdnE7UBpvHCgUznvn2fwLt2hkaENcKPFqOyXGkvyTLfxCXBN6roc1RmECNYuzzbHePzD3PaAov5rri9hehzx9Q==",
+			"requires": {
+				"@types/node": "^18.11.18"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "18.16.16",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
+					"integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g=="
+				}
+			}
+		},
 		"@types/tar": {
 			"version": "6.1.4",
 			"resolved": "https://registry.npmjs.org/@types/tar/-/tar-6.1.4.tgz",
@@ -4408,6 +4463,12 @@
 			"integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
 			"dev": true
 		},
+		"buildcheck": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
+			"integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
+			"optional": true
+		},
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -4498,6 +4559,16 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
 			"dev": true
+		},
+		"cpu-features": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.8.tgz",
+			"integrity": "sha512-BbHBvtYhUhksqTjr6bhNOjGgMnhwhGTQmOoZGD+K7BCaQDCuZl/Ve1ZxUSMRwVC4D/rkCPQ2MAIeYzrWyK7eEg==",
+			"optional": true,
+			"requires": {
+				"buildcheck": "~0.0.6",
+				"nan": "^2.17.0"
+			}
 		},
 		"cross-spawn": {
 			"version": "7.0.3",
@@ -5157,6 +5228,11 @@
 				"isobject": "^3.0.1"
 			}
 		},
+		"is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -5432,6 +5508,12 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
+		"nan": {
+			"version": "2.17.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+			"integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+			"optional": true
+		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -5451,15 +5533,17 @@
 			"dev": true
 		},
 		"node-ssh": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/node-ssh/-/node-ssh-11.1.1.tgz",
-			"integrity": "sha512-B3Tb3t54nCj2PyA8vnUMeH19Z2hybJzg5n4t9mRCOTfVGwGlJrv0frDjhPjisTAg3JplJiSxzfImOTMvFPkraQ==",
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/node-ssh/-/node-ssh-13.1.0.tgz",
+			"integrity": "sha512-GLcw49yFd9+rUpP+FgX6wrF/N90cmuDl2n0i8d3L828b6riRjkb9w3SS+XvviRWbrAhLxuMKywFqxvQDZQ1bug==",
 			"requires": {
+				"@types/ssh2": "^1.11.9",
+				"is-stream": "^2.0.0",
 				"make-dir": "^3.1.0",
 				"sb-promise-queue": "^2.1.0",
 				"sb-scandir": "^3.1.0",
 				"shell-escape": "^0.2.0",
-				"ssh2": "^0.8.9"
+				"ssh2": "^1.11.0"
 			}
 		},
 		"once": {
@@ -5800,32 +5884,20 @@
 			"dev": true
 		},
 		"ssh2": {
-			"version": "0.8.9",
-			"resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.9.tgz",
-			"integrity": "sha512-GmoNPxWDMkVpMFa9LVVzQZHF6EW3WKmBwL+4/GeILf2hFmix5Isxm7Amamo8o7bHiU0tC+wXsGcUXOxp8ChPaw==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.13.0.tgz",
+			"integrity": "sha512-CIZBFRRY1y9mAZSqBGFE4EB4dNJad2ysT2PqO8OpkiI3UTB/gUZwE5EaN16qVyQ6s/M7EgC/iaV/MnjdlvnuzA==",
 			"requires": {
-				"ssh2-streams": "~0.4.10"
-			}
-		},
-		"ssh2-streams": {
-			"version": "0.4.10",
-			"resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.10.tgz",
-			"integrity": "sha512-8pnlMjvnIZJvmTzUIIA5nT4jr2ZWNNVHwyXfMGdRJbug9TpI3kd99ffglgfSWqujVv/0gxwMsDn9j9RVst8yhQ==",
-			"requires": {
-				"asn1": "~0.2.0",
+				"asn1": "^0.2.6",
 				"bcrypt-pbkdf": "^1.0.2",
-				"streamsearch": "~0.1.2"
+				"cpu-features": "~0.0.7",
+				"nan": "^2.17.0"
 			}
 		},
 		"stream-transform": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-3.2.0.tgz",
 			"integrity": "sha512-M22v88wNknyJiIyHYoiIYI5RPl/R7tkf92j1YNkmrbe5XRGHW0jW8n458j1njOrR4Edcj8bwbpSV0iLIWon1hg=="
-		},
-		"streamsearch": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-			"integrity": "sha512-jos8u++JKm0ARcSUTAZXOVC0mSox7Bhn6sBgty73P1f3JGf7yG2clTbBNHUdde/kdvP2FESam+vM6l8jBrNxHA=="
 		},
 		"string_decoder": {
 			"version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1514,7 +1514,7 @@
 					"id": "connectionBrowser",
 					"name": "Servers",
 					"when": "code-for-ibmi:connected == false && code-for-ibmi:connectionBrowserDisabled !== true"
-				},				
+				},
 				{
 					"id": "profilesView",
 					"name": "Profiles",
@@ -2186,7 +2186,7 @@
 		"@types/tmp": "^0.2.3",
 		"csv": "^6.2.1",
 		"ignore": "^5.1.9",
-		"node-ssh": "^11.1.1",
+		"node-ssh": "^13.1.0",
 		"tar": "^6.1.13",
 		"tmp": "^0.2.1",
 		"vscode-diff": "^2.0.2"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,10 @@ const config = {
   plugins: [
     new webpack.DefinePlugin({
       'process.env.DEV': JSON.stringify(!isProduction),
-    })
+    }),
+
+    // We do this so we don't ship the optional binaries provided by ssh2
+    new webpack.IgnorePlugin({ resourceRegExp: /(cpu-features|sshcrypto\.node)/u })
   ],
   module: {
     rules: [


### PR DESCRIPTION
### Changes

Finally upgraded node-ssh to 13.1. We failed to do it in the past because ssh2 (a sub dep) now builds binaries for the package, **but they are optional**. I have updated our webpack configuration to ignore the errors for those binary files.

See this issue for how someone else fixed it: https://github.com/mscdex/ssh2/issues/1213

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
