### PR TITLE
Add `-f` flag when removing mapepire jar file

### DIFF
--- a/src/api/components/mapepire/index.ts
+++ b/src/api/components/mapepire/index.ts
@@ -69,7 +69,7 @@ export class Mapepire implements IBMiComponent {
         throw `Local Mapepire asset not found at ${this.localAssetPath}!`;
       }
 
-      let result = await connection.sendCommand({ command: `rm ${this.installPath.substring(0, this.installPath.lastIndexOf('-'))}*.jar` });
+      let result = await connection.sendCommand({ command: `rm -f ${this.installPath.substring(0, this.installPath.lastIndexOf('-'))}*.jar` });
       if (result.code !== 0) {
         throw `Failed to clear previous Mapepire installation: ${result.stderr}`;
       }


### PR DESCRIPTION
### Changes

When we previously tried to remove any existing mapepire jar files, the install would fail if no jar files existed:
```
Failed to clear previous Mapepire installation: rm: /home/SANJULA/.vscode/mapepire-server*.jar: No such file or directory
Mapepire state after startup: Error
Warning: Mapepire component not available
```

### How to test this PR
1. Ensure there are no mapepire jar files in your ` ~/.vscode` directory
2. Connect and make sure mapepire installs correctly

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
