### PR TITLE
Correctly reset internal storage prefix after disconnection

### DIFF
--- a/src/api/configuration/storage/ConnectionStorage.ts
+++ b/src/api/configuration/storage/ConnectionStorage.ts
@@ -1,5 +1,5 @@
 import { BaseStorage } from "./BaseStorage";
-import { PathContent, DeploymentPath, DebugCommands } from "./CodeForIStorage";
+import { DebugCommands, DeploymentPath, PathContent } from "./CodeForIStorage";
 
 const PREVIOUS_CUR_LIBS_KEY = `prevCurLibs`;
 const LAST_PROFILE_KEY = `currentProfile`;
@@ -34,7 +34,7 @@ export class ConnectionStorage {
 
   setConnectionName(connectionName: string) {
     this.connectionName = connectionName;
-    this.internalStorage.setUniqueKeyPrefix(`settings-${connectionName}`);
+    this.internalStorage.setUniqueKeyPrefix(connectionName ? `settings-${connectionName}` : '');
   }
 
   getSourceList() {


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
This PR fixes the internal storage key prefix not being reset correctly after disconnecting from a system.

To reproduce the issue:
- Connect to an IBM i
- Disconnect
- Try reconnecting using the `Connect to previous IBM i` action form the Connection Browser
<img width="162" height="56" alt="image" src="https://github.com/user-attachments/assets/71fba851-897d-4856-874b-39d15aeaf8b0" />

- Nothing will happen

That's because the internal storage prefix was set to `settings-` instead of blank after the disconnection happens.
Setting it back to blank fixes the issue.

### How to test this PR
1. Connect to an IBM i
2. Disconnect
3. Reconnect using the `Connect to previous IBM i` action from the Connection Browser

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
