### PR TITLE
Check if member can be written before edition

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -5,7 +5,7 @@ import tmp from 'tmp';
 import util from 'util';
 import vscode from "vscode";
 import { ObjectTypes } from '../schemas/Objects';
-import { IBMiError, IBMiFile, IBMiMember, IBMiObject, IFSFile, QsysPath, CommandResult } from '../typings';
+import { CommandResult, IBMiError, IBMiFile, IBMiMember, IBMiObject, IFSFile, QsysPath } from '../typings';
 import { ConnectionConfiguration } from './Configuration';
 import { default as IBMi } from './IBMi';
 import { Tools } from './Tools';
@@ -14,6 +14,8 @@ const readFileAsync = util.promisify(fs.readFile);
 const writeFileAsync = util.promisify(fs.writeFile);
 
 const UTF8_CCSIDS = [`819`, `1208`, `1252`];
+
+type Authority = "*ADD" | "*DLT" | "*EXECUTE" | "*READ" | "*UPD" | "*NONE" | "*ALL" | "*CHANGE" | "*USE" | "*EXCLUDE" | "*AUTLMGT";
 
 export type SortOptions = {
   order: "name" | "date" | "?"
@@ -597,7 +599,7 @@ export default class IBMiContent {
           };
         });
       }
-    } else {      
+    } else {
       fileListResult = (await this.ibmi.sendCommand({
         command: `${this.ibmi.remoteFeatures.ls} -a -p -L ${sort.order === "date" ? "-t" : ""} ${(sort.order === 'date' && sort.ascending) ? "-r" : ""} ${Tools.escapePath(remotePath)}`
       }));
@@ -666,8 +668,8 @@ export default class IBMiContent {
 
     return undefined;
   }
-  
-  async objectResolve(object: string, libraries: string[]): Promise<string|undefined> {
+
+  async objectResolve(object: string, libraries: string[]): Promise<string | undefined> {
     const command = `for f in ${libraries.map(lib => `/QSYS.LIB/${lib.toUpperCase()}.LIB/${object.toUpperCase()}.*`).join(` `)}; do if [ -f $f ] || [ -d $f ]; then echo $f; break; fi; done`;
 
     const result = await this.ibmi.sendCommand({
@@ -759,9 +761,15 @@ export default class IBMiContent {
    * 
    * @param remotePath: a remote IFS path
    */
-  async isDirectory(remotePath : string){
+  async isDirectory(remotePath: string) {
     return (await this.ibmi.sendCommand({
       command: `cd ${remotePath}`
     })).code === 0;
+  }
+
+  async checkObject(object: { library: string, name: string, type: string }, ...authorities: Authority[]) {
+    return (await this.ibmi.runCommand({
+      command: `CHKOBJ OBJ(${object.library.toLocaleUpperCase()}/${object.name.toLocaleUpperCase()}) OBJTYPE(${object.type.toLocaleUpperCase()}) AUT(${authorities.join(" ")})`
+    }))?.code === 0;
   }
 }

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -115,6 +115,14 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
     ),
     vscode.commands.registerCommand(`code-for-ibmi.openEditable`, async (path: string, line?: number, options?: QsysFsOptions) => {
       console.log(path);
+      if(!options?.readonly && !path.startsWith('/')){
+        const [library, name] = path.split('/');
+        const writable = await instance.getContent()?.checkObject({library, name, type: '*FILE'}, "*UPD");
+        if(!writable){
+          options = options || {};
+          options.readonly = true;
+        }
+      }
       const uri = getUriFromPath(path, options);
       try {
         if (line) {


### PR DESCRIPTION
### Changes
This PR addresses what's been discussed here: https://github.com/orgs/halcyon-tech/discussions/1331

- Source file write access is now checked when it's expanded in the Object Browser. If it cannot be written to, all members will be opened in read-only mode (and a lock will be shown next to the members).
![image](https://github.com/halcyon-tech/vscode-ibmi/assets/11096890/374ab512-cbab-4ea3-81ae-609ef334db74)
- Write access is also checked when opening a member using the `Go to File` command. The member is open in read-only mode if its source file cannot be written to.

Checking the write access while saving was not implemented since it would show the misleading "Failed to save" dialog.

### Checklist
* [x] have tested my change
* [x] **for feature PRs**: PR only includes one feature enhancement.
