### PR TITLE
Feature/ile_libl_only

### DIFF
--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -576,8 +576,10 @@ export namespace CompileTools {
         const commands = commandString.split(`\n`).filter(command => command.trim().length > 0);
 
         outputChannel.append(`\n\n`);
-        outputChannel.append(`Current library: ` + ileSetup.currentLibrary + `\n`);
-        outputChannel.append(`Library list: ` + ileSetup.libraryList.join(` `) + `\n`);
+        if (options.environment === `ile`) {
+          outputChannel.append(`Current library: ` + ileSetup.currentLibrary + `\n`);
+          outputChannel.append(`Library list: ` + ileSetup.libraryList.join(` `) + `\n`);
+        }
         outputChannel.append(`Commands:\n${commands.map(command => `\t\t${command}\n`).join(``)}\n`);
 
         const callbacks: StandardIO = {

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -29,28 +29,16 @@ disconnectBarItem.command = {
   command: `code-for-ibmi.disconnect`,
   title: `Disconnect from system`
 }
-
-const connectedBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 10);
-connectedBarItem.command = {
-  command: `code-for-ibmi.showAdditionalSettings`,
-  title: `Show Additional Connection Settings`,
-};
 disconnectBarItem.tooltip = `Disconnect from system.`;
 disconnectBarItem.text = `$(debug-disconnect)`;
 
-const terminalBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
-terminalBarItem.command = {
-  command: `code-for-ibmi.launchTerminalPicker`,
-  title: `Launch Terminal Picker`
-}
-terminalBarItem.text = `$(terminal) Terminals`;
-
-const actionsBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
-actionsBarItem.command = {
-  command: `code-for-ibmi.showActionsMaintenance`,
-  title: `Show IBM i Actions`,
-};
-actionsBarItem.text = `$(file-binary) Actions`;
+const connectedBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 10);
+connectedBarItem.tooltip = new vscode.MarkdownString([
+  `[$(settings-gear) Settings](command:code-for-ibmi.showAdditionalSettings)`,
+  `[$(file-binary) Actions](command:code-for-ibmi.showActionsMaintenance)`,
+  `[$(terminal) Terminals](command:code-for-ibmi.launchTerminalPicker)`
+].join(`\n\n---\n\n`), true);
+connectedBarItem.tooltip.isTrusted = true;
 
 let selectedForCompare: vscode.Uri;
 let searchViewContext: SearchView;
@@ -95,8 +83,6 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     connectedBarItem,
     disconnectBarItem,
-    terminalBarItem,
-    actionsBarItem,
     vscode.commands.registerCommand(`code-for-ibmi.disconnect`, async (silent?:boolean) => {
       if (instance.getConnection()) {
         await disconnect();
@@ -400,7 +386,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
 function updateConnectedBar() {
   const config = instance.getConfig();
   if (config) {
-    connectedBarItem.text = `$(${config.readOnlyMode ? "lock" : "settings-gear"}) Settings: ${config.name}`;
+    connectedBarItem.text = `$(${config.readOnlyMode ? "lock" : "settings-gear"}) ${config.name}`;
   }
 }
 
@@ -410,8 +396,6 @@ async function onConnected(context: vscode.ExtensionContext) {
   [
     connectedBarItem,
     disconnectBarItem,
-    terminalBarItem,
-    actionsBarItem
   ].forEach(barItem => barItem.show());
 
   updateConnectedBar();
@@ -447,7 +431,5 @@ async function onDisconnected() {
   [
     disconnectBarItem,
     connectedBarItem,
-    terminalBarItem,
-    actionsBarItem,
   ].forEach(barItem => barItem.hide())
 }


### PR DESCRIPTION
### Changes

We should only show the user libraries when running an ILE command. QSH/PASE doesn't use a library list as such, so we need to show it for them.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
