### PR TITLE
Remove duplicates from the library list

### DIFF
--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -516,7 +516,7 @@ export namespace CompileTools {
         if (curlib) ileSetup.currentLibrary = curlib;
       }
 
-      // Remove any duplicates fromr the library list
+      // Remove any duplicates from the library list
       ileSetup.libraryList = ileSetup.libraryList.filter(Tools.distinct); 
 
       let commandString = replaceValues(


### PR DESCRIPTION
## Changes

When `.env` is used, or when the `runCommand` API is used, it's possible for the user or code to pass in duplicate libraries, which the IBM i doesn't like too much. This is a simple change to remove duplicates from the end of the library list.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
