### PR TITLE
Resume read operation after reconnecting with editors left opened 

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ import { CustomEditor, CustomEditorProvider } from "./editors/customEditorProvid
 import { IFSFS } from "./filesystems/ifsFs";
 import { DeployTools } from "./filesystems/local/deployTools";
 import { Deployment } from "./filesystems/local/deployment";
-import { initializeFSUtils } from "./filesystems/qsys/FSUtils";
+import { handleEditorsLeftOpened } from "./filesystems/qsys/FSUtils";
 import { instance, loadAllofExtension } from './instantiate';
 import { LocalActionCompletionItemProvider } from "./languages/actions/completion";
 import { mergeCommandProfiles } from "./mergeProfiles";
@@ -97,8 +97,6 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
   Debug.initialize(context);
   Deployment.initialize(context);
   updateLastConnectionAndServerCache();
-  initializeFSUtils(context);
-
   initializeSandbox();
 
   console.log(`Developer environment: ${process.env.DEV}`);
@@ -135,6 +133,8 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
   );
 
   await mergeCommandProfiles();
+
+  handleEditorsLeftOpened(context);
 
   return {
     instance,

--- a/src/filesystems/ifsFs.ts
+++ b/src/filesystems/ifsFs.ts
@@ -1,7 +1,7 @@
 import vscode, { FileSystemError, FileType } from "vscode";
 import { Tools } from "../api/Tools";
 import { instance } from "../instantiate";
-import { reconnectFS } from "./qsys/FSUtils";
+import { waitOnReconnect } from "./qsys/FSUtils";
 import { getFilePermission } from "./qsys/QSysFs";
 
 export class IFSFS implements vscode.FileSystemProvider {
@@ -25,7 +25,7 @@ export class IFSFS implements vscode.FileSystemProvider {
         throw new FileSystemError("Not connected to IBM i");
       }
       else {
-        if (await reconnectFS(uri)) {
+        if (await waitOnReconnect()) {
           return this.readFile(uri, true);
         }
         else {

--- a/src/filesystems/qsys/FSUtils.ts
+++ b/src/filesystems/qsys/FSUtils.ts
@@ -1,14 +1,37 @@
-import path from "path";
 import vscode, { l10n } from "vscode";
 import IBMi from "../../api/IBMi";
 import { instance } from "../../instantiate";
 import { ReconnectMode } from "../../typings";
-import { VscodeTools } from "../../ui/Tools";
 
-let createOnConnectPromise: (connection: string) => Promise<boolean>;
-export function initializeFSUtils(context: vscode.ExtensionContext) {
-  createOnConnectPromise = (connection) => {
-    return new Promise<boolean>((resolve) => instance.subscribe(context, "connected", "Restore previously opened editor", () => resolve(instance.getConnection()?.currentConnectionName === connection), true));
+export let restoreEditors: Promise<boolean> | undefined;
+
+export function handleEditorsLeftOpened(context: vscode.ExtensionContext) {
+  const reconnect = IBMi.connectionManager.get<ReconnectMode>("autoReconnect") || "ask";
+
+  if (reconnect !== "never") {
+    const editorsLeftOpened = vscode.window.tabGroups.all
+      .flatMap(group => group.tabs)
+      .filter(tab => tab.input instanceof vscode.TabInputText && ["member", "streamfile"].includes(tab.input.uri.scheme));
+
+    const lastConnection = IBMi.GlobalStorage.getLastConnections()?.at(0)?.name;
+    if (editorsLeftOpened.length && lastConnection) {
+      const promises: PromiseLike<boolean>[] = [new Promise<boolean>((resolve) => instance.subscribe(context, "connected", "Restore previously opened editor", () => resolve(instance.getConnection()?.currentConnectionName === lastConnection), true))];
+      if (reconnect === "ask") {
+        promises.push(
+          vscode.window.showInformationMessage(l10n.t("{0} editors were left opened; do you want to reconnect to {1} and restore them?", editorsLeftOpened.length, lastConnection), l10n.t("Reconnect"))
+            .then(reply => reply ? vscode.commands.executeCommand<boolean>(`code-for-ibmi.connectToPrevious`) : false)
+        );
+      }
+      else {
+        vscode.commands.executeCommand<boolean>(`code-for-ibmi.connectToPrevious`);
+      }
+      restoreEditors = Promise.race(promises).then(restore => {
+        if (!restore) {
+          return vscode.window.tabGroups.close(editorsLeftOpened).then(() => false);
+        }
+        return restore;
+      });
+    }
   }
 }
 
@@ -16,45 +39,8 @@ export function initializeFSUtils(context: vscode.ExtensionContext) {
  * Called when a member/streamfile is left open when VS Code is closed and re-opened to reconnect (or not) to the previous IBM i, based on the `autoReconnect` global configuration value.
  * If the user choses not to reconnect, the editor tab will be closed.
  * 
- * @param uri the uri of the file triggerring the reconnection attempt
- * @returns `true` if the user choses to reconnect, `false` otherwise.
+ * @returns `true` if the user has chose to reconnect, `false` otherwise.
  */
-export async function reconnectFS(uri: vscode.Uri) {
-  const reconnect = IBMi.connectionManager.get<ReconnectMode>("autoReconnect") || "ask";
-  let doReconnect = false;
-  switch (reconnect) {
-    case "always":
-      doReconnect = true;
-      break;
-
-    case "ask":
-      const lastConnection = IBMi.GlobalStorage.getLastConnections()?.at(0)?.name;
-      if (lastConnection) {
-        const answer = await Promise.race([
-          vscode.window.showInformationMessage(l10n.t("Do you want to reconnect to {0} and open {1}?", lastConnection, path.basename(uri.path)), l10n.t("Reconnect")),
-          createOnConnectPromise(lastConnection)
-        ]);
-        if (answer === true) {
-          //createOnConnectPromise resolved first
-          return true;
-        }
-        else if (typeof answer === "string") {
-          //Dialog was answered
-          doReconnect = true
-        }
-      }
-      break;
-
-    default:
-  }
-
-  if (doReconnect) {
-    return await vscode.commands.executeCommand<boolean>(`code-for-ibmi.connectToPrevious`);
-  }
-  else {
-    for (const tab of VscodeTools.findUriTabs(uri)) {
-      await vscode.window.tabGroups.close(tab);
-    }
-    return false;
-  }
+export async function waitOnReconnect() {
+  return restoreEditors ? await restoreEditors : false;
 }

--- a/src/filesystems/qsys/QSysFs.ts
+++ b/src/filesystems/qsys/QSysFs.ts
@@ -7,7 +7,7 @@ import { onCodeForIBMiConfigurationChange } from "../../config/Configuration";
 import { instance } from "../../instantiate";
 import { IBMiMember, QsysFsOptions, QsysPath } from "../../typings";
 import { ExtendedIBMiContent } from "./extendedContent";
-import { reconnectFS } from "./FSUtils";
+import { waitOnReconnect } from "./FSUtils";
 import { SourceDateHandler } from "./sourceDateHandler";
 
 export function getMemberUri(member: IBMiMember, options?: QsysFsOptions) {
@@ -182,7 +182,7 @@ export class QSysFS implements vscode.FileSystemProvider {
             if (retrying) {
                 throw new FileSystemError("Not connected to IBM i");
             } else {
-                if (await reconnectFS(uri)) {
+                if (await waitOnReconnect()) {
                     this.updateMemberSupport(); //this needs to be done right after reconnecting, before the member is read (the connect event may be triggered too late at this point)
                     return this.readFile(uri, true);
                 } else {


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Fixes #3042 

When editors are left open when VS Code is closed, the extension displays a notification asking if the user wants to restore the connection and reload the editor's content.

The problem is that while that notification is left open, the read operation for these editors that were left open cannot carry on. As long as the notification is not answered in any way, the content of these editors can never be loaded (as explained in #3042).

This PR addresses this by provinding a single Promise the editors will awai on when not connected. That single promise will resolve and let the read operation carry on if the user connected to the previously connected IBM i or click on `Reconnect` if the reconnect dialog shows up.

If the user connects to another IBM i or closes the dialog, the editors are closed.

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. open a member or a streamfile
2. close and re-open VS Code
3. ignore the "Do you want to reconnect...?" notification
4. connect to the system the member/streamfile was opened from in 1.
5. the editor must load its content once the connection is established

Try again, but at step 4., connect to any IBM i but the one the member/streamfile was opened from: the editor must be closed after the connection is established.

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change