### PR TITLE
Correctly return and handle connection command status

### DIFF
--- a/src/filesystems/qsys/FSUtils.ts
+++ b/src/filesystems/qsys/FSUtils.ts
@@ -1,8 +1,8 @@
 import path from "path";
 import vscode, { l10n } from "vscode";
-import { VscodeTools } from "../../ui/Tools";
 import IBMi from "../../api/IBMi";
 import { ReconnectMode } from "../../typings";
+import { VscodeTools } from "../../ui/Tools";
 
 /**
  * Called when a member/streamfile is left open when VS Code is closed and re-opened to reconnect (or not) to the previous IBM i, based on the `autoReconnect` global configuration value.
@@ -32,8 +32,7 @@ export async function reconnectFS(uri: vscode.Uri) {
   }
 
   if (doReconnect) {
-    await vscode.commands.executeCommand(`code-for-ibmi.connectToPrevious`);
-    return true;
+    return await vscode.commands.executeCommand<boolean>(`code-for-ibmi.connectToPrevious`);
   }
   else {
     for (const tab of VscodeTools.findUriTabs(uri)) {

--- a/src/ui/views/ConnectionBrowser.ts
+++ b/src/ui/views/ConnectionBrowser.ts
@@ -1,10 +1,10 @@
 import vscode from 'vscode';
 import { ConnectionConfig, ConnectionData, Server } from '../../typings';
 
-import { instance } from '../../instantiate';
-import { Login } from '../../webviews/login';
 import IBMi from '../../api/IBMi';
 import { deleteStoredPassword, getStoredPassword, setStoredPassword } from '../../config/passwords';
+import { instance } from '../../instantiate';
+import { Login } from '../../webviews/login';
 
 type CopyOperationItem = {
   label: string
@@ -32,11 +32,13 @@ export function initializeConnectionBrowser(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(`code-for-ibmi.connectToPrevious`, async () => {
       const lastConnection = IBMi.GlobalStorage.getLastConnections()?.[0];
       if (lastConnection) {
-        return await vscode.commands.executeCommand(`code-for-ibmi.connectTo`, lastConnection.name);
+        return await vscode.commands.executeCommand<boolean>(`code-for-ibmi.connectTo`, lastConnection.name);
       }
+      return false;
     }),
 
     vscode.commands.registerCommand(`code-for-ibmi.connectTo`, async (name?: string | Server, reloadServerSettings?: boolean) => {
+      let connected = false;
       if (!connectionBrowser.attemptingConnection) {
         connectionBrowser.attemptingConnection = true;
 
@@ -52,10 +54,10 @@ export function initializeConnectionBrowser(context: vscode.ExtensionContext) {
 
         switch (typeof name) {
           case `string`: // Name of connection object
-            await Login.LoginToPrevious(name, context, reloadServerSettings);
+            connected = await Login.LoginToPrevious(name, context, reloadServerSettings);
             break;
           case `object`: // A Server object
-            await Login.LoginToPrevious(name.name, context, reloadServerSettings);
+            connected = await Login.LoginToPrevious(name.name, context, reloadServerSettings);
             break;
           default:
             vscode.window.showErrorMessage(vscode.l10n.t(`Use the Server Browser to select which system to connect to.`));
@@ -63,14 +65,16 @@ export function initializeConnectionBrowser(context: vscode.ExtensionContext) {
         }
 
         connectionBrowser.attemptingConnection = false;
+        return connected;
       }
     }),
 
     vscode.commands.registerCommand(`code-for-ibmi.connectToAndReload`, async (server: Server) => {
       if (!connectionBrowser.attemptingConnection && server) {
         const reloadServerSettings = true;
-        vscode.commands.executeCommand(`code-for-ibmi.connectTo`, server.name, reloadServerSettings);
+        return vscode.commands.executeCommand<boolean>(`code-for-ibmi.connectTo`, server.name, reloadServerSettings);
       }
+      return false;
     }),
 
     vscode.commands.registerCommand(`code-for-ibmi.refreshConnections`, () => {

--- a/src/uri/handlers/open.ts
+++ b/src/uri/handlers/open.ts
@@ -31,11 +31,14 @@ export const openURIHandler: Code4iUriHandler = {
     try {
       const parameters = await loadParameters(querystring.parse(uri.query), connection);
       if (!parameters.cancel) {
+        let doOpen = true;
         if (parameters.connect && parameters.host) {
-          await vscode.commands.executeCommand(`code-for-ibmi.connectTo`, parameters.host.name)
+          doOpen = await vscode.commands.executeCommand<boolean>(`code-for-ibmi.connectTo`, parameters.host.name)
         }
 
-        vscode.commands.executeCommand("code-for-ibmi.openWithDefaultMode", parameters.path, parameters.readonly);
+        if (doOpen) {
+          vscode.commands.executeCommand("code-for-ibmi.openWithDefaultMode", parameters.path, parameters.readonly);
+        }
       }
     }
     catch (error: any) {

--- a/src/webviews/login/index.ts
+++ b/src/webviews/login/index.ts
@@ -154,7 +154,7 @@ export class Login {
       }
     }
 
-    const connection = await IBMi.connectionManager.getByName(name);
+    const connection = IBMi.connectionManager.getByName(name);
     if (connection) {
       const toDoOnConnected: Function[] = [];
       const connectionConfig = connection.data;
@@ -171,7 +171,7 @@ export class Login {
         }
 
         if (!connectionConfig.password) {
-          return;
+          return false;
         }
       }
 
@@ -179,11 +179,10 @@ export class Login {
         const connected = await instance.connect({ data: connectionConfig, onConnectedOperations: toDoOnConnected, reloadServerSettings });
         if (connected.success) {
           vscode.window.showInformationMessage(`Connected to ${connectionConfig.host}!`);
+          return true;
         } else {
           vscode.window.showErrorMessage(`Not connected to ${connectionConfig.host}${connected.error ? `: ${connected.error}` : '!'}`);
         }
-
-        return true;
       } catch (e) {
         vscode.window.showErrorMessage(`Error connecting to ${connectionConfig.host}! ${e}`);
       }


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->

The `code-for-ibmi.connectTo` command did not always return the actual result of the connection process. It would return `true` even if the connection failed (i.e. trying to connect to an unreachable system would return `true`).

This PR fixes this issue and makes sure that the connection result is sent back to whichever process calls it.

### How to test this PR
Put a logpoint or a breakpoint in ConnectionBrowser.ts on line 68 and check the value of the `connected` field. It must reflect the actual connection process result.

Connecting to an unreachable system must return `false`.
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change