### PR TITLE
Feature/disconnectOnDeactivate

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -116,4 +116,6 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
 }
 
 // this method is called when your extension is deactivated
-export function deactivate() { }
+export async function deactivate() {
+  await commands.executeCommand(`code-for-ibmi.disconnect`, true);
+}

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -97,10 +97,10 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
     disconnectBarItem,
     terminalBarItem,
     actionsBarItem,
-    vscode.commands.registerCommand(`code-for-ibmi.disconnect`, () => {
+    vscode.commands.registerCommand(`code-for-ibmi.disconnect`, async (silent?:boolean) => {
       if (instance.getConnection()) {
-        disconnect();
-      } else {
+        await disconnect();
+      } else if(!silent) {
         vscode.window.showErrorMessage(`Not currently connected to any system.`);
       }
     }),


### PR DESCRIPTION
### Changes
This change will call the `code-for-ibmi.disconnect` command when the extension gets deactivated (i.e. when VSCode closes).
It never hurts to clean behind us right? 😅

The only way I could test this was to put a breakpoint in `disconnect` and close VSCode. But it seems to work though!

### Checklist
* [x] have tested my change
* [x] **for feature PRs**: PR only includes one feature enhancement.
