### PR TITLE
Fix and cleanup login settings

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -124,11 +124,11 @@ async function fixLoginSettings(){
   for(const connection of connections){
     //privateKey was used to hold privateKeyPath 
     if('privateKey' in connection){
-      const privateKey = connection.privateKey as string;
+      const privateKey = connection["privateKey"] as string;
       if(privateKey){
         connection.privateKeyPath = privateKey;
       }
-      connection.privateKey = undefined;
+      delete connection["privateKey"];
       update = true;
     }
 
@@ -140,7 +140,7 @@ async function fixLoginSettings(){
     
     //buttons were added by the login settings page
     if(`buttons` in connection) {
-      connection.buttons = undefined;
+      delete connection["buttons"];
       update = true;
     }
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -133,7 +133,7 @@ async function fixLoginSettings(){
     }
 
     //An empty privateKeyPath will crash the connection
-    if(!connection.privateKeyPath || !connection.privateKeyPath.trim()) {
+    if(!connection.privateKeyPath?.trim()) {
       connection.privateKeyPath = undefined;
       update = true;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,18 +113,31 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
     ]);
   });
 
-  await fixPrivateKeys();
+  await fixLoginSettings();
 
   return { instance, customUI: () => new CustomUI(), deployTools: DeployTools, evfeventParser: parseErrors, tools: Tools };
 }
 
-async function fixPrivateKeys(){
+async function fixLoginSettings(){
   const connections = (GlobalConfiguration.get<ConnectionData[]>(`connections`) || []);
   let update = false;
   for(const connection of connections){
-    if('privateKey' in connection && connection[`privateKey`]){
-      connection.privateKeyPath = connection[`privateKey`] as string;
-      connection[`privateKey`] = undefined;
+    if('privateKey' in connection){
+      const privateKey = connection.privateKey as string;
+      if(privateKey){
+        connection.privateKeyPath = privateKey;
+      }
+      connection.privateKey = undefined;
+      update = true;
+    }
+
+    if(!connection.privateKeyPath || !connection.privateKeyPath.trim()) {
+      connection.privateKeyPath = undefined;
+      update = true;
+    }
+    
+    if(`buttons` in connection) {
+      connection.buttons = undefined;
       update = true;
     }
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,6 +122,7 @@ async function fixLoginSettings(){
   const connections = (GlobalConfiguration.get<ConnectionData[]>(`connections`) || []);
   let update = false;
   for(const connection of connections){
+    //privateKey was used to hold privateKeyPath 
     if('privateKey' in connection){
       const privateKey = connection.privateKey as string;
       if(privateKey){
@@ -131,11 +132,13 @@ async function fixLoginSettings(){
       update = true;
     }
 
+    //An empty privateKeyPath will crash the connection
     if(!connection.privateKeyPath || !connection.privateKeyPath.trim()) {
       connection.privateKeyPath = undefined;
       update = true;
     }
     
+    //buttons were added by the login settings page
     if(`buttons` in connection) {
       connection.buttons = undefined;
       update = true;

--- a/src/webviews/login/index.ts
+++ b/src/webviews/login/index.ts
@@ -5,6 +5,11 @@ import IBMi from "../../api/IBMi";
 import { disconnect, instance } from "../../instantiate";
 import { ConnectionData } from '../../typings';
 
+type NewLoginSettings = ConnectionData & {  
+  savePassword: boolean  
+  buttons: 'saveExit' | 'connect'
+}
+
 export class Login {
 
   /**
@@ -20,10 +25,10 @@ export class Login {
     const existingConnections = GlobalConfiguration.get<ConnectionData[]>(`connections`) || [];
 
     const page = await new CustomUI()
-      .addInput(`name`, `Connection Name`, undefined, {minlength: 1})
-      .addInput(`host`, `Host or IP Address`, undefined, {minlength: 1})
+      .addInput(`name`, `Connection Name`, undefined, { minlength: 1 })
+      .addInput(`host`, `Host or IP Address`, undefined, { minlength: 1 })
       .addInput(`port`, `Port (SSH)`, ``, { default: `22`, minlength: 1, maxlength: 5, regexTest: `^\\d+$` })
-      .addInput(`username`, `Username`, undefined, {minlength: 1, maxlength: 10})
+      .addInput(`username`, `Username`, undefined, { minlength: 1, maxlength: 10 })
       .addParagraph(`Only provide either the password or a private key - not both.`)
       .addPassword(`password`, `Password`)
       .addCheckbox(`savePassword`, `Save Password`)
@@ -32,7 +37,7 @@ export class Login {
         { id: `connect`, label: `Connect`, requiresValidation: true },
         { id: `saveExit`, label: `Save & Exit` }
       )
-      .loadPage<any>(`IBM i Login`);
+      .loadPage<NewLoginSettings>(`IBM i Login`);
 
     if (page && page.data) {
       const data = page.data;
@@ -46,7 +51,7 @@ export class Login {
         if (existingConnection) {
           vscode.window.showErrorMessage(`Connection with name ${data.name} already exists.`);
         } else {
-          let newConnection = (!existingConnections.some(item => item.name === data.name));
+          const newConnection = (!existingConnections.some(item => item.name === data.name));
           if (newConnection) {
             // New connection!
             existingConnections.push({
@@ -54,10 +59,12 @@ export class Login {
               host: data.host,
               port: data.port,
               username: data.username,
-              privateKeyPath: data.privateKeyPath
+              privateKeyPath: data.privateKeyPath ? data.privateKeyPath : undefined
             });
 
-            if (data.savePassword) context.secrets.store(`${data.name}_password`, `${data.password}`);
+            if (data.savePassword) {
+              context.secrets.store(`${data.name}_password`, `${data.password}`);
+            }
 
             await GlobalConfiguration.set(`connections`, existingConnections);
             vscode.commands.executeCommand(`code-for-ibmi.refreshConnections`);

--- a/src/webviews/login/index.ts
+++ b/src/webviews/login/index.ts
@@ -44,7 +44,7 @@ export class Login {
       page.panel.dispose();
 
       data.port = Number(data.port);
-
+      data.privateKeyPath = data.privateKeyPath?.trim() ? data.privateKeyPath : undefined;
       if (data.name) {
         const existingConnection = existingConnections.find(item => item.name === data.name);
 
@@ -59,7 +59,7 @@ export class Login {
               host: data.host,
               port: data.port,
               username: data.username,
-              privateKeyPath: data.privateKeyPath ? data.privateKeyPath : undefined
+              privateKeyPath: data.privateKeyPath
             });
 
             if (data.savePassword) {


### PR DESCRIPTION
### Changes
This PR makes sure that `privateKeyPath` is always `undefined` and never `''` in the login settings.
It completely removes `privateKey` once and for all.
It removes some fields from the login page who could have made their way in the settings (like `buttons`).

Fixes https://github.com/halcyon-tech/vscode-ibmi/issues/1550

### Checklist
* [x] have tested my change
* [x] updated relevant documentation