### PR TITLE
Fix reload server settings not updating cache

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -714,7 +714,7 @@ export default class IBMi {
                 message: `Checking /QOpenSys/pkgs/bin in $PATH.`
               });
 
-              if ((!quickConnect || !cachedServerSettings?.pathChecked)) {
+              if ((!quickConnect() || !cachedServerSettings?.pathChecked)) {
                 const currentPaths = (await this.sendCommand({ command: "echo $PATH" })).stdout.split(":");
                 const bashrcFile = `${defaultHomeDir}/.bashrc`;
                 let bashrcExists = (await this.sendCommand({ command: `test -e ${bashrcFile}` })).code === 0;
@@ -802,7 +802,7 @@ export default class IBMi {
       }
 
       let debugConfigLoaded = false
-      if ((!quickConnect || !cachedServerSettings?.debugConfigLoaded)) {
+      if ((!quickConnect() || !cachedServerSettings?.debugConfigLoaded)) {
         if (this.debugPTFInstalled()) {
           try {
             const debugServiceConfig = await new DebugConfiguration(this).load();
@@ -817,7 +817,7 @@ export default class IBMi {
         }
       }
 
-      if ((!quickConnect || !cachedServerSettings?.maximumArgsLength)) {
+      if ((!quickConnect() || !cachedServerSettings?.maximumArgsLength)) {
         //Compute the maximum admited length of a command's arguments. Source: Googling and https://www.in-ulm.de/~mascheck/various/argmax/#effectively_usable
         this.maximumArgsLength = Number((await this.sendCommand({ command: "/QOpenSys/usr/bin/expr `/QOpenSys/usr/bin/getconf ARG_MAX` - `env|wc -c` - `env|wc -l` \\* 4 - 2048" })).stdout);
       }


### PR DESCRIPTION
### Changes

This PR now properly calls the `quickConnect()` function rather than just checking the function exists. Previously some of the cached connection settings were not being updated.

### How to test this PR
I tested this by updating the `DBGSRV_SECURED_PORT` in `/QIBM/ProdData/IBMiDebugService/bin/DebugService.env` and then doing a `Connect and Reload Server Settings`. Then verify it is updated in the cached server settings by checking the `Debugger` tab in the Connection Settings.

### Checklist
* [x] have tested my change
