### PR TITLE
Externalized files listing errors

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -3,9 +3,8 @@ import fs from 'fs';
 import path from 'path';
 import tmp from 'tmp';
 import util from 'util';
-import vscode from "vscode";
 import { ObjectTypes } from '../schemas/Objects';
-import { IBMiError, IBMiFile, IBMiMember, IBMiObject, IFSFile, QsysPath, CommandResult } from '../typings';
+import { CommandResult, IBMiError, IBMiFile, IBMiMember, IBMiObject, IFSFile, QsysPath } from '../typings';
 import { ConnectionConfiguration } from './Configuration';
 import { default as IBMi } from './IBMi';
 import { Tools } from './Tools';
@@ -562,7 +561,7 @@ export default class IBMiContent {
    * @param remotePath 
    * @return an array of IFSFile
    */
-  async getFileList(remotePath: string, sort: SortOptions = { order: "name" }): Promise<IFSFile[]> {
+  async getFileList(remotePath: string, sort: SortOptions = { order: "name" }, onListError?:(errors:string[]) => void): Promise<IFSFile[]> {
     sort.order = sort.order === '?' ? 'name' : sort.order;
     const { 'stat': STAT } = this.ibmi.remoteFeatures;
     const { 'sort': SORT } = this.ibmi.remoteFeatures;
@@ -633,8 +632,7 @@ export default class IBMiContent {
         .filter(Tools.distinct);
 
       if (errors.length) {
-        errors.forEach(error => vscode.window.showErrorMessage(error));
-        vscode.window.showErrorMessage(`${errors.length} error${errors.length > 1 ? 's' : ''} occurred while listing files.`);
+        onListError ? onListError(errors) : errors.forEach(console.log);
       }
     }
 

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
+import { commands } from "vscode";
 import { TestSuite } from ".";
 import { instance } from "../instantiate";
-import { commands } from "vscode";
 
 export const ContentSuite: TestSuite = {
   name: `Content API tests`,

--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -623,7 +623,7 @@ module.exports = class IFSBrowser {
       if (element) { //Chosen directory
         //Fetch members
         try {
-          const objects = await content.getFileList(element.path, element.sort);
+          const objects = await content.getFileList(element.path, element.sort, this.handleFileListErrors);
           items.push(...objects.filter(o => o.type === `directory`)
             .concat(objects.filter(o => o.type === `streamfile`))
             .map(object => new Object(object.type, object.name, object.path, object.size, object.modified, object.owner, object.type === `streamfile` ? element : undefined)));
@@ -646,6 +646,15 @@ module.exports = class IFSBrowser {
 
   getParent(item) {
     return item.parent;
+  }
+
+  /**
+   * 
+   * @param {string[]} errors 
+   */
+  handleFileListErrors(errors) {
+    errors.forEach(error => vscode.window.showErrorMessage(error));
+    vscode.window.showErrorMessage(`${errors.length} error${errors.length > 1 ? `s` : ``} occurred while listing files.`);
   }
 
   /**


### PR DESCRIPTION
### Changes
`IBMiContent.getFileList` was using `vscode.window.showErrorMessage` to display non fatal error occurring when listing files.
With this PR, the handling of those error is now delegated to an optional callback received in parameter. If there is no callback, the errors are sent to the console.

### Checklist
* [x] have tested my change
* [x] eslint is not complaining