### PR TITLE
Fixed cd failing when path has whitespaces

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -573,7 +573,7 @@ export default class IBMiContent {
 
     if (STAT && SORT) {
       fileListResult = (await this.ibmi.sendCommand({
-        command: `cd ${remotePath} && ${STAT} --dereference --printf="%A\t%h\t%U\t%G\t%s\t%Y\t%n\n" * .* ${sort.order === `date` ? `| ${SORT} --key=6` : ``} ${(sort.order === `date` && !sort.ascending) ? ` --reverse` : ``}`
+        command: `cd '${remotePath}' && ${STAT} --dereference --printf="%A\t%h\t%U\t%G\t%s\t%Y\t%n\n" * .* ${sort.order === `date` ? `| ${SORT} --key=6` : ``} ${(sort.order === `date` && !sort.ascending) ? ` --reverse` : ``}`
       }));
 
       if (fileListResult.stdout !== '') {


### PR DESCRIPTION
### Changes
Fixes https://github.com/halcyon-tech/vscode-ibmi/issues/1348

When using `stat` to list a folder's content, the `cd` command run before failed if the target path had whitespaces. Puting quotes around the path fixes the issue.

### Checklist
* [x] have tested my change
