### PR TITLE
Fixed IFS browser sort icon

### DIFF
--- a/src/ui/views/ifsBrowser.ts
+++ b/src/ui/views/ifsBrowser.ts
@@ -1,6 +1,6 @@
 import os from "os";
 import path, { dirname, extname } from "path";
-import vscode, { CancellationToken, Event, FileDecoration, FileDecorationProvider, FileType, l10n, ProviderResult, ThemeColor, Uri, window } from "vscode";
+import vscode, { CancellationToken, FileDecoration, FileDecorationProvider, FileType, l10n, ProviderResult, ThemeColor, Uri, window } from "vscode";
 
 import { existsSync, mkdirSync, rmdirSync } from "fs";
 import IBMi from "../../api/IBMi";
@@ -111,7 +111,7 @@ class IFSItem extends BrowserItem implements WithPath {
     else {
       this.sort.ascending = !this.sort.ascending
     }
-    this.description = `(sort: ${sort.order} ${sort.ascending ? `🔼` : `🔽`})`;
+    this.description = `(sort: ${this.sort.order} ${this.sort.ascending ? `🔼` : `🔽`})`;
     this.reveal({ expand: true });
     this.refresh();
   }


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
The sort icon in the IFS browser would always show the Descending order icon (🔽), regardless of the actual sorting order.
This PR fixes this to show the correct sort icon.

### How to test this PR

<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Sort an IFS folder by name
2. The icon must be 🔽
3. Select `Sort by -> Name` gain
4. The icon must be 🔼
5. The same behaviour must be observed when sorting by date

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change