### PR TITLE
Better handling of spaces when editing in diff mode

### DIFF
--- a/src/filesystems/qsys/sourceDateHandler.ts
+++ b/src/filesystems/qsys/sourceDateHandler.ts
@@ -301,6 +301,8 @@ export class SourceDateHandler {
         event.contentChanges[0].range.isSingleLine &&
         !event.contentChanges[0].text.includes(`\n`);
 
+      const isSpace = (isSingleLine && event.contentChanges[0].text === ` `);
+
       const currentEditingLine = isSingleLine ? event.contentChanges[0].range.start.line : undefined;
 
       const editedBefore = isSingleLine && currentEditingLine === this.lineEditedBefore;
@@ -312,7 +314,7 @@ export class SourceDateHandler {
         this._diffRefreshGutter(document);
       }
 
-      if (isDelete) {
+      if (isDelete || isSpace) {
         this.lineEditedBefore = 0;
       } else
       if (event.contentChanges.length > 0) {


### PR DESCRIPTION
### Changes

If a space was added at the end of a line, any further additions to that line were no longer letting the gutter refresh.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
