### PR TITLE
Show "Prompting" in notification when prompting a single target action

### DIFF
--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -14,8 +14,9 @@ export namespace CompileTools {
   export const DID_NOT_RUN = -123;
 
   interface RunCommandEvents {
-    writeEvent?: (content: string) => void;
-    commandConfirm?: (command: string) => Promise<string>;
+    writeEvent?: (content: string) => void
+    commandConfirm?: (command: string) => Promise<string>
+    updateProgress?: (message: string) => void
   }
 
   /**
@@ -40,7 +41,9 @@ export namespace CompileTools {
       let commandString = variables.expand(options.command);
 
       if (events.commandConfirm) {
+        events.updateProgress?.(" - Prompting...");
         commandString = await events.commandConfirm(commandString);
+        events.updateProgress?.("");
       }
 
       if (commandString) {

--- a/src/ui/actions.ts
+++ b/src/ui/actions.ts
@@ -294,7 +294,7 @@ export async function runAction(instance: Instance, uris: vscode.Uri | vscode.Ur
                 break;
             }
 
-            task.report({ message: `${processedPath} (${done++}/${targets.length})`, increment })
+            task.report({ message: `${processedPath}${targets.length > 1 ? ` (${done++}/${targets.length})` : ''}`, increment })
 
             const viewControl = IBMi.connectionManager.get<string>(`postActionView`) || "none";
             let actionName = chosenAction.name;
@@ -372,7 +372,8 @@ export async function runAction(instance: Instance, uris: vscode.Uri | vscode.Ur
                             env: variables,
                           }, {
                           writeEvent: (content) => writeEmitter.fire(content),
-                          commandConfirm: promptOnce ? undefined : commandConfirm
+                          commandConfirm: promptOnce ? undefined : commandConfirm,
+                          updateProgress: message => task.report({ message: `${processedPath}${message}` })
                         }
                         );
 
@@ -388,7 +389,7 @@ export async function runAction(instance: Instance, uris: vscode.Uri | vscode.Ur
                           if (isIleCommand && possibleObjects) {
                             evfeventInfos.length = 0;
                             if (Array.isArray(possibleObjects)) {
-                              for(const o of possibleObjects) {
+                              for (const o of possibleObjects) {
                                 evfeventInfos.push({
                                   library: o.library || evfeventInfo.library,
                                   object: o.object,
@@ -652,7 +653,7 @@ function getObjectsFromJoblog(stderr: string): CommandObject[] | undefined {
   // Filter lines with EVFEVENT info from server.
   const joblogLines = stderr.split(`\n`).filter(line => line.match(/:  EVFEVENT:/i));
 
-  for(const joblogLine of joblogLines) {
+  for (const joblogLine of joblogLines) {
     const evfevent = joblogLine.match(/:  EVFEVENT:(.*)/i) || '';
     if (evfevent.length) {
       const object = evfevent[1].trim().split(/[,\|/]/);


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Resolves #3015 

When running a prompted action on a single item, the notification text will now show "Prompting..." while the prompt is shown so the user can at least guess his attention is required.

<img width="464" height="130" alt="image" src="https://github.com/user-attachments/assets/906c9b28-18bf-47d3-9ac7-2cdb539860d9" />

The way prompting works on a single target and the fact that the VS Code API cannot be invoked from the `CompileTools.runCommand` function doesn't allow for a better solution for #3015 at the moment.

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Run a prompted action on a single item
2. Check the notification shows "Prompting..."

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change