### PR TITLE
Modify actions for RPG compile from IFS

### DIFF
--- a/package.json
+++ b/package.json
@@ -694,7 +694,7 @@
 								"rpgle"
 							],
 							"name": "Create Bound RPG Program (CRTBNDRPG) with inputs",
-							"command": "CRTBNDRPG PGM(${buildlib|Build library|&BUILDLIB}/${objectname|Object Name|&NAME}) SRCSTMF('${sourcePath|Source path|&FULLPATH}') OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT)"
+							"command": "CRTBNDRPG PGM(${buildlib|Build library|&BUILDLIB}/${objectname|Object Name|&NAME}) SRCSTMF('${sourcePath|Source path|&FULLPATH}') OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT) TGTCCSID(*JOB)"
 						},
 						{
 							"type": "streamfile",
@@ -703,7 +703,7 @@
 								"RPG"
 							],
 							"name": "Create Bound RPG Program (CRTBNDRPG)",
-							"command": "CRTBNDRPG PGM(&BUILDLIB/&NAME) SRCSTMF('&FULLPATH') OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT)"
+							"command": "CRTBNDRPG PGM(&BUILDLIB/&NAME) SRCSTMF('&FULLPATH') OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT) TGTCCSID(*JOB)"
 						},
 						{
 							"type": "streamfile",
@@ -719,7 +719,7 @@
 								"SQLRPGLE"
 							],
 							"name": "Create SQL ILE RPG Program (CRTSQLRPGI)",
-							"command": "?CRTSQLRPGI OBJ(&BUILDLIB/&NAME) SRCSTMF('&FULLPATH') CLOSQLCSR(*ENDMOD) OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT)"
+							"command": "?CRTSQLRPGI OBJ(&BUILDLIB/&NAME) SRCSTMF('&FULLPATH') CLOSQLCSR(*ENDMOD) OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT) CVTCCSID(*JOB)"
 						},
 						{
 							"type": "streamfile",
@@ -727,7 +727,7 @@
 								"SQLRPGLE"
 							],
 							"name": "Create SQL ILE RPG Module (CRTSQLRPGI)",
-							"command": "?CRTSQLRPGI OBJ(&BUILDLIB/&NAME) SRCSTMF('&FULLPATH') OBJTYPE(*MODULE) CLOSQLCSR(*ENDMOD) OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT)"
+							"command": "?CRTSQLRPGI OBJ(&BUILDLIB/&NAME) SRCSTMF('&FULLPATH') OBJTYPE(*MODULE) CLOSQLCSR(*ENDMOD) OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT) CVTCCSID(*JOB)"
 						},
 						{
 							"type": "streamfile",


### PR DESCRIPTION
- Add `TGTCCSID(*JOB)` to defaults for CRTBNDRPG
- Add `TGTCCSID(*JOB)` to defaults for CRTBNDRPG w/ inputs
- Add `CVTCCSID(*JOB)` to defaults for CRTSQLRPG program
- Add `CVTCCSID(*JOB)` to defaults for CRTSQLRPG module


### Changes
The specific RPG compilation commands changed complain on IFS source about the 1208 CCSID.
Added arguments to command string to convert source to the Job ccside.

### Checklist

* [x] have tested my change
* [n/a] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [n/a ] **for feature PRs**: PR only includes one feature enhancement.
