### PR TITLE
Validate library list when connecting

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -724,6 +724,9 @@ export default class IBMi {
           // Do nothing, bad data areas are already checked.
         } else {
           if (this.config.libraryList) {
+            progress.report({
+              message: `Validate configured library list`
+            });
             let validLibs: string[] = [];
             let badLibs: string[] = [];
 

--- a/src/api/Storage.ts
+++ b/src/api/Storage.ts
@@ -40,7 +40,8 @@ export type CachedServerSettings = {
   remoteFeatures: { [name: string]: string | undefined };
   remoteFeaturesKeys: string | null;
   variantChars: { american: string, local: string };
-  badDataAreasChecked: boolean | null
+  badDataAreasChecked: boolean | null,
+  libraryListValidated: boolean | null
 } | undefined;
 
 export class GlobalStorage extends Storage {


### PR DESCRIPTION
### Changes

This PR was created to partially fix issue #1431 by validating the library list when connecting to a system.
If any libraries in the list does not exist, the user will be prompted to remove them from the list:

![billede](https://github.com/halcyon-tech/vscode-ibmi/assets/13275072/c7348581-5f03-4b44-af64-16546f1c194d)

![billede](https://github.com/halcyon-tech/vscode-ibmi/assets/13275072/54851165-57a8-4a50-a353-5a93c7aff9ab)

Library list validation is not done on Quick Connect.

### Checklist

* [x] have tested my change
* [x] eslint is not complaining
