### PR TITLE
Fix Quick Connect remoteFeatures

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -15,7 +15,7 @@ export interface MemberParts extends IBMiMember {
   basename: string
 }
 
-let remoteApps = [
+let remoteApps = [ // All names MUST also be defined as key in 'remoteFeatures' below!!
   {
     path: `/usr/bin/`,
     names: [`setccsid`, `iconv`, `attr`, `tar`, `ls`]
@@ -93,6 +93,7 @@ export default class IBMi {
       attr: undefined,
       iconv: undefined,
       tar: undefined,
+      ls: undefined,
     };
 
     this.variantChars = {


### PR DESCRIPTION
### Changes

This PR will fix Quick Connect remote features test - `ls` was missing in the `remoteFeatures`, so all remote features were checked at each connection.

I have also created a note at `remoteApps` to remember adding any new name to `remoteFeatures`.

### Checklist

* [x] have tested my change
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
