### PR TITLE
Allow multiple IFS shortcuts to be removed at once

### DIFF
--- a/package.json
+++ b/package.json
@@ -2860,7 +2860,7 @@
 				},
 				{
 					"command": "code-for-ibmi.removeIFSShortcut",
-					"when": "view == ifsBrowser && !listMultiSelection && viewItem =~ /^shortcut.*$/",
+					"when": "view == ifsBrowser && viewItem =~ /^shortcut.*$/",
 					"group": "3_ifsStuff@2"
 				},
 				{

--- a/src/ui/views/ifsBrowser.ts
+++ b/src/ui/views/ifsBrowser.ts
@@ -383,25 +383,19 @@ export function initializeIFSBrowser(context: vscode.ExtensionContext) {
       }
     }),
 
-    vscode.commands.registerCommand(`code-for-ibmi.removeIFSShortcut`, async (node: IFSShortcutItem) => {
+    vscode.commands.registerCommand(`code-for-ibmi.removeIFSShortcut`, async (node: IFSShortcutItem, nodes?: IFSShortcutItem[]) => {
       const connection = instance.getConnection();
       if (connection) {
         const config = connection.getConfig();
         const shortcuts = config.ifsShortcuts;
-        const removeDir = (node.path || (await vscode.window.showQuickPick(shortcuts, {
-          placeHolder: l10n.t(`Select IFS shortcut to remove`),
-        })))?.trim();
+        const toBeRemoved = (nodes || [node]).map(n => n.path);
 
         try {
-          if (removeDir) {
-            const inx = shortcuts.indexOf(removeDir);
-            if (inx >= 0) {
-              shortcuts.splice(inx, 1);
-              config.ifsShortcuts = shortcuts;
-              await IBMi.connectionManager.update(config);
-              if (IBMi.connectionManager.get(`autoRefresh`)) {
-                ifsBrowser.refresh();
-              }
+          if (toBeRemoved.length) {
+            config.ifsShortcuts = shortcuts.filter(path => !toBeRemoved.includes(path));
+            await IBMi.connectionManager.update(config);
+            if (IBMi.connectionManager.get(`autoRefresh`)) {
+              ifsBrowser.refresh();
             }
           }
         } catch (e) {


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
This PR allows the command used to remove IFS Shortcuts to support multiple selection in the IFS browser.
It also removed the part of the code that displayed a selection prompt if the command was called from the palette since it's not possible 

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Select multiple shortcuts in the IFS browser
2. Run the `Remove` action

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change