### PR TITLE
Initialize `code-for-ibmi:connected` context value when extension is activated

### DIFF
--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -82,16 +82,19 @@ export async function disconnect(): Promise<boolean> {
 }
 
 export async function loadAllofExtension(context: vscode.ExtensionContext) {
+  // No connection when the extension is first activated
+  vscode.commands.executeCommand(`setContext`, `code-for-ibmi:connected`, false);
+
   instance = new Instance(context);
   searchViewContext = new SearchView(context);
 
   context.subscriptions.push(
     connectedBarItem,
     disconnectBarItem,
-    vscode.commands.registerCommand(`code-for-ibmi.disconnect`, async (silent?:boolean) => {
+    vscode.commands.registerCommand(`code-for-ibmi.disconnect`, async (silent?: boolean) => {
       if (instance.getConnection()) {
         await disconnect();
-      } else if(!silent) {
+      } else if (!silent) {
         vscode.window.showErrorMessage(`Not currently connected to any system.`);
       }
     }),
@@ -353,7 +356,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("code-for-ibmi.browse", (node: any) => { //any for now, typed later after TS conversion of browsers
       let uri;
       if (node?.member) {
-        uri = getMemberUri(node?.member, { readonly: true });        
+        uri = getMemberUri(node?.member, { readonly: true });
       }
       else if (node?.path) {
         uri = getUriFromPath(node?.path, { readonly: true });


### PR DESCRIPTION
### Changes

Whenever the user changes the first workspace folder or goes from a single-folder workspace to a multi-root workspace, the extension is restarted which is expected in VS Code as mentioned [here](https://github.com/Microsoft/vscode/issues/46048). However, right now this leaves Code4i's views as unusable (as shown below).

This seems to be because the value of the `code-for-ibmi:connected` context value is kept despite the extension restarting. Thus, this PR sets it to be false when we first activate the extension. Although this will require uses to have to reconnect, at least they can do this instead of having to restart the entire extension again.

![image](https://github.com/halcyon-tech/vscode-ibmi/assets/32170854/893eb901-feaa-4515-bf45-1afc0fcb02d2)

### Checklist

* [x] have tested my change
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] **for feature PRs**: PR only includes one feature enhancement.
