### PR TITLE
Add `Create Quick Filter` action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1284,6 +1284,13 @@
 				"icon": "$(filter)"
 			},
 			{
+				"command": "code-for-ibmi.createQuickFilter",
+				"enablement": "code-for-ibmi:connected",
+				"title": "Create Quick Filter",
+				"category": "IBM i",
+				"icon": "$(symbol-text)"
+			},
+			{
 				"command": "code-for-ibmi.copyFilter",
 				"enablement": "code-for-ibmi:connected",
 				"title": "Copy Filter",
@@ -1707,12 +1714,17 @@
 				},
 				{
 					"command": "code-for-ibmi.createFilter",
-					"group": "navigation",
+					"group": "navigation@1",
+					"when": "view == objectBrowser"
+				},
+				{
+					"command": "code-for-ibmi.createQuickFilter",
+					"group": "navigation@2",
 					"when": "view == objectBrowser"
 				},
 				{
 					"command": "code-for-ibmi.goToFile",
-					"group": "navigation",
+					"group": "navigation@4",
 					"when": "view == objectBrowser"
 				},
 				{
@@ -1757,17 +1769,17 @@
 				},
 				{
 					"command": "code-for-ibmi.createLibrary",
-					"group": "navigation",
+					"group": "navigation@3",
 					"when": "view == objectBrowser"
 				},
 				{
 					"command": "code-for-ibmi.refreshObjectBrowser",
-					"group": "navigation@1",
+					"group": "navigation@6",
 					"when": "view == objectBrowser"
 				},
 				{
 					"command": "code-for-ibmi.sortFilters",
-					"group": "navigation",
+					"group": "navigation@5",
 					"when": "view == objectBrowser"
 				},
 				{

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -77,7 +77,7 @@ module.exports = class ObjectBrowser {
 
         const newFilter = await vscode.window.showInputBox({
           prompt: `Enter filter as LIB* or LIB/OBJ/MBR.MBRTYPE (OBJTYPE) where each parameter is optional except the library`,
-          value: newFilter,
+          value: ``,
           validateInput: newFilter => {
             const libraryRegex = LIBRARY_REGEX.exec(newFilter.toUpperCase());
             const filterRegex = FILTER_REGEX.exec(newFilter.toUpperCase());

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -67,7 +67,7 @@ module.exports = class ObjectBrowser {
         this.refresh();
       }),
 
-      vscode.commands.registerCommand(`code-for-ibmi.createQuickFilter`, async (node, newFilter) => {        
+      vscode.commands.registerCommand(`code-for-ibmi.createQuickFilter`, async () => {        
         /** @type {ConnectionConfiguration.Parameters} */
         const config = getInstance().getConfig();
         const objectFilters = config.objectFilters;
@@ -75,7 +75,7 @@ module.exports = class ObjectBrowser {
         const LIBRARY_REGEX = /^(?<lib>[^/.() ]+)\*$/;
         const FILTER_REGEX = /^(?<lib>[^/.() ]+)(\/(?<obj>[^/.() ]+))?(\/(?<mbr>[^/.() ]+))?(\.(?<mbrType>[^/.() ]+))?( \((?<objType>[^/.()]+)\))?$/;
 
-        newFilter = await vscode.window.showInputBox({
+        const newFilter = await vscode.window.showInputBox({
           prompt: `Enter filter as LIB* or LIB/OBJ/MBR.MBRTYPE (OBJTYPE) where each parameter is optional except the library`,
           value: newFilter,
           validateInput: newFilter => {
@@ -115,10 +115,6 @@ module.exports = class ObjectBrowser {
                 protected: false
               }
               objectFilters.push(filter);
-            } else {
-              if(await vscode.window.showErrorMessage(`Error creating filter ${newFilter}`, `Retry`)){
-                vscode.commands.executeCommand(`code-for-ibmi.createQuickFilter`, node, newFilter);
-              }
             }
           }
 


### PR DESCRIPTION
### Changes

Add `Create Quick Filter` action that allows users to quickly type a filter of the following format: `LIB*` or `LIB/OBJ/MBR.MBRTYPE (OBJTYPE)` where each parameter is optional except the library. For parameters which are not provided, the defaults will be used.

![image](https://github.com/halcyon-tech/vscode-ibmi/assets/32170854/ccd297d8-b58a-4239-bf8f-972a257a5963)

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [x] **for feature PRs**: PR only includes one feature enhancement.
