### PR TITLE
Fix actions highlighting when there is no active editor

### DIFF
--- a/src/ui/views/environment/actions.ts
+++ b/src/ui/views/environment/actions.ts
@@ -92,7 +92,7 @@ export class ActionsNode extends EnvironmentItem {
       };
     }
 
-    const canRunOnEditor = (actionItem: ActionItem) => activeEditorContext &&
+    const canRunOnEditor = (actionItem: ActionItem) => activeEditorContext !== undefined &&
       activeEditorContext.scheme === actionItem.action.type &&
       activeEditorContext.workspace === actionItem.workspace &&
       (actionItem.action.runOnProtected || !activeEditorContext.protected) &&


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Fixes #3018

Closing the last active editor will not let actions highlighted anymore.

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->

1. Open a member or IFS file on which at least on action can be run on
2. The action must be highlighted
3. Close the editor
4. No action must be highlighted anymore

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change