### PR TITLE
Fixed editors being blank if reconnect setting is "never"

### DIFF
--- a/src/filesystems/qsys/FSUtils.ts
+++ b/src/filesystems/qsys/FSUtils.ts
@@ -8,11 +8,29 @@ export let restoreEditors: Promise<boolean> | undefined;
 export function handleEditorsLeftOpened(context: vscode.ExtensionContext) {
   const reconnect = IBMi.connectionManager.get<ReconnectMode>("autoReconnect") || "ask";
 
-  if (reconnect !== "never") {
-    const editorsLeftOpened = vscode.window.tabGroups.all
+  const getLeftOpenedEditors = () =>
+    vscode.window.tabGroups.all
       .flatMap(group => group.tabs)
-      .filter(tab => tab.input instanceof vscode.TabInputText && ["member", "streamfile"].includes(tab.input.uri.scheme));
+      .filter(
+        tab =>
+          tab.input instanceof vscode.TabInputText &&
+          ["member", "streamfile"].includes(tab.input.uri.scheme)
+      );
 
+  const closeAll = async () => {
+    const tabsToClose = getLeftOpenedEditors(); // re-resolve fresh tab handles
+    if (!tabsToClose.length) return false;
+
+    try {
+      await vscode.window.tabGroups.close(tabsToClose, false);
+    } catch {
+      // Tabs can disappear between query and close; ignore safely.
+    }
+    return false;
+  };
+
+  if (reconnect !== "never") {
+    const editorsLeftOpened = getLeftOpenedEditors();
     const lastConnection = IBMi.GlobalStorage.getLastConnections()?.at(0)?.name;
     if (editorsLeftOpened.length && lastConnection) {
       const promises: PromiseLike<boolean>[] = [new Promise<boolean>((resolve) => instance.subscribe(context, "connected", "Restore previously opened editor", () => resolve(instance.getConnection()?.currentConnectionName === lastConnection), true))];
@@ -27,11 +45,14 @@ export function handleEditorsLeftOpened(context: vscode.ExtensionContext) {
       }
       restoreEditors = Promise.race(promises).then(restore => {
         if (!restore) {
-          return vscode.window.tabGroups.close(editorsLeftOpened).then(() => false);
+          return closeAll();
         }
         return restore;
       });
     }
+  }
+  else {
+    return closeAll();
   }
 }
 


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Following up #3058 
When the `Auto Reconnect` setting is set to `never`, editors left opened would remain opened and blank.

This PR fixes this so this editors are correctly closed on startup.
It also fix a crash that can happen when the setting is set to `ask` and the user closes the notification: the editor tab may show an error instead of being closed.  

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Set the Auto reconnect setting to `never`
2. Connect and open a streamfile or a member
3. Reload VS Code window
4. The editor(s) must be closed on startup
5. Set the Auto reconnect setting to `ask`
6. Connect and open a streamfile or a member
7. When the notification offerring to reconnect shows up, close it (do not reconnect)
8. The editors must be closed

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
