### PR TITLE
Fix object default tooltips still showing

### DIFF
--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -275,7 +275,7 @@ class ObjectBrowserObjectItem extends ObjectBrowserItem implements ObjectItem {
     this.updateDescription();
 
     this.contextValue = `object.${type.toLowerCase()}${object.attribute ? `.${object.attribute}` : ``}${isProtected(this.filter) ? `_readonly` : ``}`;
-    this.tooltip = ``;
+    this.tooltip = new vscode.MarkdownString(``);
 
     this.resourceUri = vscode.Uri.from({
       scheme: `object`,


### PR DESCRIPTION
### Changes

This PR will remove the default toolip being shown for non-sourcefile objects in the Object browser:

![image](https://github.com/codefori/vscode-ibmi/assets/13275072/d5f59feb-d2fa-4d4e-87e4-c40be43851db)

Seems like if the tree has items with markdown tooltips, all items must use markdown tooltips...

### Checklist

* [x] have tested my change
