### PR TITLE
Fixed copyObject crashing when copying library

### DIFF
--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -935,7 +935,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
           try {
             newPathOK = true;
             await connection.remoteCommand(
-              node.object.type === `LIB` ?
+              node.object.type.toLocaleLowerCase() === `*lib` ?
                 `CPYLIB FROMLIB(${oldObject}) TOLIB(${newObject})` :
                 `CRTDUPOBJ OBJ(${oldObject}) FROMLIB(${oldLibrary}) OBJTYPE(${node.object.type}) TOLIB(${newLibrary}) NEWOBJ(${newObject})`
             );


### PR DESCRIPTION
### Changes
Fixes https://github.com/halcyon-tech/vscode-ibmi/issues/1565

The object type test made in the `code-for-ibmi.copyObject` action was not changed after the Object Browser was converted to TypeScript. This PR fixes the test to compare the selected object's type with `*lib`.

### Checklist
* [x] have tested my change