### PR TITLE
Use -o when extracting with tar to give ownership to current user

### DIFF
--- a/src/api/local/deployment.ts
+++ b/src/api/local/deployment.ts
@@ -523,7 +523,7 @@ export namespace Deployment {
 
       progress?.report({ message: `extracting deployment tarball to ${parameters.remotePath}...` });
       //Extract and remove tar's PaxHeader metadata folder
-      const result = await connection.sendCommand({ command: `${connection.remoteFeatures.tar} -xf ${remoteTarball} && rm -rf PaxHeader`, directory: parameters.remotePath });
+      const result = await connection.sendCommand({ command: `${connection.remoteFeatures.tar} -xof ${remoteTarball} && rm -rf PaxHeader`, directory: parameters.remotePath });
       if (result.code !== 0) {
         throw new Error(`Tarball extraction failed: ${result.stderr}`)
       }


### PR DESCRIPTION
### Changes
Fixes https://github.com/halcyon-tech/vscode-ibmi/issues/1405

For some reason (?) `tar` would give ownership of the deployed files to QSECOFR (always with `/usb/bin`'s `tar`, not on files with `/QOpensys`' tar).

Using the `-o` flag (i.e. `--no-same-owner`) fixes the issue and gives owner of every extracted files to the currently connected user.

### Checklist
* [x] have tested my change