### PR TITLE
Remove editor title actions from arbitrary editor panels

### DIFF
--- a/package.json
+++ b/package.json
@@ -2644,17 +2644,17 @@
 				},
 				{
 					"command": "code-for-ibmi.debug.endDebug",
-					"when": "code-for-ibmi:connected && debugState == initializing",
+					"when": "code-for-ibmi:connected && debugState == initializing && (resourceScheme == file || resourceScheme == streamfile || resourceScheme == member)",
 					"group": "navigation@1"
 				},
 				{
 					"command": "code-for-ibmi.runAction",
-					"when": "code-for-ibmi:connected",
+					"when": "code-for-ibmi:connected && (resourceScheme == file || resourceScheme == streamfile || resourceScheme == member)",
 					"group": "navigation@2"
 				},
 				{
 					"command": "code-for-ibmi.clearDiagnostics",
-					"when": "code-for-ibmi:connected",
+					"when": "code-for-ibmi:connected && (resourceScheme == file || resourceScheme == streamfile || resourceScheme == member)",
 					"group": "navigation@3"
 				},
 				{


### PR DESCRIPTION
### Changes
This PR removes the `editor/title` actions from non `file`/`streamfile`/`member` editors.

For example, removes:
<img width="2395" height="398" alt="image" src="https://github.com/user-attachments/assets/738feb2f-dd5f-481d-85b1-d5867367c62e" />

Similar PR in Project Explorer: https://github.com/IBM/vscode-ibmi-projectexplorer/pull/707

### How to test this PR
1. Verify actions are visible on `file`/`streamfile`/`member` scheme editors still
2. Verify actions are not visible on other editors (profiles editor, actions editor, results panel from Db2i, etc)

### Checklist
* [x] have tested my change
