### PR TITLE
Moved `LastDownloadLocation` to global storage

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -1,7 +1,5 @@
 import { parse } from 'csv-parse/sync';
-import { existsSync } from "fs";
 import * as node_ssh from "node-ssh";
-import os from "os";
 import path, { parse as parsePath } from 'path';
 import { EventEmitter } from 'stream';
 import { CompileTools } from "./CompileTools";
@@ -1356,22 +1354,6 @@ export default class IBMi {
     };
 
     return result
-  }
-
-  getLastDownloadLocation() {
-    if (this.config?.lastDownloadLocation && existsSync(Tools.fixWindowsPath(this.config.lastDownloadLocation))) {
-      return this.config.lastDownloadLocation;
-    }
-    else {
-      return os.homedir();
-    }
-  }
-
-  async setLastDownloadLocation(location: string) {
-    if (this.config && location && location !== this.config.lastDownloadLocation) {
-      this.config.lastDownloadLocation = location;
-      await IBMi.connectionManager.update(this.config);
-    }
   }
 
   /**

--- a/src/api/configuration/config/ConnectionManager.ts
+++ b/src/api/configuration/config/ConnectionManager.ts
@@ -1,5 +1,4 @@
 
-import os from "os";
 import { ConnectionData } from "../../types";
 import { ConnectionConfig } from "./types";
 import { Config, VirtualConfig } from "./VirtualConfig";
@@ -42,8 +41,7 @@ function initialize(parameters: Partial<ConnectionConfig>): ConnectionConfig {
     quickConnect: (parameters.quickConnect === true || parameters.quickConnect === undefined),
     defaultDeploymentMethod: parameters.defaultDeploymentMethod || ``,
     protectedPaths: (parameters.protectedPaths || []),
-    showHiddenFiles: (parameters.showHiddenFiles === true || parameters.showHiddenFiles === undefined),
-    lastDownloadLocation: (parameters.lastDownloadLocation || os.homedir())
+    showHiddenFiles: (parameters.showHiddenFiles === true || parameters.showHiddenFiles === undefined)
   }
 }
 

--- a/src/api/configuration/config/types.ts
+++ b/src/api/configuration/config/types.ts
@@ -32,7 +32,6 @@ export interface ConnectionConfig extends ConnectionProfile {
   defaultDeploymentMethod: DeploymentMethod | '';
   protectedPaths: string[];
   showHiddenFiles: boolean;
-  lastDownloadLocation: string;
   currentProfile?: string
   [name: string]: any;
 }

--- a/src/api/configuration/storage/CodeForIStorage.ts
+++ b/src/api/configuration/storage/CodeForIStorage.ts
@@ -1,10 +1,15 @@
+import { existsSync } from "fs";
+import os from "os";
 import { ComponentInstallState } from "../../components/component";
+import { Tools } from "../../Tools";
 import { AspInfo, ConnectionData } from "../../types";
 import { BaseStorage } from "./BaseStorage";
+
 const SERVER_SETTINGS_CACHE_PREFIX = `serverSettingsCache_`;
 const SERVER_SETTINGS_CACHE_KEY = (name: string) => SERVER_SETTINGS_CACHE_PREFIX + name;
 const PREVIOUS_SEARCH_TERMS_KEY = `prevSearchTerms`;
 const PREVIOUS_FIND_TERMS_KEY = `prevFindTerms`;
+const PREVIOUS_DOWNLOAD_LOCATION = `previousDownloadLocation`;
 
 export type PathContent = Record<string, string[]>;
 export type DeploymentPath = Record<string, string>;
@@ -32,7 +37,7 @@ export type CachedServerSettings = {
 } | undefined;
 
 export class CodeForIStorage {
-  constructor(private internalStorage: BaseStorage) {}
+  constructor(private internalStorage: BaseStorage) { }
 
   getLastConnections() {
     return this.internalStorage.get<LastConnection[]>("lastConnections");
@@ -55,7 +60,7 @@ export class CodeForIStorage {
   }
 
   getServerSettingsCache(name: string) {
-    return this.internalStorage.get<CachedServerSettings|undefined>(SERVER_SETTINGS_CACHE_KEY(name));
+    return this.internalStorage.get<CachedServerSettings | undefined>(SERVER_SETTINGS_CACHE_KEY(name));
   }
 
   async setServerSettingsCache(name: string, serverSettings: CachedServerSettings) {
@@ -78,7 +83,7 @@ export class CodeForIStorage {
 
     const componentCache = existingSettings.installedComponents;
     const stateId = componentCache.findIndex(c => c.id.name === component.id.name);
-    
+
     if (stateId >= 0) {
       if (component.state === `Installed`) {
         componentCache[stateId] = component;
@@ -96,7 +101,7 @@ export class CodeForIStorage {
       installedComponents: componentCache
     });
   }
- 
+
   async deleteServerSettingsCache(name: string) {
     await this.internalStorage.set(SERVER_SETTINGS_CACHE_KEY(name), undefined);
   }
@@ -114,11 +119,11 @@ export class CodeForIStorage {
     return this.internalStorage.get<string[]>(PREVIOUS_SEARCH_TERMS_KEY) || [];
   }
 
-  async addPreviousSearchTerm(term: string) {    
+  async addPreviousSearchTerm(term: string) {
     await this.internalStorage.set(PREVIOUS_SEARCH_TERMS_KEY, [term].concat(this.getPreviousSearchTerms().filter(t => t !== term)));
   }
 
-  async clearPreviousSearchTerms(){
+  async clearPreviousSearchTerms() {
     await this.internalStorage.set(PREVIOUS_SEARCH_TERMS_KEY, undefined);
   }
 
@@ -130,7 +135,19 @@ export class CodeForIStorage {
     await this.internalStorage.set(PREVIOUS_FIND_TERMS_KEY, [term].concat(this.getPreviousFindTerms().filter(t => t !== term)));
   }
 
-  async clearPreviousFindTerms(){
+  async clearPreviousFindTerms() {
     await this.internalStorage.set(PREVIOUS_FIND_TERMS_KEY, undefined);
+  }
+
+  getLastDownloadLocation() {
+    const lastLocation = this.internalStorage.get<string>(PREVIOUS_DOWNLOAD_LOCATION);
+    return lastLocation && existsSync(Tools.fixWindowsPath(lastLocation)) ? lastLocation : os.homedir();
+  }
+
+  async setLastDownloadLocation(location: string) {
+    const lastLocation = this.internalStorage.get<string>(PREVIOUS_DOWNLOAD_LOCATION);
+    if (location && location !== lastLocation) {
+      await this.internalStorage.set(PREVIOUS_DOWNLOAD_LOCATION, location);
+    }
   }
 }

--- a/src/ui/views/ifsBrowser.ts
+++ b/src/ui/views/ifsBrowser.ts
@@ -901,11 +901,11 @@ Please type "{0}" to confirm deletion.`, dirName);
             canSelectMany: false,
             canSelectFiles: false,
             canSelectFolders: true,
-            defaultUri: vscode.Uri.file(ibmi.getLastDownloadLocation())
+            defaultUri: vscode.Uri.file(IBMi.GlobalStorage.getLastDownloadLocation())
           }))?.[0];
         }
         else {
-          const remoteFilepath = path.join(ibmi.getLastDownloadLocation(), path.basename(node.path));
+          const remoteFilepath = path.join(IBMi.GlobalStorage.getLastDownloadLocation(), path.basename(node.path));
           downloadLocationURI = (await vscode.window.showSaveDialog({
             defaultUri: vscode.Uri.file(remoteFilepath),
             filters: { 'Streamfile': [extname(node.path).substring(1) || '*'] }
@@ -914,7 +914,7 @@ Please type "{0}" to confirm deletion.`, dirName);
 
         if (downloadLocationURI) {
           const downloadLocation = downloadLocationURI.path;
-          await ibmi.setLastDownloadLocation(saveIntoDirectory ? downloadLocation : dirname(downloadLocation));
+          await IBMi.GlobalStorage.setLastDownloadLocation(saveIntoDirectory ? downloadLocation : dirname(downloadLocation));
           const increment = 100 / items.length;
           window.withProgress({ title: l10n.t(`Downloading`), location: vscode.ProgressLocation.Notification }, async (task) => {
             try {

--- a/src/ui/views/objectBrowser.ts
+++ b/src/ui/views/objectBrowser.ts
@@ -894,12 +894,12 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
           canSelectMany: false,
           canSelectFiles: false,
           canSelectFolders: true,
-          defaultUri: vscode.Uri.file(connection.getLastDownloadLocation())
+          defaultUri: vscode.Uri.file(IBMi.GlobalStorage.getLastDownloadLocation())
         }))?.[0];
       }
       else {
         downloadLocationURI = (await vscode.window.showSaveDialog({
-          defaultUri: vscode.Uri.file(path.join(connection.getLastDownloadLocation(), members[0].name)),
+          defaultUri: vscode.Uri.file(path.join(IBMi.GlobalStorage.getLastDownloadLocation(), members[0].name)),
           filters: { 'Source member': [members[0].extension || '*'] }
         }));
       }
@@ -916,7 +916,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
         }
 
         const downloadLocation = saveIntoDirectory ? downloadLocationURI.path : dirname(downloadLocationURI.path);
-        await connection.setLastDownloadLocation(downloadLocation);
+        await IBMi.GlobalStorage.setLastDownloadLocation(downloadLocation);
 
         //Ask what do to with existing files in the target directory
         if (saveIntoDirectory) {


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
This PR moves the `Last Download Location` field from the connection settings to the global storage.
Since this field is not related to the connection and it's OS specific, it doesn't make sense to keep it there. And it prevents the configuration change event from being triggerred whenever that location changes.

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Download an IFS file or a member
2. Download another file: the location picked at 1. must be the same

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change