### PR TITLE
Fix "Report issue" crashing when not authorized to WRKPTFGRP

### DIFF
--- a/src/views/helpView.ts
+++ b/src/views/helpView.ts
@@ -131,11 +131,12 @@ async function getRemoteSection() {
       catch (error) {
         console.log(`Couldn't run QSYS2.GROUP_PTF_INFO: ${error}`);
         try {
-          const [osVersionRow] = await content.runSQL(`Select DATA_AREA_VALUE as OS ` +
+          const [osVersionRow] = await content.runSQL(`Select Substring(DATA_AREA_VALUE, 0, 7) as OS ` +
             `From TABLE(QSYS2.DATA_AREA_INFO(` +
             `DATA_AREA_NAME => 'QSS1MRI',` +
             `DATA_AREA_LIBRARY => 'QUSRSYS'))` +
             `Fetch first row only`);
+
             Object.assign(osVersion, osVersionRow);
         }
         catch (anotherError) {

--- a/src/views/helpView.ts
+++ b/src/views/helpView.ts
@@ -81,10 +81,10 @@ async function openNewIssue() {
   let issueUrl = encodeURIComponent(issue);
   if (issueUrl.length > 8130) {
     //Empirically tested: issueUrl must not exceed 8130 characters
-    if(await vscode.window.showWarningMessage("Issue data is too long. It will be truncated.", "Copy full data to clipboard")){
+    if (await vscode.window.showWarningMessage("Issue data is too long. It will be truncated.", "Copy full data to clipboard")) {
       await vscode.env.clipboard.writeText(issue);
     }
-    
+
     issueUrl = issueUrl.substring(0, 8130);
   }
 
@@ -109,11 +109,16 @@ async function getRemoteSection() {
   const connection = instance.getConnection();
   const config = instance.getConfig();
   const content = instance.getContent();
-  if (connection && config && content) {    
-      return await vscode.window.withProgress({
-        location: vscode.ProgressLocation.Notification,
-        title: `Gathering issue details...`,
-      }, async progress => {
+  if (connection && config && content) {
+    return await vscode.window.withProgress({
+      location: vscode.ProgressLocation.Notification,
+      title: `Gathering issue details...`,
+    }, async progress => {
+      let osVersion = {
+        OS: "n/a",
+        TR: "n/a"
+      };
+      try {
         const [osVersion] = await content.runSQL(
           `SELECT PTF_GROUP_TARGET_RELEASE as OS, PTF_GROUP_LEVEL AS TR ` +
           `FROM QSYS2.GROUP_PTF_INFO ` +
@@ -121,34 +126,38 @@ async function getRemoteSection() {
           `ORDER BY PTF_GROUP_TARGET_RELEASE, PTF_GROUP_LEVEL DESC ` +
           `LIMIT 1`
         );
-        
-        return [
-          createSection(`Remote system`,
-            '|Setting|Value|',
-            '|-|-|',
-            `|IBM i OS|${osVersion?.OS || '?'}|`,
-            `|Tech Refresh|${osVersion?.TR || '?'}|`,
-            `|CCSID|${connection.qccsid || '?'}|`,
-            `|SQL|${config.enableSQL ? 'Enabled' : 'Disabled'}`,
-            `|Source dates|${config.enableSourceDates ? 'Enabled' : 'Disabled'}`,
-            '',
-            `### Enabled features`,
-            '',
-            ...getRemoteFeatures(connection)
-          ),
-          ``,
-          createSection(`Shell env`, `\`\`\`bash`, ...await getEnv(connection), `\`\`\``,),
-          ``,
-          createSection(`Variants`,
-            `\`\`\`json`,
-            JSON.stringify(connection?.variantChars || {}, null, 2),
-            `\`\`\``),
-          ``,
-          createSection(`Errors`,
-            `\`\`\`json`,
-            JSON.stringify(connection?.lastErrors || [], null, 2),
-            `\`\`\``)
-        ].join("\n");
+      }
+      catch (error) {
+        console.log(`Couldn't run QSYS2.GROUP_PTF_INFO: ${error}`);
+      }
+
+      return [
+        createSection(`Remote system`,
+          '|Setting|Value|',
+          '|-|-|',
+          `|IBM i OS|${osVersion?.OS || '?'}|`,
+          `|Tech Refresh|${osVersion?.TR || '?'}|`,
+          `|CCSID|${connection.qccsid || '?'}|`,
+          `|SQL|${config.enableSQL ? 'Enabled' : 'Disabled'}`,
+          `|Source dates|${config.enableSourceDates ? 'Enabled' : 'Disabled'}`,
+          '',
+          `### Enabled features`,
+          '',
+          ...getRemoteFeatures(connection)
+        ),
+        ``,
+        createSection(`Shell env`, `\`\`\`bash`, ...await getEnv(connection), `\`\`\``,),
+        ``,
+        createSection(`Variants`,
+          `\`\`\`json`,
+          JSON.stringify(connection?.variantChars || {}, null, 2),
+          `\`\`\``),
+        ``,
+        createSection(`Errors`,
+          `\`\`\`json`,
+          JSON.stringify(connection?.lastErrors || [], null, 2),
+          `\`\`\``)
+      ].join("\n");
     });
   }
   else {
@@ -156,13 +165,13 @@ async function getRemoteSection() {
   }
 }
 
-function getRemoteFeatures(connection : IBMi) {
-  const features : Map<string, string[]> = new Map;
+function getRemoteFeatures(connection: IBMi) {
+  const features: Map<string, string[]> = new Map;
   Object.values(connection.remoteFeatures).forEach(feature => {
-    if(feature){
+    if (feature) {
       const featurePath = parse(feature);
       let featureDir = features.get(featurePath.dir);
-      if(!featureDir){
+      if (!featureDir) {
         featureDir = [];
         features.set(featurePath.dir, featureDir);
       }
@@ -170,7 +179,7 @@ function getRemoteFeatures(connection : IBMi) {
       featureDir.sort();
     }
   });
-  
+
   const maxLine = Array.from(features.values()).map(e => e.length).sort((len1, len2) => len1 - len2).reverse()[0];
   const dirs = Array.from(features.keys());
   const rows = [];
@@ -181,7 +190,7 @@ function getRemoteFeatures(connection : IBMi) {
     `|${dirs.join('|')}|`,
     `|${dirs.map(d => '-').join('|')}|`,
     ...rows
-  ]  
+  ]
 }
 
 async function getEnv(connection: IBMi) {

--- a/src/views/helpView.ts
+++ b/src/views/helpView.ts
@@ -130,6 +130,17 @@ async function getRemoteSection() {
       }
       catch (error) {
         console.log(`Couldn't run QSYS2.GROUP_PTF_INFO: ${error}`);
+        try {
+          const [osVersionRow] = await content.runSQL(`Select DATA_AREA_VALUE as OS ` +
+            `From TABLE(QSYS2.DATA_AREA_INFO(` +
+            `DATA_AREA_NAME => 'QSS1MRI',` +
+            `DATA_AREA_LIBRARY => 'QUSRSYS'))` +
+            `Fetch first row only`);
+            Object.assign(osVersion, osVersionRow);
+        }
+        catch (anotherError) {
+          console.log(`Couldn't run QSYS2.DATA_AREA_INFO and read QUSRSYS/QSS1MRI: ${error}`);
+        }
       }
 
       return [

--- a/src/views/helpView.ts
+++ b/src/views/helpView.ts
@@ -119,13 +119,14 @@ async function getRemoteSection() {
         TR: "n/a"
       };
       try {
-        const [osVersion] = await content.runSQL(
+        const [osVersionRow] = await content.runSQL(
           `SELECT PTF_GROUP_TARGET_RELEASE as OS, PTF_GROUP_LEVEL AS TR ` +
           `FROM QSYS2.GROUP_PTF_INFO ` +
           `WHERE PTF_GROUP_DESCRIPTION = 'TECHNOLOGY REFRESH' AND PTF_GROUP_STATUS = 'INSTALLED' ` +
           `ORDER BY PTF_GROUP_TARGET_RELEASE, PTF_GROUP_LEVEL DESC ` +
           `LIMIT 1`
         );
+        Object.assign(osVersion, osVersionRow);
       }
       catch (error) {
         console.log(`Couldn't run QSYS2.GROUP_PTF_INFO: ${error}`);


### PR DESCRIPTION
### Changes
Fixes https://github.com/halcyon-tech/vscode-ibmi/issues/1364
`Report Issue` would crash if the user was not authorized to `WRKPTFGRP` (like many of us on PUB400).
The related SQL query is now surround by `try/catch` to avoid it from crashing the whole process. If the user is not authorized, we'll try to read the `QUSRSYS/QSS1MRI` data area to get the OS version.
If it fails, `OS Version` and `TR level` will simply show `n/a`.

### Checklist
* [x] have tested my change