### PR TITLE
Add test for getFileList with special chars

### DIFF
--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -203,7 +203,7 @@ export const ContentSuite: TestSuite = {
     {name: `Test getFileList (special chars)`, test: async () => {
       const connection = instance.getConnection();
       const content = instance.getContent();
-      const files = [`name with blank`, `name_with_dollar$`, `name_with_quote'`];
+      const files = [`name with blank`, `name_with_quote'`, `name_with_dollar$`];
       const dir = `/tmp/${Date.now()}`;
       const dirWithSubdir = `${dir}/${files[0]}`;
 
@@ -219,6 +219,7 @@ export const ContentSuite: TestSuite = {
 
       const objects = await content?.getFileList(`${dirWithSubdir}`);
       assert.strictEqual(objects?.length, files.length);
+      assert.deepStrictEqual(objects?.map(a => {return a.name}).sort(), files.sort());
 
       result = await connection?.sendCommand({command: `rm -r "${dir}"`});
       assert.strictEqual(result?.code, 0);

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -211,18 +211,20 @@ export const ContentSuite: TestSuite = {
 
       result = await connection?.sendCommand({command: `mkdir -p "${dirWithSubdir}"`});
       assert.strictEqual(result?.code, 0);
+      try{
+        for (const file of files) {
+          result = await connection?.sendCommand({command: `touch "${dirWithSubdir}/${file}"`});
+          assert.strictEqual(result?.code, 0);
+        };
 
-      for (const file of files) {
-        result = await connection?.sendCommand({command: `touch "${dirWithSubdir}/${file}"`});
+        const objects = await content?.getFileList(`${dirWithSubdir}`);
+        assert.strictEqual(objects?.length, files.length);
+        assert.deepStrictEqual(objects?.map(a => a.name).sort(), files.sort());
+      }
+      finally{
+        result = await connection?.sendCommand({command: `rm -r "${dir}"`});
         assert.strictEqual(result?.code, 0);
-      };
-
-      const objects = await content?.getFileList(`${dirWithSubdir}`);
-      assert.strictEqual(objects?.length, files.length);
-      assert.deepStrictEqual(objects?.map(a => {return a.name}).sort(), files.sort());
-
-      result = await connection?.sendCommand({command: `rm -r "${dir}"`});
-      assert.strictEqual(result?.code, 0);
+      }
     }},
 
     {name: `Test getObjectList (all objects)`, test: async () => {


### PR DESCRIPTION
### Changes

Create a test for calling `getFileList` to get files with special characters in their names.

This is to avoid errors like the one encountered in issue #1348.

### Checklist

* [x] have tested my change
* [x] eslint is not complaining
