### PR TITLE
Fix initialization of locale from config

### DIFF
--- a/package.json
+++ b/package.json
@@ -457,7 +457,7 @@
 						"Danish",
 						"French"
 					],
-					"description": "The locale used when displaying text in Code for IBM i."
+					"description": "The locale used when displaying text in Code for IBM i. Requires restart if changed."
 				},
 				"code-for-ibmi.showDateSearchButton": {
 					"type": "boolean",

--- a/src/locale/index.ts
+++ b/src/locale/index.ts
@@ -13,6 +13,7 @@ const locales: {[locale: string]: Locale} = {
 }
 
 let currentLocale = String(env.language);
+updateLocale();
 
 export function updateLocale() {
   const localeSetting = GlobalConfiguration.get(`locale`) as string;


### PR DESCRIPTION
### Changes

This PR will fix the initialization of the locale from the config value by calling `updateLocale()` on start.
It will also revert the commit, which removed the text `Requires restart if changed.`

### Checklist

* [x] have tested my change
