### PR TITLE
Renamed connection's privateKey to privateKeyPath

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -3,7 +3,6 @@ import * as node_ssh from "node-ssh";
 import * as vscode from "vscode";
 import { ConnectionConfiguration } from "./Configuration";
 
-import { readFileSync } from "fs";
 import path from 'path';
 import { instance } from "../instantiate";
 import { CommandData, CommandResult, ConnectionData, IBMiMember, RemoteCommand, StandardIO } from "../typings";
@@ -117,14 +116,7 @@ export default class IBMi {
     try {
       connectionObject.keepaliveInterval = 35000;
       
-      configVars.replaceAll(connectionObject);
-
-      // Make sure we're not passing any blank strings, as node_ssh will try to validate it
-      if (connectionObject.privateKey) {
-        connectionObject.privateKey = readFileSync(connectionObject.privateKey, {encoding: `utf-8`});
-      } else {
-        connectionObject.privateKey = null;
-      }      
+      configVars.replaceAll(connectionObject);   
 
       return await vscode.window.withProgress({
         location: vscode.ProgressLocation.Notification,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,7 +113,26 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
     ]);
   });
 
+  await fixPrivateKeys();
+
   return { instance, customUI: () => new CustomUI(), deployTools: DeployTools, evfeventParser: parseErrors, tools: Tools };
+}
+
+async function fixPrivateKeys(){
+  const connections = (GlobalConfiguration.get<ConnectionData[]>(`connections`) || []);
+  let update = false;
+  for(const connection of connections){
+    if('privateKey' in connection && connection.privateKey){
+      connection.privateKeyPath = connection.privateKey as string;
+      connection.privateKey = undefined;
+      console.log(`Fixed private key for ${connection.name}`);
+      update = true;
+    }
+  }
+
+  if(update){
+    await GlobalConfiguration.set(`connections`, connections);
+  }
 }
 
 // this method is called when your extension is deactivated

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -125,7 +125,6 @@ async function fixPrivateKeys(){
     if('privateKey' in connection && connection.privateKey){
       connection.privateKeyPath = connection.privateKey as string;
       connection.privateKey = undefined;
-      console.log(`Fixed private key for ${connection.name}`);
       update = true;
     }
   }

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -53,8 +53,7 @@ export async function registerUriHandler(context: ExtensionContext) {
                     name: `${user}-${host}`,
                     username: String(user),
                     password: String(pass),
-                    port,
-                    privateKey: null
+                    port
                   };
 
                   const connectionResult = await commands.executeCommand(`code-for-ibmi.connectDirect`, connectionData);
@@ -154,8 +153,7 @@ export async function handleStartup() {
       name: `Sandbox-${username}`,
       username,
       password,
-      port: 22,
-      privateKey: null
+      port: 22
     };
 
     if (env.VSCODE_IBMI_SANDBOX) {

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -73,7 +73,7 @@ export interface ConnectionData {
   port: number;
   username: string;
   password?: string;
-  privateKey: string | null;
+  privateKeyPath?: string;
   keepaliveInterval?: number;
 }
 

--- a/src/webviews/login/index.ts
+++ b/src/webviews/login/index.ts
@@ -1,9 +1,9 @@
 import vscode from "vscode";
-import IBMi from "../../api/IBMi";
-import { CustomUI } from "../../api/CustomUI";
 import { GlobalConfiguration } from "../../api/Configuration";
-import { ConnectionData } from '../../typings';
+import { CustomUI } from "../../api/CustomUI";
+import IBMi from "../../api/IBMi";
 import { disconnect, instance } from "../../instantiate";
+import { ConnectionData } from '../../typings';
 
 export class Login {
 
@@ -27,7 +27,7 @@ export class Login {
       .addParagraph(`Only provide either the password or a private key - not both.`)
       .addPassword(`password`, `Password`)
       .addCheckbox(`savePassword`, `Save Password`)
-      .addFile(`privateKey`, `Private Key`, `OpenSSH, RFC4716, or PPK formats are supported.`)
+      .addFile(`privateKeyPath`, `Private Key`, `OpenSSH, RFC4716, or PPK formats are supported.`)
       .addButtons(
         { id: `connect`, label: `Connect`, requiresValidation: true },
         { id: `saveExit`, label: `Save & Exit` }
@@ -54,7 +54,7 @@ export class Login {
               host: data.host,
               port: data.port,
               username: data.username,
-              privateKey: data.privateKey
+              privateKeyPath: data.privateKeyPath
             });
 
             if (data.savePassword) context.secrets.store(`${data.name}_password`, `${data.password}`);
@@ -128,7 +128,7 @@ export class Login {
     const existingConnections = GlobalConfiguration.get<ConnectionData[]>(`connections`) || [];
     let connectionConfig = existingConnections.find(item => item.name === name);
     if (connectionConfig) {
-      if (!connectionConfig.privateKey) {
+      if (!connectionConfig.privateKeyPath) {
         connectionConfig.password = await context.secrets.get(`${connectionConfig.name}_password`);
         if (!connectionConfig.password) {
           connectionConfig.password = await vscode.window.showInputBox({

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -1,9 +1,9 @@
 import vscode from "vscode";
+import { ConnectionConfiguration, GlobalConfiguration } from "../../api/Configuration";
 import { ComplexTab, CustomUI, Section } from "../../api/CustomUI";
-import { GlobalConfiguration, ConnectionConfiguration } from "../../api/Configuration";
-import { ConnectionData, Server } from '../../typings';
-import { instance } from "../../instantiate";
 import * as certificates from "../../api/debug/certificates";
+import { instance } from "../../instantiate";
+import { ConnectionData, Server } from '../../typings';
 
 const ENCODINGS = [`37`, `256`, `273`, `277`, `278`, `280`, `284`, `285`, `297`, `500`, `871`, `870`, `905`, `880`, `420`, `875`, `424`, `1026`, `290`, `win37`, `win256`, `win273`, `win277`, `win278`, `win280`, `win284`, `win285`, `win297`, `win500`, `win871`, `win870`, `win905`, `win880`, `win420`, `win875`, `win424`, `win1026`];
 
@@ -228,7 +228,7 @@ export class SettingsUI {
               .addInput(`username`, `Username`, undefined, { default: connection.username, minlength: 1 })
               .addParagraph(`Only provide either the password or a private key - not both.`)
               .addPassword(`password`, `Password`, `Only provide a password if you want to update an existing one or set a new one.`)
-              .addFile(`privateKey`, `Private Key${connection.privateKey ? ` (current: ${connection.privateKey})` : ``}`, `Only provide a private key if you want to update from the existing one or set one. OpenSSH, RFC4716, or PPK formats are supported.`)
+              .addFile(`privateKeyPath`, `Private Key${connection.privateKeyPath ? ` (current: ${connection.privateKeyPath})` : ``}`, `Only provide a private key if you want to update from the existing one or set one. OpenSSH, RFC4716, or PPK formats are supported.`)
               .addButtons({ id: `submitButton`, label: `Save`, requiresValidation: true })
               .loadPage<any>(`Login Settings: ${name}`);
 
@@ -237,12 +237,12 @@ export class SettingsUI {
 
               const data = page.data;
               data.port = Number(data.port);
-              if (data.privateKey === ``) data.privateKey = connection.privateKey;
+              if (data.privateKeyPath === ``) data.privateKeyPath = connection.privateKeyPath;
 
-              if (data.password && !data.privateKey) {
+              if (data.password && !data.privateKeyPath) {
                 context.secrets.delete(`${name}_password`);
                 context.secrets.store(`${name}_password`, `${data.password}`);
-                data.privateKey = ``;
+                data.privateKeyPath = ``;
               };
 
               delete data.password;


### PR DESCRIPTION
### Changes
- Use the correct field used by node-ssh Config object
- Added a method called on activation to fix existing configurations (can be removed in the future)
- Fixes https://github.com/halcyon-tech/vscode-ibmi/issues/1542

The private key file content was loaded into the `privateKey` field, which is not wrong, but it caused an issue when the `ConnectionData` object was reused while reconnecting a dropped connection.

This PR renames `ConnectionData` `privateKey` to `privateKeyPath` which is an actual field used by node-ssh when connecting. This way we use the correct field for the job and leave it up to node-ssh to read the file's content, too.

A small migration method is called when the extension activates to update the existing configurations.

### Checklist
* [x] have tested my change
* [x] Remove any/all `console.log`s I added
