### PR TITLE
Add the current host as a default variable

### DIFF
--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -82,6 +82,8 @@ export namespace CompileTools {
       variables.set(`\\*CURLIB`, librarySettings ? librarySettings.currentLibrary : config.currentLibrary);
       variables.set(`&USERNAME`, connection.currentUser);
       variables.set(`{usrprf}`, connection.currentUser);
+      variables.set(`&HOST`, connection.currentHost);
+      variables.set(`{host}`, connection.currentHost);
       variables.set(`&HOME`, config.homeDirectory);
 
       const libraryList = buildLibraryList(librarySettings);


### PR DESCRIPTION
### Changes

Add the current host as a default variable to support the variable substitution documented for `buildCommand` and `compileCommand` in `iproj.json`. For references: https://ibm.github.io/vscode-ibmi-projectexplorer/#/pages/ibm-i-projects/iproj-json?id=buildcommand

### Checklist

* [x] have tested my change
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] **for feature PRs**: PR only includes one feature enhancement.
