### PR TITLE
Added "Browse" action on streamfiles and members

### DIFF
--- a/package.json
+++ b/package.json
@@ -1973,7 +1973,7 @@
 					"command": "code-for-ibmi.runAction",
 					"when": "view == objectBrowser && viewItem =~ /^member.*$/",
 					"group": "1_workspace@1"
-				},				
+				},
 				{
 					"command": "code-for-ibmi.updateMemberText",
 					"when": "view == objectBrowser && viewItem == member",

--- a/package.json
+++ b/package.json
@@ -1443,6 +1443,12 @@
 				"command": "code-for-ibmi.ifs.copyPath",
 				"title": "Copy Path",
 				"category": "IBM i"
+			},
+			{
+				"command": "code-for-ibmi.browse",
+				"title": "Browse",
+				"enablement": "code-for-ibmi:connected",
+				"category": "IBM i"
 			}
 		],
 		"keybindings": [
@@ -1661,6 +1667,10 @@
 				},
 				{
 					"command": "code-for-ibmi.ifs.copyPath",
+					"when": "never"
+				},
+				{
+					"command": "code-for-ibmi.browse",
 					"when": "never"
 				}
 			],
@@ -1955,10 +1965,15 @@
 					"group": "5_sourceFileStuff@1"
 				},
 				{
+					"command": "code-for-ibmi.browse",
+					"when": "view == objectBrowser && viewItem =~ /^member.*$/",
+					"group": "0_browse@1"
+				},
+				{
 					"command": "code-for-ibmi.runAction",
 					"when": "view == objectBrowser && viewItem =~ /^member.*$/",
 					"group": "1_workspace@1"
-				},
+				},				
 				{
 					"command": "code-for-ibmi.updateMemberText",
 					"when": "view == objectBrowser && viewItem == member",
@@ -1998,6 +2013,11 @@
 					"command": "code-for-ibmi.moveIFSShortcutUp",
 					"when": "view == ifsBrowser && viewItem == shortcut",
 					"group": "inline"
+				},
+				{
+					"command": "code-for-ibmi.browse",
+					"when": "view == ifsBrowser && viewItem == streamfile",
+					"group": "0_browse@1"
 				},
 				{
 					"command": "code-for-ibmi.runAction",

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -15,7 +15,7 @@ import { VariablesUI } from "./webviews/variables";
 import { dirname } from 'path';
 import { ConnectionConfiguration, GlobalConfiguration } from "./api/Configuration";
 import { Search } from "./api/Search";
-import { QSysFS, getUriFromPath } from "./filesystems/qsys/QSysFs";
+import { QSysFS, getMemberUri, getUriFromPath } from "./filesystems/qsys/QSysFs";
 import { init as clApiInit } from "./languages/clle/clApi";
 import * as clRunner from "./languages/clle/clRunner";
 import { initGetNewLibl } from "./languages/clle/getnewlibl";
@@ -260,7 +260,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
             CompileTools.runAction(instance, uri);
           }
         }
-        else{
+        else {
           vscode.window.showErrorMessage('Please connect to an IBM i first');
         }
       }
@@ -389,6 +389,20 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
           ui.addField(Object.assign(uiField, field));
         });
         ui.loadPage(title, callback);
+      }
+    }),
+
+    vscode.commands.registerCommand("code-for-ibmi.browse", (node: any) => { //any for now, typed later after TS conversion of browsers
+      let uri;
+      if (node?.member) {
+        uri = getMemberUri(node?.member, { readonly: true });        
+      }
+      else if (node?.path) {
+        uri = getUriFromPath(node?.path, { readonly: true });
+      }
+
+      if (uri) {
+        return vscode.commands.executeCommand(`vscode.open`, uri);
       }
     })
   );

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -1193,6 +1193,7 @@ class Member extends vscode.TreeItem {
     super(`${member.name}.${member.extension}`);
     const readOnly = filter.protected || !writable;
     this.parent = parent;
+    this.member = member;
     this.contextValue = `member${readOnly ? `_readonly` : ``}`;
     this.description = member.text;
     this.resourceUri = getMemberUri(member, readOnly ? { readonly: true } : undefined);


### PR DESCRIPTION
### Changes
Added a Browse action in right-click menu of stream files and members.
![image](https://github.com/halcyon-tech/vscode-ibmi/assets/11096890/3b9942b4-ab1b-4680-a3ae-59fe84277204)

This simple action was missing from these menus. The idea came from this discussion: https://github.com/orgs/halcyon-tech/discussions/1412

### Checklist

* [x] have tested my change
* [x] eslint is not complaining
* [x] **for feature PRs**: PR only includes one feature enhancement.
