### PR TITLE
Add `ConnectionManager` to exported API

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -215,10 +215,6 @@ export default class IBMi {
     this.config = newConfig;
   }
 
-  getConnectionManager(): ConnectionManager {
-    return IBMi.connectionManager;
-  }
-
   constructor() {
     this.remoteFeatures = {
       git: undefined,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -142,7 +142,8 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
     deployTools: DeployTools,
     evfeventParser: parseErrors,
     tools: VscodeTools,
-    componentRegistry: extensionComponentRegistry
+    componentRegistry: extensionComponentRegistry,
+    connectionManager: IBMi.connectionManager
   };
 }
 

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -2,6 +2,7 @@ import { Ignore } from "ignore";
 import { WorkspaceFolder } from "vscode";
 import Instance from "./Instance";
 import { ComponentRegistry } from './api/components/manager';
+import { ConnectionManager } from "./api/configuration/config/ConnectionManager";
 import { DeploymentMethod, FileError } from "./api/types";
 import { CustomEditor } from "./editors/customEditorProvider";
 import { DeployTools } from "./filesystems/local/deployTools";
@@ -15,7 +16,8 @@ export interface CodeForIBMi {
   deployTools: typeof DeployTools,
   evfeventParser: (lines: string[]) => Map<string, FileError[]>,
   tools: typeof VscodeTools,
-  componentRegistry: ComponentRegistry
+  componentRegistry: ComponentRegistry,
+  connectionManager: ConnectionManager
 }
 
 export interface DeploymentParameters {


### PR DESCRIPTION
### Changes
This PR just adds an API for other extensions to access the `ConnectionManager`

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
