### PR TITLE
Wait actual end of CompileTools.runAction

### DIFF
--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -1,14 +1,11 @@
 
-import path from 'path';
+import path, { dirname } from 'path';
 import * as vscode from "vscode";
-import Instance from "./api/Instance";
 import { CompileTools } from './api/CompileTools';
-import { Terminal } from './api/Terminal';
-import { SearchView } from "./views/searchView";
-import { VariablesUI } from "./webviews/variables";
-import { dirname } from 'path';
 import { ConnectionConfiguration, GlobalConfiguration, onCodeForIBMiConfigurationChange } from "./api/Configuration";
+import Instance from "./api/Instance";
 import { Search } from "./api/Search";
+import { Terminal } from './api/Terminal';
 import { refreshDiagnosticsFromServer } from './api/errors/diagnostics';
 import { QSysFS, getMemberUri, getUriFromPath } from "./filesystems/qsys/QSysFs";
 import { init as clApiInit } from "./languages/clle/clApi";
@@ -16,7 +13,9 @@ import * as clRunner from "./languages/clle/clRunner";
 import { initGetNewLibl } from "./languages/clle/getnewlibl";
 import { SEUColorProvider } from "./languages/general/SEUColorProvider";
 import { Action, DeploymentMethod, QsysFsOptions } from "./typings";
+import { SearchView } from "./views/searchView";
 import { ActionsUI } from './webviews/actions';
+import { VariablesUI } from "./webviews/variables";
 
 export let instance: Instance;
 
@@ -211,15 +210,15 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(`code-for-ibmi.runAction`, async (target: vscode.TreeItem | vscode.Uri, group?: any, action?: Action, method?: DeploymentMethod) => {
       const editor = vscode.window.activeTextEditor;
       let uri;
-      if(target){
-        if("fsPath" in target){
+      if (target) {
+        if ("fsPath" in target) {
           uri = target;
         }
-        else{
+        else {
           uri = target?.resourceUri;
         }
-      } 
-      
+      }
+
       uri = uri || editor?.document.uri;
 
       if (uri) {
@@ -250,13 +249,15 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
           }
 
           if (canRun && [`member`, `streamfile`, `file`].includes(uri.scheme)) {
-            await CompileTools.runAction(instance, uri, action, method);
+            return await CompileTools.runAction(instance, uri, action, method);
           }
         }
         else {
           vscode.window.showErrorMessage('Please connect to an IBM i first');
         }
       }
+      
+      return false;
     }),
 
     vscode.commands.registerCommand(`code-for-ibmi.openErrors`, async (qualifiedObject?: string) => {

--- a/src/languages/clle/clRunner.ts
+++ b/src/languages/clle/clRunner.ts
@@ -23,7 +23,7 @@ export function initialise(context: ExtensionContext) {
               );
             }
             
-            return await CompileTools.runAction(instance, editor.document.uri, {
+            CompileTools.runAction(instance, editor.document.uri, {
               command: selectedCommand.content,
               environment: `ile`,
               name: `CL command`,
@@ -31,8 +31,6 @@ export function initialise(context: ExtensionContext) {
           }
         }
       }
-
-      return false;
     })
   )
 }

--- a/src/languages/clle/clRunner.ts
+++ b/src/languages/clle/clRunner.ts
@@ -23,7 +23,7 @@ export function initialise(context: ExtensionContext) {
               );
             }
             
-            await CompileTools.runAction(instance, editor.document.uri, {
+            return await CompileTools.runAction(instance, editor.document.uri, {
               command: selectedCommand.content,
               environment: `ile`,
               name: `CL command`,
@@ -31,6 +31,8 @@ export function initialise(context: ExtensionContext) {
           }
         }
       }
+
+      return false;
     })
   )
 }

--- a/src/languages/clle/clRunner.ts
+++ b/src/languages/clle/clRunner.ts
@@ -1,8 +1,6 @@
-import { ExtensionContext, Position, Range, Selection, TextDocument, commands, window } from "vscode";
-import { instance } from "../../instantiate";
-import { GlobalConfiguration } from "../../api/Configuration";
-import { EndOfLine } from "vscode";
+import { EndOfLine, ExtensionContext, Position, Range, Selection, TextDocument, commands, window } from "vscode";
 import { CompileTools } from "../../api/CompileTools";
+import { instance } from "../../instantiate";
 
 export function initialise(context: ExtensionContext) {
   context.subscriptions.push(
@@ -25,7 +23,7 @@ export function initialise(context: ExtensionContext) {
               );
             }
             
-            CompileTools.runAction(instance, editor.document.uri, {
+            await CompileTools.runAction(instance, editor.document.uri, {
               command: selectedCommand.content,
               environment: `ile`,
               name: `CL command`,


### PR DESCRIPTION
### Changes
Since `CompileTools.runAction` now uses task, it returns right after the task is created and started.
This PR makes it wait for the actual end of the action before returning and also lets the `code-for-ibmi.runAction` command returns the result of the action as a `boolean`.

### Checklist

* [x] have tested my change
* [x] Remove any/all `console.log`s I added