### PR TITLE
SQL extension support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,4 +46,5 @@ Thanks so much to everyone [who has contributed](https://github.com/halcyon-tech
 * [@beckhamrryyaann](https://github.com/beckhamrryyaann)
 * [@angelorpa](https://github.com/angelorpa)
 * [@SanjulaGanepola](https://github.com/SanjulaGanepola)
-* [@shamby87](https://github.com/shamby87)
+* [@shamby87](https://github.com/shamby87)njulaGanepola)
+* [@edmundreinhardt](https://github.com/edmundreinhardt)

--- a/src/schemas/LocalLanguageActions.ts
+++ b/src/schemas/LocalLanguageActions.ts
@@ -113,7 +113,15 @@ export const LocalLanguageActions: Record<string, Action[]> = {
   SQL: [
     {
       extensions: [
-        `SQL`
+        `SQL`,
+        `TABLE`,
+        `VIEW`,
+        `SQLPRC`,
+        `SQLUDF`,
+        `SQLUDT`,
+        `SQLTRG`,
+        `SQLALIAS`,
+        `SQLSEQ`
       ],
       name: `Run SQL Statements (RUNSQLSTM)`,
       command: `RUNSQLSTM SRCSTMF('&FULLPATH') COMMIT(*NONE) NAMING(*SQL)`,


### PR DESCRIPTION
### Changes

For tools that support compiling from IFS stream files, the standard for CL and SQL based objects is to have the corresponding CL and SQL commands in stream files with the file extension that corresponds to the target object type.
i.e. `TABLE` objects have their DDL in a stream files with the extension `.table`

The complete set is described here https://ibm.github.io/ibmi-bob/#/welcome/features?id=support-sql-pseudo-source
This PR contributes the SQL file extensions to the  `Local Language Actions`.

![image](https://github.com/halcyon-tech/vscode-ibmi/assets/11184579/3a4478ab-f806-4566-a869-a588350dd153)


### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
