### PR TITLE
Remove status bar items for tooltip menu

### DIFF
--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -29,28 +29,16 @@ disconnectBarItem.command = {
   command: `code-for-ibmi.disconnect`,
   title: `Disconnect from system`
 }
-
-const connectedBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 10);
-connectedBarItem.command = {
-  command: `code-for-ibmi.showAdditionalSettings`,
-  title: `Show Additional Connection Settings`,
-};
 disconnectBarItem.tooltip = `Disconnect from system.`;
 disconnectBarItem.text = `$(debug-disconnect)`;
 
-const terminalBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
-terminalBarItem.command = {
-  command: `code-for-ibmi.launchTerminalPicker`,
-  title: `Launch Terminal Picker`
-}
-terminalBarItem.text = `$(terminal) Terminals`;
-
-const actionsBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
-actionsBarItem.command = {
-  command: `code-for-ibmi.showActionsMaintenance`,
-  title: `Show IBM i Actions`,
-};
-actionsBarItem.text = `$(file-binary) Actions`;
+const connectedBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 10);
+connectedBarItem.tooltip = new vscode.MarkdownString([
+  `[$(settings-gear) Settings](command:code-for-ibmi.showAdditionalSettings)`,
+  `[$(file-binary) Actions](command:code-for-ibmi.showActionsMaintenance)`,
+  `[$(terminal) Terminals](command:code-for-ibmi.launchTerminalPicker)`
+].join(`\n\n---\n\n`), true);
+connectedBarItem.tooltip.isTrusted = true;
 
 let selectedForCompare: vscode.Uri;
 let searchViewContext: SearchView;
@@ -95,8 +83,6 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     connectedBarItem,
     disconnectBarItem,
-    terminalBarItem,
-    actionsBarItem,
     vscode.commands.registerCommand(`code-for-ibmi.disconnect`, async (silent?:boolean) => {
       if (instance.getConnection()) {
         await disconnect();
@@ -400,7 +386,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
 function updateConnectedBar() {
   const config = instance.getConfig();
   if (config) {
-    connectedBarItem.text = `$(${config.readOnlyMode ? "lock" : "settings-gear"}) Settings: ${config.name}`;
+    connectedBarItem.text = `$(${config.readOnlyMode ? "lock" : "settings-gear"}) ${config.name}`;
   }
 }
 
@@ -410,8 +396,6 @@ async function onConnected(context: vscode.ExtensionContext) {
   [
     connectedBarItem,
     disconnectBarItem,
-    terminalBarItem,
-    actionsBarItem
   ].forEach(barItem => barItem.show());
 
   updateConnectedBar();
@@ -447,7 +431,5 @@ async function onDisconnected() {
   [
     disconnectBarItem,
     connectedBarItem,
-    terminalBarItem,
-    actionsBarItem,
   ].forEach(barItem => barItem.hide())
 }


### PR DESCRIPTION
### Changes

Removes the Actions and Terminals items in place of tooltip buttons on the Settings item.

As much as I want this to, I am not expecting this to be merged due to how big of a UI change this is, but it sure is nice IMO.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
