### PR TITLE
Add missing `getEvfeventFiles` function

### DIFF
--- a/src/api/errors/diagnostics.ts
+++ b/src/api/errors/diagnostics.ts
@@ -3,7 +3,6 @@ import * as vscode from "vscode";
 import Instance from "../Instance";
 import { parseErrors } from "./handler";
 import { FileError } from "../../typings";
-import { getEvfeventFiles } from "../local/actions";
 
 const ileDiagnostics = vscode.languages.createDiagnosticCollection(`ILE`);
 
@@ -18,7 +17,7 @@ export interface EvfEventInfo {
 export function registerDiagnostics(): vscode.Disposable[] {
   return [
     ileDiagnostics,
-    
+
     vscode.commands.registerCommand(`code-for-ibmi.clearDiagnostics`, async () => {
       clearDiagnostics();
     }),
@@ -134,6 +133,17 @@ export async function handleEvfeventLines(lines: string[], instance: Instance, e
   } else {
     ileDiagnostics.clear();
   }
+}
+
+export async function getEvfeventFiles(currentWorkspace: vscode.WorkspaceFolder) {
+  const evfeventFiles: vscode.Uri[] = [];
+
+  if (currentWorkspace) {
+    const relativeSearch = new vscode.RelativePattern(currentWorkspace, `**/.evfevent/*`);
+    evfeventFiles.push(...await vscode.workspace.findFiles(relativeSearch));
+  }
+
+  return evfeventFiles;
 }
 
 const diagnosticSeverity = (error: FileError) => {

--- a/src/api/errors/diagnostics.ts
+++ b/src/api/errors/diagnostics.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 import Instance from "../Instance";
 import { parseErrors } from "./handler";
 import { FileError } from "../../typings";
+import { getEvfeventFiles } from "../local/actions";
 
 const ileDiagnostics = vscode.languages.createDiagnosticCollection(`ILE`);
 
@@ -133,17 +134,6 @@ export async function handleEvfeventLines(lines: string[], instance: Instance, e
   } else {
     ileDiagnostics.clear();
   }
-}
-
-export async function getEvfeventFiles(currentWorkspace: vscode.WorkspaceFolder) {
-  const evfeventFiles: vscode.Uri[] = [];
-
-  if (currentWorkspace) {
-    const relativeSearch = new vscode.RelativePattern(currentWorkspace, `**/.evfevent/*`);
-    evfeventFiles.push(...await vscode.workspace.findFiles(relativeSearch));
-  }
-
-  return evfeventFiles;
 }
 
 const diagnosticSeverity = (error: FileError) => {

--- a/src/api/local/actions.ts
+++ b/src/api/local/actions.ts
@@ -40,14 +40,3 @@ export async function getLocalActions(currentWorkspace: WorkspaceFolder) {
 
   return actions;
 }
-
-export async function getEvfeventFiles(currentWorkspace: WorkspaceFolder) {
-  const evfeventFiles: Uri[] = [];
-
-  if (currentWorkspace) {
-    const relativeSearch = new RelativePattern(currentWorkspace, `**/.evfevent/*`);
-    evfeventFiles.push(...await workspace.findFiles(relativeSearch));
-  }
-
-  return evfeventFiles;
-}

--- a/src/api/local/actions.ts
+++ b/src/api/local/actions.ts
@@ -40,3 +40,12 @@ export async function getLocalActions(currentWorkspace: WorkspaceFolder) {
 
   return actions;
 }
+
+export async function getEvfeventFiles(currentWorkspace: WorkspaceFolder) {
+  if (currentWorkspace) {
+    const relativeSearch = new RelativePattern(currentWorkspace, `**/.evfevent/*`);
+    const iprojectFiles = await workspace.findFiles(relativeSearch, null, 1);
+
+    return iprojectFiles;
+  }
+}

--- a/src/api/local/actions.ts
+++ b/src/api/local/actions.ts
@@ -1,4 +1,4 @@
-import { RelativePattern, window, workspace, WorkspaceFolder, Uri } from "vscode";
+import { RelativePattern, window, workspace, WorkspaceFolder } from "vscode";
 import { Action } from "../../typings";
 
 export async function getLocalActions(currentWorkspace: WorkspaceFolder) {

--- a/src/api/local/actions.ts
+++ b/src/api/local/actions.ts
@@ -1,4 +1,4 @@
-import { RelativePattern, window, workspace, WorkspaceFolder } from "vscode";
+import { RelativePattern, window, workspace, WorkspaceFolder, Uri } from "vscode";
 import { Action } from "../../typings";
 
 export async function getLocalActions(currentWorkspace: WorkspaceFolder) {
@@ -39,4 +39,15 @@ export async function getLocalActions(currentWorkspace: WorkspaceFolder) {
   }
 
   return actions;
+}
+
+export async function getEvfeventFiles(currentWorkspace: WorkspaceFolder) {
+  const evfeventFiles: Uri[] = [];
+
+  if (currentWorkspace) {
+    const relativeSearch = new RelativePattern(currentWorkspace, `**/.evfevent/*`);
+    evfeventFiles.push(...await workspace.findFiles(relativeSearch));
+  }
+
+  return evfeventFiles;
 }


### PR DESCRIPTION
### Changes

Fix change made in PR #1450 by adding `getEvfeventFiles` function.

![image](https://github.com/halcyon-tech/vscode-ibmi/assets/32170854/d61c19d8-5c2e-4aa5-8348-14ce7c1a975c)

### Checklist

* [x] have tested my change
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] **for feature PRs**: PR only includes one feature enhancement.
