### PR TITLE
Fix ASP and library list validation

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -798,7 +798,7 @@ export default class IBMi {
               const lines = result.stderr.split(`\n`);
         
               lines.forEach(line => {
-                const badLib = this.config?.libraryList.find(lib => line.includes(`ibrary ${lib}`));
+                const badLib = this.config?.libraryList.find(lib => line.includes(`ibrary ${lib} `));
         
                 // If there is an error about the library, store it
                 if (badLib) badLibs.push(badLib);

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -778,7 +778,7 @@ export default class IBMi {
 
         // Validate configured library list.
         if (quickConnect === true && cachedServerSettings?.libraryListValidated === true) {
-          // Do nothing, bad data areas are already checked.
+          // Do nothing, library list is already checked.
         } else {
           if (this.config.libraryList) {
             progress.report({
@@ -787,21 +787,31 @@ export default class IBMi {
             let validLibs: string[] = [];
             let badLibs: string[] = [];
 
-            result = await this.sendCommand({
-              command: `for lib in ` + this.config.libraryList.map(lib => this.sysNameInAmerican(lib)).join(` `).replace(/\$/g, `\\$`)
-                                    + `; do if [ -d /QSYS.LIB/$lib.LIB ]; then echo $lib; fi; done`
+            const result = await this.sendQsh({
+              command: [
+                `liblist -d ` + this.defaultUserLibraries.join(` `).replace(/\$/g, `\\$`),
+                ...this.config.libraryList.map(lib => `liblist -a ` + lib.replace(/\$/g, `\\$`))
+              ].join(`; `)
             });
-            if (result) {
-              validLibs = result.stdout.split(`\n`).filter(lib => lib.trim() !== ``).map(lib => this.sysNameInLocal(lib));
-              badLibs = this.config.libraryList.filter(lib => !validLibs.includes(lib)).map(lib => this.sysNameInLocal(lib));
-              
-              if (badLibs.length > 0) {
-                const chosen = await vscode.window.showWarningMessage(`The following ${badLibs.length > 1 ? `libraries` : `library`} does not exist: ${badLibs.join(`,`)}. Remove ${badLibs.length > 1 ? `them` : `it`} from the library list?`, `Yes`, `No`);
-                if (chosen === `Yes`) {
-                  this.config!.libraryList = validLibs;
-                } else {
-                  vscode.window.showWarningMessage(`The following libraries does not exist: ${badLibs.join(`,`)}.`);
-                }
+        
+            if (result.stderr) {
+              const lines = result.stderr.split(`\n`);
+        
+              lines.forEach(line => {
+                const badLib = this.config?.libraryList.find(lib => line.includes(`ibrary ${lib}`));
+        
+                // If there is an error about the library, store it
+                if (badLib) badLibs.push(badLib);
+              });
+            }
+        
+            if (result && badLibs.length > 0) {
+              validLibs = this.config.libraryList.filter(lib => !badLibs.includes(lib));
+              const chosen = await vscode.window.showWarningMessage(`The following ${badLibs.length > 1 ? `libraries` : `library`} does not exist: ${badLibs.join(`,`)}. Remove ${badLibs.length > 1 ? `them` : `it`} from the library list?`, `Yes`, `No`);
+              if (chosen === `Yes`) {
+                this.config!.libraryList = validLibs;
+              } else {
+                vscode.window.showWarningMessage(`The following libraries does not exist: ${badLibs.join(`,`)}.`);
               }
             }
           }

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -381,7 +381,7 @@ export default class IBMiContent {
       const lines = result.stderr.split(`\n`);
 
       lines.forEach(line => {
-        const badLib = newLibl.find(lib => line.includes(`ibrary ${lib}`));
+        const badLib = newLibl.find(lib => line.includes(`ibrary ${lib} `));
 
         // If there is an error about the library, remove it
         if (badLib) badLibs.push(badLib);

--- a/src/locale/ids/da.ts
+++ b/src/locale/ids/da.ts
@@ -91,8 +91,11 @@ export const da: Locale = {
   'LibraryListView.changeUserLibraryList.prompt': `Skift biblioteksliste (du kan bruge '*reset')`,
   'LibraryListView.changeUserLibraryList.removedLibs': `De følgende biblioteker blev fjernet fra den opdaterede biblioteksliste, da de ikke er gyldige: {0}`,
   'LibraryListView.addToLibraryList.prompt': `Tilføj bibliotek`,
-  'LibraryListView.addToLibraryList.removedLibs': `De følgende biblioteker blev fjernet fra den opdaterede biblioteksliste, da de ikke er gyldige: {0}`,
   'LibraryListView.addToLibraryList.tooLong': `Bibioteksnavn er for langt.`,
+  'LibraryListView.addToLibraryList.alreadyInList': `Bibliotek {0} er allerede i bibliotekslisten.`,
+  'LibraryListView.addToLibraryList.invalidLib': `Bibliotek {0} findes ikke.`,
+  'LibraryListView.addToLibraryList.addedLib': `Bibliotek {0} blev tilføjet til bibliotekslisten.`,
+  'LibraryListView.addToLibraryList.removedLibs': `De følgende biblioteker blev fjernet fra den opdaterede biblioteksliste, da de ikke er gyldige: {0}`,
   'LibraryListView.cleanupLibraryList.removedLibs': `De følgende biblioteker blev fjernet fra den opdaterede biblioteksliste, da de ikke er gyldige: {0}`,
   'LibraryListView.cleanupLibraryList.validated': `Bibliotekslisten blev valideret uden fejl.`,
   // objectBrowser:

--- a/src/locale/ids/da.ts
+++ b/src/locale/ids/da.ts
@@ -96,6 +96,7 @@ export const da: Locale = {
   'LibraryListView.addToLibraryList.invalidLib': `Bibliotek {0} findes ikke.`,
   'LibraryListView.addToLibraryList.addedLib': `Bibliotek {0} blev tilføjet til bibliotekslisten.`,
   'LibraryListView.addToLibraryList.removedLibs': `De følgende biblioteker blev fjernet fra den opdaterede biblioteksliste, da de ikke er gyldige: {0}`,
+  'LibraryListView.removeFromLibraryList.removedLib': `Bibliotek {0} blev fjernet fra bibliotekslisten.`,
   'LibraryListView.cleanupLibraryList.removedLibs': `De følgende biblioteker blev fjernet fra den opdaterede biblioteksliste, da de ikke er gyldige: {0}`,
   'LibraryListView.cleanupLibraryList.validated': `Bibliotekslisten blev valideret uden fejl.`,
   // objectBrowser:

--- a/src/locale/ids/en.ts
+++ b/src/locale/ids/en.ts
@@ -91,8 +91,11 @@ export const en: Locale = {
   'LibraryListView.changeUserLibraryList.prompt': `Changing library list (can use '*reset')`,
   'LibraryListView.changeUserLibraryList.removedLibs': `The following libraries were removed from the updated library list as they are invalid: {0}`,
   'LibraryListView.addToLibraryList.prompt': `Library to add`,
-  'LibraryListView.addToLibraryList.removedLibs': `The following libraries were removed from the updated library list as they are invalid: {0}`,
   'LibraryListView.addToLibraryList.tooLong': `Library is too long.`,
+  'LibraryListView.addToLibraryList.alreadyInList': `Library {0} was already in the library list.`,
+  'LibraryListView.addToLibraryList.invalidLib': `Library {0} does not exist.`,
+  'LibraryListView.addToLibraryList.addedLib': `Library {0} was added to the library list.`,
+  'LibraryListView.addToLibraryList.removedLibs': `The following libraries were removed from the updated library list as they are invalid: {0}`,
   'LibraryListView.cleanupLibraryList.removedLibs': `The following libraries were removed from the updated library list as they are invalid: {0}`,
   'LibraryListView.cleanupLibraryList.validated': `Library list were validated without any errors.`,
   // objectBrowser:

--- a/src/locale/ids/en.ts
+++ b/src/locale/ids/en.ts
@@ -96,6 +96,7 @@ export const en: Locale = {
   'LibraryListView.addToLibraryList.invalidLib': `Library {0} does not exist.`,
   'LibraryListView.addToLibraryList.addedLib': `Library {0} was added to the library list.`,
   'LibraryListView.addToLibraryList.removedLibs': `The following libraries were removed from the updated library list as they are invalid: {0}`,
+  'LibraryListView.removeFromLibraryList.removedLib': `Library {0} was removed from the library list.`,
   'LibraryListView.cleanupLibraryList.removedLibs': `The following libraries were removed from the updated library list as they are invalid: {0}`,
   'LibraryListView.cleanupLibraryList.validated': `Library list were validated without any errors.`,
   // objectBrowser:

--- a/src/views/LibraryListView.ts
+++ b/src/views/LibraryListView.ts
@@ -181,10 +181,12 @@ export class LibraryListProvider implements vscode.TreeDataProvider<LibraryListN
 
             let index = libraryList.findIndex(file => file.toUpperCase() === node.path)
             if (index >= 0) {
+              const removedLib = libraryList[index];
               libraryList.splice(index, 1);
 
               config.libraryList = libraryList;
               await this.updateConfig(config);
+              vscode.window.showInformationMessage(t(`LibraryListView.removeFromLibraryList.removedLib`, removedLib));
             }
           }
         }

--- a/src/views/LibraryListView.ts
+++ b/src/views/LibraryListView.ts
@@ -137,20 +137,37 @@ export class LibraryListProvider implements vscode.TreeDataProvider<LibraryListN
           }
 
           if (addingLib) {
-            if (addingLib.length <= 10) {
-              libraryList.push(addingLib.toUpperCase());
-              const badLibs = await content.validateLibraryList(libraryList);
-
-              if (badLibs.length > 0) {
-                libraryList = libraryList.filter(lib => !badLibs.includes(lib));
-                vscode.window.showWarningMessage(t(`LibraryListView.addToLibraryList.removedLibs`, badLibs.join(`, `)));
-              }
-
-              config.libraryList = libraryList;
-              await this.updateConfig(config);
-            } else {
+            if (addingLib.length > 10) {
               vscode.window.showErrorMessage(t(`LibraryListView.addToLibraryList.tooLong`));
+              return;
             }
+
+            addingLib = addingLib.toUpperCase();
+
+            if (libraryList.includes(addingLib)) {
+              vscode.window.showWarningMessage(t(`LibraryListView.addToLibraryList.alreadyInList`, addingLib));
+              return;
+            }
+
+            let badLibs = await content.validateLibraryList([addingLib]);
+
+            if (badLibs.length > 0) {
+              libraryList = libraryList.filter(lib => !badLibs.includes(lib));
+              vscode.window.showWarningMessage(t(`LibraryListView.addToLibraryList.invalidLib`, badLibs.join(`, `)));
+            } else {
+              libraryList.push(addingLib);
+              vscode.window.showInformationMessage(t(`LibraryListView.addToLibraryList.addedLib`, addingLib));
+            }
+
+            badLibs = await content.validateLibraryList(libraryList);
+
+            if (badLibs.length > 0) {
+              libraryList = libraryList.filter(lib => !badLibs.includes(lib));
+              vscode.window.showWarningMessage(t(`LibraryListView.addToLibraryList.removedLibs`, badLibs.join(`, `)));
+            }
+
+            config.libraryList = libraryList;
+            await this.updateConfig(config);
           }
         }
       }),


### PR DESCRIPTION
### Changes

This PR will

- fix the problem in issue #1497 and allow ASP libraries in the library list validation when connecting.
- enhance validation when a library is added to the list
- show message when a library is removed from the list
- fix an error in library list validation, where the wrong library were removed, e.g. library ABC was removed if library ABCDEF did not exist

@sebjulliand Locale files has been changed with the following message id's:

```
LibraryListView.addToLibraryList.alreadyInList
LibraryListView.addToLibraryList.invalidLib
LibraryListView.addToLibraryList.addedLib
LibraryListView.addToLibraryList.removedLibs
LibraryListView.removeFromLibraryList.removedLib
```

Will you translate into French?

### Checklist

* [x] have tested my change
* [x] eslint is not complaining
