### PR TITLE
Read in private key contents on connect

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -10,6 +10,7 @@ import { CompileTools } from "./CompileTools";
 import { CachedServerSettings, GlobalStorage } from './Storage';
 import { Tools } from './Tools';
 import * as configVars from './configVars';
+import { readFileSync } from "fs";
 
 export interface MemberParts extends IBMiMember {
   basename: string
@@ -116,7 +117,11 @@ export default class IBMi {
     try {
       connectionObject.keepaliveInterval = 35000;
       // Make sure we're not passing any blank strings, as node_ssh will try to validate it
-      if (!connectionObject.privateKey) (connectionObject.privateKey = null);
+      if (connectionObject.privateKey) {
+        connectionObject.privateKey = readFileSync(connectionObject.privateKey, {encoding: `utf-8`});
+      } else {
+        connectionObject.privateKey = null;
+      }
 
       configVars.replaceAll(connectionObject);
 


### PR DESCRIPTION
### Changes

Fixes #1422.

Newer versions of node_ssh (and therefore ssh2) require us read the file and pass the buffer.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
