### PR TITLE
Keep editors opened when connection drops

### DIFF
--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -28,6 +28,7 @@ export interface ConnectionOptions {
 
 export default class Instance {
   private connection: IBMi | undefined;
+  connected?: Promise<ConnectionResult>;
 
   private output = {
     channel: vscode.window.createOutputChannel(`Code for IBM i`),
@@ -99,7 +100,7 @@ export default class Instance {
             });
           }
 
-          this.disconnect();
+          this.disconnect(reconnect);
 
           if (reconnect) {
             await this.connect({ ...options, reconnecting: true });
@@ -111,7 +112,7 @@ export default class Instance {
       }
     };
 
-    return VscodeTools.withContext("code-for-ibmi:connecting", async () => {
+    this.connected = VscodeTools.withContext("code-for-ibmi:connecting", async () => {
       while (true) {
         let customError: string | undefined;
         await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: options.data.name, cancellable: true }, async (p, cancelToken) => {
@@ -145,7 +146,7 @@ export default class Instance {
           await this.setConnection(connection);
           break;
         } else {
-          await this.disconnect();
+          await this.disconnect(options.reconnecting);
           if (options.reconnecting && await vscode.window.showWarningMessage(`Could not reconnect`, {
             modal: true,
             detail: `Reconnection has failed. Would you like to try again?\n\n${customError || `No error provided.`}`
@@ -162,9 +163,20 @@ export default class Instance {
 
       return result;
     });
+
+    return this.connected;
   }
 
-  async disconnect() {
+  async disconnect(keepTabsOpened?: boolean) {
+    delete this.connected;
+    if (!keepTabsOpened) {
+      vscode.window.tabGroups.close(
+        vscode.window.tabGroups.all
+          .flatMap(group => group.tabs)
+          .filter(tab => tab.input instanceof vscode.TabInputText && ["member", "streamfile", "object"].includes(tab.input.uri.scheme))
+      );
+    }
+
     await this.setConnection();
 
     await Promise.all([

--- a/src/filesystems/qsys/FSUtils.ts
+++ b/src/filesystems/qsys/FSUtils.ts
@@ -42,5 +42,12 @@ export function handleEditorsLeftOpened(context: vscode.ExtensionContext) {
  * @returns `true` if the user has chose to reconnect, `false` otherwise.
  */
 export async function waitOnReconnect() {
-  return restoreEditors ? await restoreEditors : false;
+  if(restoreEditors){
+    return await restoreEditors
+  }
+  else if(instance.connected){
+    return (await instance.connected).success;
+  }
+
+  return false;
 }

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -143,20 +143,6 @@ async function onConnected() {
 }
 
 async function onDisconnected() {
-  // Close the tabs with no dirty editors
-  vscode.window.tabGroups.all
-    .filter(group => !group.tabs.some(tab => tab.isDirty))
-    .forEach(group => {
-      group.tabs.forEach(tab => {
-        if (tab.input instanceof vscode.TabInputText) {
-          const uri = tab.input.uri;
-          if ([`member`, `streamfile`, `object`].includes(uri.scheme)) {
-            vscode.window.tabGroups.close(tab);
-          }
-        }
-      })
-    });
-
   // Hide the bar items
   [
     disconnectBarItem,


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Resolves #3092 

Opened members/streamfiles/objects used to be closed inconditionnaly.
This PR changes that behavior and let the editors opened until the user decides to reconnect or not.
If the user choses to reconnect, the editors will await on the connection process. Should the connection fail and the user decides to give up, then they'll be closed.

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Open several members/streamfiles
2. Close the VPN or Wifi or pull the ethernet cable
3. Wait for the timeout to happen
4. Click on reconnect
5. While the reconnection happens, the editors must stay opened and not try to reload their content
6. Once the reconnection is done, the editors must behave as usual

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change