### PR TITLE
Added before/after methods and test duration + deployment tests

### DIFF
--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -1,6 +1,6 @@
-import { API, GitExtension } from "./import/git";
+import path from "path";
 import vscode from "vscode";
-import path from "path"
+import { API, GitExtension } from "./import/git";
 
 export namespace Tools {
   export class SqlError extends Error {
@@ -116,12 +116,12 @@ export namespace Tools {
     return rows;
   }
 
-  export function makeid() {
+  export function makeid(length: number = 8) {
     let text = `O_`;
     const possible =
       `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789`;
 
-    for (let i = 0; i < 8; i++)
+    for (let i = 0; i < length; i++)
       text += possible.charAt(Math.floor(Math.random() * possible.length));
 
     return text;

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -1,3 +1,5 @@
+import Crypto from 'crypto';
+import { readFileSync } from "fs";
 import path from "path";
 import vscode from "vscode";
 import { API, GitExtension } from "./import/git";
@@ -194,5 +196,13 @@ export namespace Tools {
 
   export function distinct(value: any, index: number, array: any[]) {
     return array.indexOf(value) === index;
+  }
+
+  export function md5Hash(file: vscode.Uri): string {
+    const bytes = readFileSync(file.fsPath);
+    return Crypto.createHash("md5")
+      .update(bytes)
+      .digest("hex")
+      .toLowerCase();
   }
 }

--- a/src/api/local/deployment.ts
+++ b/src/api/local/deployment.ts
@@ -1,5 +1,3 @@
-import Crypto from 'crypto';
-import { readFileSync } from 'fs';
 import createIgnore, { Ignore } from 'ignore';
 import path, { basename } from 'path';
 import tar from 'tar';
@@ -358,7 +356,7 @@ export namespace Deployment {
         const uploads: vscode.Uri[] = [];
         for await (const file of localFiles) {
           const remote = remoteMD5.find(e => e.path === file.path);
-          const md5 = md5Hash(file.uri);
+          const md5 = Tools.md5Hash(file.uri);
           if (!remote || remote.md5 !== md5) {
             uploads.push(file.uri);
           }
@@ -481,14 +479,6 @@ export namespace Deployment {
       md5: parts[0].trim(),
       path: parts[1].trim().substring(2) //these path starts with ./
     };
-  }
-
-  function md5Hash(file: vscode.Uri): string {
-    const bytes = readFileSync(file.fsPath);
-    return Crypto.createHash("md5")
-      .update(bytes)
-      .digest("hex")
-      .toLowerCase();
   }
 
   function toRelative(root: vscode.Uri, file: vscode.Uri) {

--- a/src/testing/connection.ts
+++ b/src/testing/connection.ts
@@ -1,10 +1,10 @@
 import assert from "assert";
+import { commands } from "vscode";
 import { TestSuite } from ".";
 import { instance } from "../instantiate";
-import { commands } from "vscode";
 import { CommandResult } from "../typings";
 
-export const ConnectionSuite: TestSuite = {
+export const ConnectionSuite: TestSuite = {  
   name: `Connection tests`,
   tests: [
     {name: `Test sendCommand`, test: async () => {

--- a/src/testing/deployment.ts
+++ b/src/testing/deployment.ts
@@ -1,0 +1,239 @@
+import assert from "assert";
+import { randomInt } from "crypto";
+import { existsSync } from "fs";
+import ignore from "ignore";
+import { EOL } from "os";
+import { basename, posix } from "path";
+import vscode from "vscode";
+import { TestSuite } from ".";
+import { Tools } from "../api/Tools";
+import { Deployment } from "../api/local/deployment";
+import { instance } from "../instantiate";
+import { DeploymentMethod } from "../typings";
+
+type FileInfo = {
+    md5: string
+    date: string
+}
+
+type FilesInfo = Map<string, FileInfo>;
+
+class File {
+    readonly content: string[] = [];
+    localPath?: vscode.Uri;
+    remotePath?: string;
+
+    constructor(readonly name: string) {
+        this.changeContent();
+
+    }
+
+    changeContent() {
+        this.content.splice(0, this.content.length);
+        for (let line = 0; line < (5 + randomInt(41)); line++) {
+            this.content.push(Tools.makeid(10 + randomInt(100)));
+        }
+    }
+
+    getContent(){
+        return this.content.join(EOL);
+    }
+}
+
+type Folder = {
+    name: string
+    folders?: Folder[]
+    files?: File[]
+    localPath?: vscode.Uri
+    remotePath?: string;
+}
+
+const fakeProject: Folder = {
+    name: `DeleteMe_${Tools.makeid()}`,
+    folders: [
+        { name: "folder1", files: [new File("file11.txt"), new File("file22.txt"), new File("file23.txt")] },
+        {
+            name: "folder2", files: [new File("file21.txt")], folders: [
+                { name: "subfolder21", files: [new File("subfile211.txt"), new File("subfile212.txt")] },
+                { name: "subfolder22", files: [new File("subfile221.txt"), new File("subfile222.txt"), new File("subfile223.txt")] }
+            ]
+        },
+        {
+            name: "folder3", files: [new File("file31.txt"), new File("file32.txt"), new File("file33.txt"), new File("file34.txt"), new File("file35.txt")], folders: [
+                {
+                    name: "subfolder32", files: [new File("subfile321.txt")], folders: [
+                        { name: "subsubfolder331", files: [new File("subsubfile3311.txt"), new File("subsubfile3312.txt")] },
+                        { name: "subsubfolder332", files: [new File("subsubfile3321.txt"), new File("subsubfile3322.txt"), new File("subsubfile3324'.txt"), new File("subsubfile3325.txt")] }
+                    ]
+                },
+            ]
+        }
+    ],
+    files: [
+        new File("rootFile1.txt"),
+        new File("rootFile2.txt"),
+        new File("rootFile3.txt")
+    ],
+}
+
+export const DeploymentSuite: TestSuite = {
+    name: `Deployment tests`,
+    before: async () => {
+        const features = instance.getConnection()?.remoteFeatures;
+        assert.ok(features?.stat, "stat is required to run Deployment test suite");
+        assert.ok(features?.md5sum, "md5sum is required to run Deployment test suite");
+
+        const workspaceFolder = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0] : undefined;
+        const tempDir = instance.getConfig()?.tempDir;
+        assert.ok(workspaceFolder, "No workspace folder to work with");
+        assert.ok(tempDir, "Cannot run deployment tests: no remote temp directory defined");
+
+        await createFolder(workspaceFolder.uri, tempDir, fakeProject);
+        assert.ok(fakeProject.localPath, "Project has no local path");
+        assert.ok(existsSync(fakeProject.localPath.fsPath), "Project local directory does not exist");
+    },
+    tests: [
+        {
+            name: `Test 'All' deployment`, test: async () => {
+                const locals = await getLocalFilesInfo();
+                const remotes = await deploy("all");
+                assertFilesInfoEquals(locals, remotes);
+            }
+        },
+        {
+            name: `Test 'Compare' deployment`, test: async () => {                
+                createFile(fakeProject.localPath!, fakeProject.remotePath!, new File("new1.txt"));
+                createFile(fakeProject.folders![0].localPath!, fakeProject.folders![0].remotePath!, new File("newnew1.txt"));
+                createFile(fakeProject.folders![1].localPath!, fakeProject.folders![1].remotePath!, new File("newnew2.txt"));
+                
+                await vscode.workspace.fs.delete(fakeProject.folders![2].files![0].localPath!, { useTrash: false });
+                
+                await changeFile(fakeProject.files![0]);
+                await changeFile(fakeProject.folders![0].files![0]);
+
+                const oldRemotes = await getRemoteFilesInfo();
+                const locals = await getLocalFilesInfo();
+                const remotes = await deploy("compare");
+                assertFilesInfoEquals(locals, remotes);
+
+                let newFiles = 0;
+                let changed = 0;                
+                let deleted = 0;
+                oldRemotes.forEach((oldInfo, file) => {
+                    const newInfos = remotes.get(file);
+                    if(newInfos && newInfos.date !== oldInfo.date){
+                        changed++;
+                    }
+                    else if(!newInfos){
+                        deleted++;
+                    }
+                });
+                
+                remotes.forEach((newInfo, file) => {
+                    const oldInfo = oldRemotes.get(file);
+                    if(!oldInfo){
+                        newFiles++;
+                    }
+                });
+
+                assert.strictEqual(newFiles, 3);
+                assert.strictEqual(changed, 2);
+                assert.strictEqual(deleted, 1);
+            }
+        }
+    ],
+    after: async () => {
+        if (fakeProject.localPath && existsSync(fakeProject.localPath.fsPath)) {
+            await vscode.workspace.fs.delete(fakeProject.localPath, { recursive: true, useTrash: false });
+        }
+
+        if (fakeProject.remotePath && await instance.getContent()?.isDirectory(fakeProject.remotePath)) {
+            await instance.getConnection()?.sendCommand({ command: `rm -rf ${fakeProject.remotePath}` })
+        }
+    },
+}
+
+async function deploy(method: DeploymentMethod) {
+    assert.ok(fakeProject.localPath, "No local path");
+    assert.ok(fakeProject.remotePath, "No remote path");
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(fakeProject.localPath);
+    assert.ok(workspaceFolder, "No workspace folder");
+    //Deploy only the fake project
+    const ignoreRules = ignore().add([
+        `*`, //Ignore all
+        `!${basename(fakeProject.localPath.path)}/`, //Allow directory (required)
+        `!${basename(fakeProject.localPath.path)}/**` //Allow content
+    ]);
+
+    assert.ok(await Deployment.deploy({ method, remotePath: fakeProject.remotePath, workspaceFolder, ignoreRules }), `"${method}" deployment failed`);
+    return await getRemoteFilesInfo();
+}
+
+async function createFolder(parent: vscode.Uri, remoteParent: string, folder: Folder) {
+    folder.localPath = vscode.Uri.joinPath(parent, folder.name);
+    folder.remotePath = posix.join(remoteParent, folder.name);
+    await vscode.workspace.fs.createDirectory(folder.localPath);
+
+    for (const file of folder.files || []) {
+        await createFile(folder.localPath!, folder.remotePath!, file);
+    }
+
+    for (const childFolder of folder.folders || []) {
+        await createFolder(folder.localPath!, folder.remotePath!, childFolder);
+    }
+}
+
+async function createFile(folder: vscode.Uri, remote: string, file: File): Promise<void> {
+    file.localPath = vscode.Uri.joinPath(folder, file.name);
+    file.remotePath = posix.join(remote, file.name);
+    await vscode.workspace.fs.writeFile(file.localPath, Buffer.from(file.content));
+}
+
+async function changeFile(file : File){
+    file.changeContent();
+    await vscode.workspace.fs.writeFile(file.localPath!, Buffer.from(file.content));
+}
+
+async function getLocalFilesInfo() {
+    const localFiles: FilesInfo = new Map;
+    for await (const file of await vscode.workspace.findFiles(new vscode.RelativePattern(fakeProject.localPath!, "**/*"))) {
+        const path = posix.join(basename(fakeProject.localPath!.path), posix.relative(fakeProject.localPath!.path, file.path));
+        localFiles.set(path, { date: "unused", md5: Tools.md5Hash(file) });
+    }
+    return localFiles;
+}
+
+async function getRemoteFilesInfo() {
+    const remoteFiles: FilesInfo = new Map;
+
+    //Get dates
+    const stat = (await instance.getConnection()?.sendCommand({
+        directory: fakeProject.remotePath,
+        command: `find . -type f -exec ${instance.getConnection()?.remoteFeatures.stat} '{}' --printf="%n %s\\n" \\;`
+    }));
+    assert.strictEqual(0, stat?.code, "Remote stat call failed");
+    stat?.stdout.split("\n")
+        .map(line => line.split(" "))
+        .forEach(([file, date]) => remoteFiles.set(file.substring(2), { date, md5: "" }));
+
+    //Get md5 sums
+    const md5sum = (await instance.getConnection()?.sendCommand({
+        directory: fakeProject.remotePath,
+        command: `${instance.getConnection()?.remoteFeatures.md5sum} $(find . -type f);`
+    }));
+    assert.strictEqual(0, md5sum?.code, "Remote md5sum call failed");
+    md5sum?.stdout.split("\n")
+        .map(line => line.split(/\s+/))
+        .forEach(([md5, file]) => remoteFiles.get(file.substring(2))!.md5 = md5);
+
+    return remoteFiles;
+}
+
+function assertFilesInfoEquals(locals: FilesInfo, remotes: FilesInfo) {
+    assert.strictEqual(locals.size, remotes.size, `Local (${locals.size}) and remote (${remotes.size}) files counts don't match`);
+    locals.forEach((info, file) => {
+        const remoteFile = remotes.get(file);
+        assert.ok(remoteFile, "Local file not found in remote files list");
+        assert.strictEqual(info.md5, remoteFile.md5, "Remote file hash doesn't match local's");
+    });
+}

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -39,9 +39,9 @@ export function initialise(context: vscode.ExtensionContext) {
     vscode.commands.executeCommand(`setContext`, `code-for-ibmi:testing`, true);
     instance.onEvent(`connected`, runTests);
     instance.onEvent(`disconnected`, resetTests);
-    testSuitesTreeProvider = new TestSuitesTreeProvider(suites);    
+    testSuitesTreeProvider = new TestSuitesTreeProvider(suites);
     context.subscriptions.push(
-      vscode.window.createTreeView("testingView", {treeDataProvider: testSuitesTreeProvider, showCollapseAll: true}),
+      vscode.window.createTreeView("testingView", { treeDataProvider: testSuitesTreeProvider, showCollapseAll: true }),
       vscode.commands.registerCommand(`code-for-ibmi.testing.specific`, (suiteName: string, testName: string) => {
         if (suiteName && testName) {
           const suite = suites.find(suite => suite.name === suiteName);
@@ -77,7 +77,7 @@ async function runTests() {
     }
     catch (error: any) {
       console.log(error);
-      suite.failure = String(error);
+      suite.failure = `${error.message ? error.message : error}`;
     }
     finally {
       suite.status = "done";
@@ -85,7 +85,13 @@ async function runTests() {
       if (suite.after) {
         console.log();
         console.log(`Post-processing suite ${suite.name}`);
-        await suite.after();
+        try {
+          await suite.after();
+        }
+        catch (error: any) {
+          console.log(error);
+          suite.failure = `${error.message ? error.message : error}`;
+        }
       }
       testSuitesTreeProvider.refresh(suite);
     }
@@ -105,7 +111,7 @@ async function runTest(test: TestCase) {
   catch (error: any) {
     console.log(error);
     test.status = "failed";
-    test.failure = String(error);
+    test.failure = `${error.message ? error.message : error}`;
   }
   finally {
     test.duration = +(new Date()) - start;

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -65,25 +65,27 @@ async function runTests() {
       if (suite.before) {
         console.log(`Pre-processing suite ${suite.name}`);
         await suite.before();
+        testSuitesTreeProvider.refresh(suite);
       }
 
       console.log(`Running suite ${suite.name} (${suite.tests.length})`);
       console.log();
       for (const test of suite.tests) {
         await runTest(test);
-      }      
+      }
     }
     catch (error: any) {
       console.log(error);
-      suite.failure = error.message;      
-      testSuitesTreeProvider.refresh();
+      suite.failure = error.message;
     }
-    finally{
+    finally {
+      testSuitesTreeProvider.refresh(suite);
       if (suite.after) {
         console.log();
         console.log(`Post-processing suite ${suite.name}`);
         await suite.after();
       }
+      testSuitesTreeProvider.refresh(suite);
     }
   }
 }
@@ -91,7 +93,7 @@ async function runTests() {
 async function runTest(test: TestCase) {
   console.log(`\tRunning ${test.name}`);
   test.status = "running";
-  testSuitesTreeProvider.refresh();
+  testSuitesTreeProvider.refresh(test);
   const start = +(new Date());
   try {
     await test.test();
@@ -105,7 +107,7 @@ async function runTest(test: TestCase) {
   }
   finally {
     test.duration = +(new Date()) - start;
-    testSuitesTreeProvider.refresh();
+    testSuitesTreeProvider.refresh(test);
   }
 }
 

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -77,7 +77,7 @@ async function runTests() {
     }
     catch (error: any) {
       console.log(error);
-      suite.failure = error.message;
+      suite.failure = String(error);
     }
     finally {
       suite.status = "done";
@@ -105,7 +105,7 @@ async function runTest(test: TestCase) {
   catch (error: any) {
     console.log(error);
     test.status = "failed";
-    test.failure = error.message;
+    test.failure = String(error);
   }
   finally {
     test.duration = +(new Date()) - start;

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -3,6 +3,7 @@ import vscode from "vscode";
 import { instance } from "../instantiate";
 import { ConnectionSuite } from "./connection";
 import { ContentSuite } from "./content";
+import { DeploymentSuite } from "./deployment";
 import { ILEErrorSuite } from "./ileErrors";
 import { TestSuitesTreeProvider } from "./testCasesTree";
 import { ToolsSuite } from "./tools";
@@ -10,6 +11,7 @@ import { ToolsSuite } from "./tools";
 const suites: TestSuite[] = [
   ConnectionSuite,
   ContentSuite,
+  DeploymentSuite,
   ToolsSuite,
   ILEErrorSuite
 ]

--- a/src/testing/testCasesTree.ts
+++ b/src/testing/testCasesTree.ts
@@ -59,7 +59,7 @@ class TestCaseItem extends vscode.TreeItem {
         super(testCase.name, vscode.TreeItemCollapsibleState.None);
         let icon;
         let color;
-        if (this.testSuite.failure) {
+        if (!testCase.status && this.testSuite.failure) {
             color = "disabledForeground";
             icon = "circle-slash";
         }

--- a/src/testing/testCasesTree.ts
+++ b/src/testing/testCasesTree.ts
@@ -29,11 +29,11 @@ export class TestSuitesTreeProvider implements vscode.TreeDataProvider<vscode.Tr
 
 class TestSuiteItem extends vscode.TreeItem {
     constructor(readonly testSuite: TestSuite) {
-        super(testSuite.name, vscode.TreeItemCollapsibleState.Expanded);
+        super(testSuite.name, testSuite.failure ? vscode.TreeItemCollapsibleState.None : vscode.TreeItemCollapsibleState.Expanded);
         this.description = `${this.testSuite.tests.filter(tc => tc.status === "pass").length}/${this.testSuite.tests.length}`;
 
         let color;
-        if (this.testSuite.tests.some(tc => tc.status === "failed")) {
+        if (this.testSuite.failure || this.testSuite.tests.some(tc => tc.status === "failed")) {
             color = "testing.iconFailed";
         }
         else if (this.testSuite.tests.some(tc => !tc.status)) {
@@ -43,10 +43,11 @@ class TestSuiteItem extends vscode.TreeItem {
             color = "testing.iconPassed";
         }
         this.iconPath = new vscode.ThemeIcon("beaker", new vscode.ThemeColor(color));
+        this.tooltip = this.testSuite.failure;
     }
 
     getChilren() {
-        return this.testSuite.tests.map(tc => new TestCaseItem(this.label as string, tc));
+        return this.testSuite.failure ? [] : this.testSuite.tests.map(tc => new TestCaseItem(this.label as string, tc));
     }
 }
 
@@ -75,8 +76,13 @@ class TestCaseItem extends vscode.TreeItem {
 
         this.iconPath = new vscode.ThemeIcon(icon, new vscode.ThemeColor(color));
 
-        if (testCase.failure)
+        if(testCase.duration){
+            this.tooltip = `Duration: ${testCase.duration} millisecond(s)`;
+        }
+
+        if (testCase.failure){
             this.tooltip = new vscode.MarkdownString(['```', testCase.failure, '```'].join(`\n`));
+        }
 
         if (testCase.status !== `running`) {
             this.command = {

--- a/src/testing/testCasesTree.ts
+++ b/src/testing/testCasesTree.ts
@@ -49,7 +49,7 @@ class TestSuiteItem extends vscode.TreeItem {
         else {
             color = "testing.iconPassed";
         }
-        this.iconPath = new vscode.ThemeIcon("beaker", new vscode.ThemeColor(color));
+        this.iconPath = new vscode.ThemeIcon(testSuite.status === "running" ? "gear~spin" : "beaker", new vscode.ThemeColor(color));
         this.tooltip = this.testSuite.failure;
     }
 }


### PR DESCRIPTION
### Changes
This PR enhances the test framework.

#### Deployment tests (requires an opened workspace folder)
- Added `Deploy all` test
- Added `Deploy compare` test

#### Test suite level
- Optional `before` method: if present, runs code before the test suite is executed and cancels the whole suite if it fails. The failure is displayed as a tooltip in the Tests browser.
- Optional `after` method: if present, runs unconditionally after the test suite is done running (even if cancelled)
- New `status` field
- Displays a spinning gear when the test suite is running

#### Test case level
- Added a `duration` field, filled when the test case is done. The duration is displayed as a tooltip in the Tests browser.

#### Tests view
- Added a `Collapse All` button
- Fixed error handling when the error thrown is not an `Error`

### Checklist
* [x] have tested my change
* [x] **for feature PRs**: PR only includes one feature enhancement.
