### PR TITLE
Automatically bump versions on release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,13 @@ on:
 jobs:
   release:
     name: Release and publish
+
     runs-on: ubuntu-latest
+
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the versions bump
+      contents: write
+
     steps:
       - uses: actions/setup-node@v2
         with:
@@ -14,10 +20,22 @@ jobs:
 
       - uses: actions/checkout@v2
       
-      - run: npm install
+      - name: Install dependencies & publishing tools
+        run: |
+          npm install
+          npm install -g vsce ovsx
       
-      - run: npm install -g vsce ovsx
-      
+      - name: Bump version numbers
+        run: |
+          npm --no-git-tag-version version ${{ github.ref_name }}
+          cd types && npm --no-git-tag-version version ${{ github.ref_name }}
+
+      - name: Commit & push versions bump
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: master
+          commit_message: Released version ${{ github.ref_name }}
+
       - name: Publish to Marketplace
         run: vsce publish -p $PUBLISHER_TOKEN
         env:


### PR DESCRIPTION
### Changes
This PR adds two actions to the release process:
- It automatically change set the version number in the extension's `package.json` and in the types' `package.json`, based on the release name.
- It commits and push this change on the master branch

This would allow contributors to create a release without the need to create a PR for bumping the versions.
It also ensures that both the extension and the types version are always aligned when publishing.