### PR TITLE
Update cached debug port and sep port when restarting debug service

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -807,8 +807,8 @@ export default class IBMi {
           try {
             const debugServiceConfig = await new DebugConfiguration(this).load();
             delete this.config.debugCertDirectory;
-            this.config.debugPort = debugServiceConfig.getOrDefault("DBGSRV_SECURED_PORT", "8005");
-            this.config.debugSepPort = debugServiceConfig.getOrDefault("DBGSRV_SEP_DAEMON_PORT", "8008");
+            this.config.debugPort = debugServiceConfig.getRemoteServiceSecuredPort();
+            this.config.debugSepPort = debugServiceConfig.getRemoteServiceSepDaemonPort();
             debugConfigLoaded = true;
           }
           catch (error) {

--- a/src/api/configuration/DebugConfiguration.ts
+++ b/src/api/configuration/DebugConfiguration.ts
@@ -81,6 +81,14 @@ export class DebugConfiguration {
   getNavigatorLogFile() {
     return `${this.getRemoteServiceWorkspace()}/startDebugServiceNavigator.log`;
   }
+
+  getRemoteServiceSecuredPort() {
+    return this.getOrDefault("DBGSRV_SECURED_PORT", "8005");
+  }
+
+  getRemoteServiceSepDaemonPort() {
+    return this.getOrDefault("DBGSRV_SEP_DAEMON_PORT", "8008");
+  }
 }
 
 interface DebugServiceDetails {


### PR DESCRIPTION
### Changes

Users were reporting issues where when they updated `DBGSRV_SECURED_PORT` or `DBGSRV_SEP_DAEMON_PORT` in the `/QIBM/ProdData/IBMiDebugService/bin/DebugService.env` file where it was not updated in Code for IBM i. This was actually an issue with the cached server settings which should be addressed by the fix in https://github.com/codefori/vscode-ibmi/pull/3033. However, this PR now also updates these 2 cached values whenever the debug service is started/restarted.

### How to test this PR
I tested this by updating the `DBGSRV_SECURED_PORT` and `DBGSRV_SEP_DAEMON_PORT` in `/QIBM/ProdData/IBMiDebugService/bin/DebugService.env` and then restarting the debug service. Then verify it is updated in the cached server settings by checking the `Debugger` tab in the Connection Settings.

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
