### PR TITLE
Log the state of dependent IBM i components

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -467,12 +467,6 @@ export default class IBMi {
           }
         }
 
-        this.appendOutput(`\nIBM i components:\n`);
-        for (const [feature, state] of Object.entries(this.remoteFeatures)) {
-          this.appendOutput(`\t${feature}: ${state}\n`);
-        }
-        this.appendOutput(`\n`);
-
         //Specific Java installations check
         callbacks.progress({
           message: `Checking installed components on host IBM i: Java`
@@ -490,6 +484,12 @@ export default class IBMi {
           javaCheck(`/QOpenSys/QIBM/ProdData/JavaVM/jdk17/64bit`)
         ]);
       }
+
+      this.appendOutput(`\nIBM i components:\n`);
+      for (const [feature, state] of Object.entries(this.remoteFeatures)) {
+        this.appendOutput(`\t${feature}: ${state}\n`);
+      }
+      this.appendOutput(`\n`);
 
       if (this.remoteFeatures.uname) {
         callbacks.progress({


### PR DESCRIPTION
### Changes

This PR just adds some additional logging so we get a more readable summary of whether IBM i components we depend on are found.

<img width="1636" height="1216" alt="image" src="https://github.com/user-attachments/assets/8bb2cc4b-2800-4377-b50c-6cd388d6decd" />


### How to test this PR
1. Use `Connect and Reload Server Settings`
2. Check the `Code for IBM i` log