### PR TITLE
feat: Add Copy Path to IFS browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1438,6 +1438,11 @@
 				"command": "code-for-ibmi.openTerminalHere",
 				"title": "Open terminal here",
 				"category": "IBM i"
+			},
+			{
+				"command": "code-for-ibmi.ifs.copyPath",
+				"title": "Copy Path",
+				"category": "IBM i"
 			}
 		],
 		"keybindings": [
@@ -1652,6 +1657,10 @@
 				},
 				{
 					"command": "code-for-ibmi.openTerminalHere",
+					"when": "never"
+				},
+				{
+					"command": "code-for-ibmi.ifs.copyPath",
 					"when": "never"
 				}
 			],
@@ -2064,6 +2073,11 @@
 					"command": "code-for-ibmi.changeWorkingDirectory",
 					"when": "view == ifsBrowser && viewItem == shortcut",
 					"group": "3_ifsStuff@3"
+				},
+				{
+					"command": "code-for-ibmi.ifs.copyPath",
+					"when": "view == ifsBrowser",
+					"group": "4_ifsStuff@1"
 				},
 				{
 					"command": "code-for-ibmi.openTerminalHere",

--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -585,6 +585,10 @@ module.exports = class IFSBrowser {
           //Running from command.
         }
       }),
+
+      vscode.commands.registerCommand(`code-for-ibmi.ifs.copyPath`, async (node) => {
+        await vscode.env.clipboard.writeText(node.path);
+      }),
     )
 
     getInstance().onEvent(`connected`, () => this.refresh());


### PR DESCRIPTION
### Changes

This PR will add a right-click option `Copy Path` to the IFS browser to copy the selected path to the clipboard.

### Checklist

* [x] have tested my change
* [x] eslint is not complaining
* [x] **for feature PRs**: PR only includes one feature enhancement.
