### PR TITLE
Always start a new terminal for Open Terminal Here

### DIFF
--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -358,8 +358,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
       const content = instance.getContent();
       if (content) {
         const path = (await content.isDirectory(ifsNode.path)) ? ifsNode.path : dirname(ifsNode.path);
-        const terminal = vscode.window.terminals.find(t => t.name === 'IBM i PASE') ||
-          await Terminal.selectAndOpen(instance, Terminal.TerminalType.PASE);
+        const terminal = await Terminal.selectAndOpen(instance, Terminal.TerminalType.PASE);
         terminal?.sendText(`cd ${path}`);        
       }
     }),


### PR DESCRIPTION
### Changes

When an IBM i PASE terminal has been started previously and exited, the Open Terminal Here function does not work anymore because it selects the exited terminal.

This PR changes the behavior for Open Terminal Here to always start a new IBM i PASE terminal.

It is still possible to use a path in an existing terminal by selecting `Copy Path` and switch to the existing terminal and enter `cd` and paste the path into the terminal.

### Checklist

* [x] have tested my change
* [x] eslint is not complaining
