### PR TITLE
Renamed BOB references to TOBi

### DIFF
--- a/src/filesystems/local/LocalLanguageActions.ts
+++ b/src/filesystems/local/LocalLanguageActions.ts
@@ -165,7 +165,7 @@ export const LocalLanguageActions: Record<string, Action[]> = {
       "extensions": [
         `GLOBAL`
       ],
-      "name": `Build all`,
+      "name": `Build all with gmake`,
       "command": `/QOpenSys/pkgs/bin/gmake BUILDLIB=&CURLIB ERR=*EVENTF`,
       environment: `pase`,
       deployFirst: true,
@@ -174,18 +174,18 @@ export const LocalLanguageActions: Record<string, Action[]> = {
       "extensions": [
         `GLOBAL`
       ],
-      "name": `Build current`,
+      "name": `Build current with gmake`,
       "command": `/QOpenSys/pkgs/bin/gmake &BASENAME BUILDLIB=&CURLIB ERR=*EVENTF`,
       environment: `pase`,
       deployFirst: true,
     }
   ],
-  "ibmi-bob": [
+  "The Object Builder for i (TOBi)": [
     {
       "extensions": [
         `GLOBAL`
       ],
-      "name": `Build all`,
+      "name": `Build all with TOBi`,
       "command": `OPT=*EVENTF BUILDLIB=&CURLIB /QOpenSys/pkgs/bin/makei build`,
       environment: `pase`,
       deployFirst: true,
@@ -198,7 +198,7 @@ export const LocalLanguageActions: Record<string, Action[]> = {
       "extensions": [
         `GLOBAL`
       ],
-      "name": `Build current`,
+      "name": `Build current with TOBi`,
       "command": `OPT=*EVENTF BUILDLIB=&CURLIB /QOpenSys/pkgs/bin/makei compile -f &BASENAME`,
       environment: `pase`,
       deployFirst: true,

--- a/src/ui/actions.ts
+++ b/src/ui/actions.ts
@@ -207,14 +207,14 @@ export async function runAction(instance: Instance, uris: vscode.Uri | vscode.Ur
                 const parent = path.parse(pathData.dir).base;
                 let name = pathData.name;
 
-                // Logic to handle second extension, caused by bob.
-                const bobTypes = [`.PGM`, `.SRVPGM`];
+                // Logic to handle second extension, caused by TOBi.
+                const tobiTypes = [`.PGM`, `.SRVPGM`];
                 const secondName = path.parse(name);
-                if (secondName.ext && bobTypes.includes(secondName.ext.toUpperCase())) {
+                if (secondName.ext && tobiTypes.includes(secondName.ext.toUpperCase())) {
                   name = secondName.name;
                 }
 
-                // Remove bob text convention
+                // Remove TOBi text convention
                 if (name.includes(`-`)) {
                   name = name.substring(0, name.indexOf(`-`));
                 }


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->

Since BOB for IBM i is now known as TOBi, this PR renames the label for the local actions accordingly.
It also differentiate the labels for `Buill all/Build current` action for gmake, TOBi and Source Orbit.

<img width="270" height="83" alt="image" src="https://github.com/user-attachments/assets/645490ef-3b24-40b0-ad24-5a11790c40e5" />


### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->

1. Launch workspace actions setup
2. Make sure ibmi-bob is now TOBi
3. Check the actions are labelled `Build all/curent with TOBi`

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change