### PR TITLE
Fix parsing of `getTable` result

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -286,6 +286,12 @@ export default class IBMiContent {
         columns: true,
         skip_empty_lines: true,
         cast: true,
+        onRecord(record) {
+          for (const key of Object.keys(record)) {
+            record[key] = record[key] === ` ` ? `` : record[key]
+          }
+          return record;
+        }
       });
     }
 

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -288,7 +288,7 @@ export default class IBMiContent {
         cast: true,
         onRecord(record) {
           for (const key of Object.keys(record)) {
-            record[key] = record[key] === ` ` ? `` : record[key]
+            record[key] = record[key] === ` ` ? `` : record[key];
           }
           return record;
         }


### PR DESCRIPTION
### Changes

When testing the `getLibraryList` API, I noticed that for a library (with a text description of `*BLANK`), the `text` field was `''` when SQL is enabled, but `' '` when disabled. When SQL is disabled, the result which is parsed in `getTable` seems to have `' '` when there is no value. 

![image](https://github.com/halcyon-tech/vscode-ibmi/assets/32170854/91982e9e-93a8-4504-8394-3031511702cd)

This PR makes the result consistent regardless of if SQL is enabled.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
