### PR TITLE
Set default source date mode to diff

### DIFF
--- a/src/api/Configuration.ts
+++ b/src/api/Configuration.ts
@@ -108,7 +108,7 @@ export namespace ConnectionConfiguration {
       autoConvertIFSccsid : (parameters.autoConvertIFSccsid === true),
       hideCompileErrors : parameters.hideCompileErrors || [],
       enableSourceDates : parameters.enableSourceDates === true,
-      sourceDateMode : parameters.sourceDateMode || "edit",
+      sourceDateMode : parameters.sourceDateMode || "diff",
       sourceDateGutter : parameters.sourceDateGutter === true,
       encodingFor5250 : parameters.encodingFor5250 || `default`,
       terminalFor5250 : parameters.terminalFor5250 || `default`,


### PR DESCRIPTION
### Changes

Makes `diff` mode for source date editing the default for new system configurations.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
