### PR TITLE
Wrap paths to resolve with double quote

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -696,7 +696,7 @@ export default class IBMiContent {
   }
 
   async streamfileResolve(names: string[], directories: string[]): Promise<string | undefined> {
-    const command = `for f in ${directories.flatMap(dir => names.map(name => `"${path.posix.join(dir, name)}"`)).join(` `)}; do if [ -f $f ]; then echo $f; break; fi; done`;
+    const command = `for f in ${directories.flatMap(dir => names.map(name => `"${path.posix.join(dir, name)}"`)).join(` `)}; do if [ -f "$f" ]; then echo $f; break; fi; done`;
 
     const result = await this.ibmi.sendCommand({
       command,

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -696,7 +696,7 @@ export default class IBMiContent {
   }
 
   async streamfileResolve(names: string[], directories: string[]): Promise<string | undefined> {
-    const command = `for f in ${directories.flatMap(dir => names.map(name => path.posix.join(dir, name))).join(` `)}; do if [ -f $f ]; then echo $f; break; fi; done`;
+    const command = `for f in ${directories.flatMap(dir => names.map(name => `"${path.posix.join(dir, name)}"`)).join(` `)}; do if [ -f $f ]; then echo $f; break; fi; done`;
 
     const result = await this.ibmi.sendCommand({
       command,

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -357,5 +357,33 @@ export const ContentSuite: TestSuite = {
 
       assert.deepStrictEqual(membersA, membersB);
     }},
+
+    {name: `Test streamfileResolve`, test: async () => {
+      const connection = instance.getConnection();
+      const content = instance.getContent();
+      const files = [`normalname`, `name with blank`, `name_with_quote'`, `name_with_dollar$`];
+      const dir = `/tmp/${Date.now()}`;
+      const dirWithSubdir = `${dir}/${files[0]}`;
+
+      let result: CommandResult | undefined;
+
+      result = await connection?.sendCommand({command: `mkdir -p "${dir}"`});
+      assert.strictEqual(result?.code, 0);
+      try{
+        for (const file of files) {
+          result = await connection?.sendCommand({command: `touch "${dir}/${file}"`});
+          assert.strictEqual(result?.code, 0);
+        };
+
+        for (const file of files) {
+          let result = await content?.streamfileResolve([`${Date.now()}`, file], [`${Date.now()}`, dir]);
+          assert.strictEqual(result, `${dir}/${file}`, `Resolving file "${dir}/${file}" failed`);
+        }
+      }
+      finally{
+        result = await connection?.sendCommand({command: `rm -r "${dir}"`});
+        assert.strictEqual(result?.code, 0);
+      }
+    }},
   ]
 };

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -99,6 +99,36 @@ export const ContentSuite: TestSuite = {
       assert.strictEqual(streamfilePath, `/QOpenSys/pkgs/bin/git`);
     }},
 
+
+
+    {name: `Test streamfileResolve with blanks in names`, test: async () => {
+      const connection = instance.getConnection();
+      const content = instance.getContent();
+      const files = [`normalname`, `name with blank`, `name_with_quote'`, `name_with_dollar$`];
+      const dir = `/tmp/${Date.now()}`;
+      const dirWithSubdir = `${dir}/${files[0]}`;
+
+      let result: CommandResult | undefined;
+
+      result = await connection?.sendCommand({command: `mkdir -p "${dir}"`});
+      assert.strictEqual(result?.code, 0);
+      try{
+        for (const file of files) {
+          result = await connection?.sendCommand({command: `touch "${dir}/${file}"`});
+          assert.strictEqual(result?.code, 0);
+        };
+
+        for (const file of files) {
+          let result = await content?.streamfileResolve([`${Date.now()}`, file], [`${Date.now()}`, dir]);
+          assert.strictEqual(result, `${dir}/${file}`, `Resolving file "${dir}/${file}" failed`);
+        }
+      }
+      finally{
+        result = await connection?.sendCommand({command: `rm -r "${dir}"`});
+        assert.strictEqual(result?.code, 0);
+      }
+    }},
+
     {name: `Test downloadMemberContent`, test: async () => {
       const content = instance.getContent();
 
@@ -356,34 +386,6 @@ export const ContentSuite: TestSuite = {
       config!.enableSQL = true;
 
       assert.deepStrictEqual(membersA, membersB);
-    }},
-
-    {name: `Test streamfileResolve`, test: async () => {
-      const connection = instance.getConnection();
-      const content = instance.getContent();
-      const files = [`normalname`, `name with blank`, `name_with_quote'`, `name_with_dollar$`];
-      const dir = `/tmp/${Date.now()}`;
-      const dirWithSubdir = `${dir}/${files[0]}`;
-
-      let result: CommandResult | undefined;
-
-      result = await connection?.sendCommand({command: `mkdir -p "${dir}"`});
-      assert.strictEqual(result?.code, 0);
-      try{
-        for (const file of files) {
-          result = await connection?.sendCommand({command: `touch "${dir}/${file}"`});
-          assert.strictEqual(result?.code, 0);
-        };
-
-        for (const file of files) {
-          let result = await content?.streamfileResolve([`${Date.now()}`, file], [`${Date.now()}`, dir]);
-          assert.strictEqual(result, `${dir}/${file}`, `Resolving file "${dir}/${file}" failed`);
-        }
-      }
-      finally{
-        result = await connection?.sendCommand({command: `rm -r "${dir}"`});
-        assert.strictEqual(result?.code, 0);
-      }
     }},
   ]
 };


### PR DESCRIPTION
### Changes

This will fix a bug that will allow the vscode-rpgle extension to resolve streamfiles with spaces in them (though... what crazy person would do that?!)

Tests are continuing to pass.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
