### PR TITLE
Fix directory for shell check

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -182,7 +182,8 @@ export default class IBMi {
 
         const checkShellText = `This should be the only text!`;
         const checkShellResult = await this.sendCommand({
-          command: `echo "${checkShellText}"`
+          command: `echo "${checkShellText}"`,
+          directory: `.`
         });
         if (checkShellResult.stdout.split(`\n`)[0] !== checkShellText) {
           const chosen = await vscode.window.showErrorMessage(`Error in shell configuration!`, {


### PR DESCRIPTION
### Changes

This PR will set the directory when checking for shell output.
Previously if the home directory did not exists, the check would fail (discovered while reviewing PR #1460)

### Checklist

* [x] have tested my change
* [x] eslint is not complaining
