### PR TITLE
Check if streamfile exists before creating it

### DIFF
--- a/src/ui/views/ifsBrowser.ts
+++ b/src/ui/views/ifsBrowser.ts
@@ -470,18 +470,17 @@ export function initializeIFSBrowser(context: vscode.ExtensionContext) {
         });
 
         if (fullName) {
-          try {
-            vscode.window.showInformationMessage(l10n.t(`Creating streamfile {0}.`, fullName));
-            await content.createStreamFile(fullName);
-            vscode.commands.executeCommand(`code-for-ibmi.openEditable`, fullName);
-            if (IBMi.connectionManager.get(`autoRefresh`)) {
-              ifsBrowser.refresh(node);
+          if (!await content.testStreamFile(fullName, "e") || await vscode.window.showWarningMessage(l10n.t("Streamfile {0} already exists. Do you want to overwrite it?", fullName), { modal: true }, l10n.t("Overwrite"))) {
+            try {
+              await content.createStreamFile(fullName);
+              vscode.commands.executeCommand(`code-for-ibmi.openEditable`, fullName);
+              vscode.window.showInformationMessage(l10n.t(`Created streamfile {0}.`, fullName));
+              if (IBMi.connectionManager.get(`autoRefresh`)) {
+                ifsBrowser.refresh(node);
+              }
+            } catch (e: any) {
+              vscode.window.showErrorMessage(l10n.t(`Error creating new streamfile! {0}`, e));
             }
-            else {
-              throw new Error("")
-            }
-          } catch (e: any) {
-            vscode.window.showErrorMessage(l10n.t(`Error creating new streamfile! {0}`, e));
           }
         }
       }


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Resolves #2686 

This PR shows a warning when creating a new streamfile that already exists. The warning dialog is modal and offers to overwrite the streamfile or cancel the creation operation.

### How to test this PR
1. Try to create a streamfile that already exists
2. A modal warning must show up
3. Clicking on overwrite actually resets the file and its CCSID attribute
<!-- 
Example:
1. Run the test cases
4. Expand view A and right click on the node
5. Run 'Execute Thing' from the command palette
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change