### PR TITLE
Generate and publish typings through ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
+          registry-url: 'https://registry.npmjs.org'
+
       - uses: actions/checkout@v2
       
       - run: npm install
@@ -23,3 +25,14 @@ jobs:
           
       - name: Publish to Open VSX
         run: npx ovsx publish -p ${{ secrets.OPENVSX_TOKEN }}
+
+      - name: Generate typings
+        run: npm run typings
+
+      - name: Cleanup typings
+        run: cd types && npm run prepublish
+
+      - name: Publish typings to npm
+        run: cd types && npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Changes

Adds back the type generation and NPM publishing to the ci workflow.

**TO DO**: Add `NPM_TOKEN` secret to repo.

### Checklist

* [ ] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
