### PR TITLE
Force STMFCODPAG(*STMF) when CPYTOSTMF is called with STMFCCSID(1208)

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -332,7 +332,7 @@ export default class IBMiContent {
     const copyResult = await this.ibmi.runCommand({
       command: `QSYS/CPYTOIMPF FROMFILE(${library}/${file} ${member}) ` +
         `TOSTMF('${tempRmt}') ` +
-        `MBROPT(*REPLACE) STMFCCSID(1208) RCDDLM(*CRLF) DTAFMT(*DLM) RMVBLANK(*TRAILING) ADDCOLNAM(*SQL) FLDDLM(',') DECPNT(*PERIOD)`,
+        `MBROPT(*REPLACE) STMFCCSID(1208) STMFCODPAG(*STMF) RCDDLM(*CRLF) DTAFMT(*DLM) RMVBLANK(*TRAILING) ADDCOLNAM(*SQL) FLDDLM(',') DECPNT(*PERIOD)`,
       noLibList: true
     });
 

--- a/src/api/components/copyToImport.ts
+++ b/src/api/components/copyToImport.ts
@@ -66,6 +66,7 @@ export class CopyToImport implements IBMiComponent {
       TOSTMF: outStmf,
       MBROPT: `*REPLACE`,
       STMFCCSID: 1208,
+      STMFCODPAG: '*STMF',
       RCDDLM: `*CRLF`,
       DTAFMT: `*DLM`,
       RMVBLANK: `*TRAILING`,


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Fixes #3029 

When `CPYTOSTMF` is called and `STMFCCSID` is `1208`, `STMFCODPAG` must be `*STMF` - which is the default value.

But when `CPYTOSTMF` default values are changed on the LPAR, this can lead to `STMFCODPAG` not having the right value (see #3029).

This PR explicitely set STMFCODPAG to *STMF to fix this.

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Open a member
2. It must open correctly

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change