### PR TITLE
Standard library list API

### DIFF
--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -8,6 +8,8 @@ import { VsCodeConfig } from "./config/Configuration";
 import { EventEmitter } from "stream";
 import { ConnectionStorage } from "./api/configuration/storage/ConnectionStorage";
 import { VscodeTools } from "./ui/Tools";
+import { ILELibrarySettings } from "./api/CompileTools";
+import { getEnvConfig } from "./filesystems/local/env";
 
 type IBMiEventSubscription = {
   func: Function,
@@ -196,6 +198,19 @@ export default class Instance {
 
   getConnection() {
     return this.connection;
+  }
+
+  async getLibraryList(connection: IBMi, workspaceFolder?: vscode.WorkspaceFolder): Promise<ILELibrarySettings> {
+    const config = connection.getConfig();
+
+    const env = workspaceFolder ? (await getEnvConfig(workspaceFolder)) : {};
+
+    const librarySetup: ILELibrarySettings = {
+      currentLibrary: env[`&CURLIB`] || config.currentLibrary,
+      libraryList: env[`&LIBL`]?.split(` `) || config.libraryList,
+    };
+
+    return librarySetup;
   }
 
   async setConfig(newConfig: ConnectionConfig) {


### PR DESCRIPTION
Introduce a new instance API that fetches the library list and current library settings based on the connection and optional workspace folder.

This will be used in many places:

* RPGLE language server
* Project Explorer
* Database extension