### PR TITLE
Prevent root being deleted from VS Code

### DIFF
--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -397,6 +397,11 @@ module.exports = class IFSBrowser {
       vscode.commands.registerCommand(`code-for-ibmi.deleteIFS`, async (node) => {
 
         if (node) {
+          if (node.path === `/`) {
+            vscode.window.showErrorMessage(`Unable to delete root (/) from the IFS Browser.`);
+            return;
+          }
+
           //Running from right click
           let deletionConfirmed = false;
           let result = await vscode.window.showWarningMessage(`Are you sure you want to delete ${node.path}?`, `Yes`, `Cancel`);


### PR DESCRIPTION
### Changes

Based on a discussion had by a user who deleted root from VS Code (by accident?), we should no longer let users delete root since as the confirmation isn't enough.

### Checklist

* [ ] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
