### PR TITLE
Listen to configuration change to refresh actions in Environment view

### DIFF
--- a/src/ui/views/environment/environmentView.ts
+++ b/src/ui/views/environment/environmentView.ts
@@ -5,6 +5,7 @@ import { getActions, updateAction } from '../../../api/actions';
 import { GetNewLibl } from '../../../api/components/getNewLibl';
 import { assignProfile, cloneProfile, getConnectionProfile, getConnectionProfiles, getDefaultProfile, updateConnectionProfile } from '../../../api/connectionProfiles';
 import IBMi from '../../../api/IBMi';
+import { onCodeForIBMiConfigurationChange } from "../../../config/Configuration";
 import { editAction, isActionEdited } from '../../../editors/actionEditor';
 import { editConnectionProfile, isProfileEdited } from '../../../editors/connectionProfileEditor';
 import { instance } from '../../../instantiate';
@@ -32,6 +33,8 @@ export function initializeEnvironmentView(context: vscode.ExtensionContext) {
   localActionsWatcher.onDidCreate(() => environmentView.actionsNode?.forceRefresh());
   localActionsWatcher.onDidChange(() => environmentView.actionsNode?.forceRefresh());
   localActionsWatcher.onDidDelete(() => environmentView.actionsNode?.forceRefresh());
+
+  onCodeForIBMiConfigurationChange("actions", () => environmentView.actionsNode?.forceRefresh())
 
   context.subscriptions.push(
     environmentTreeViewer,
@@ -84,7 +87,6 @@ export function initializeEnvironmentView(context: vscode.ExtensionContext) {
             command: ''
           };
           await updateAction(action, typeNode.workspace);
-          environmentView.actionsNode?.forceRefresh();
           vscode.commands.executeCommand("code-for-ibmi.environment.action.edit", { action, workspace: typeNode.workspace });
         }
       }
@@ -106,12 +108,11 @@ export function initializeEnvironmentView(context: vscode.ExtensionContext) {
 
         if (newName) {
           await updateAction(action, node.workspace, { newName });
-          environmentView.actionsNode?.forceRefresh();
         }
       }
     }),
     vscode.commands.registerCommand("code-for-ibmi.environment.action.edit", (node: ActionItem) => {
-      editAction(node.action, async () => environmentView.actionsNode?.forceRefresh(), node.workspace);
+      editAction(node.action, undefined, node.workspace);
     }),
     vscode.commands.registerCommand("code-for-ibmi.environment.action.copy", async (node: ActionItem) => {
       vscode.commands.executeCommand('code-for-ibmi.environment.action.create', node.parent, node);
@@ -122,7 +123,6 @@ export function initializeEnvironmentView(context: vscode.ExtensionContext) {
       }
       else if (await vscode.window.showInformationMessage(l10n.t("Do you really want to delete action '{0}' ?", node.action.name), { modal: true }, l10n.t("Yes"))) {
         await updateAction(node.action, node.workspace, { delete: true });
-        environmentView.actionsNode?.forceRefresh();
       }
     }),
     vscode.commands.registerCommand("code-for-ibmi.environment.action.runOnEditor", (node: ActionItem) => {


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
If multiple VS Code are opened, when actions are changed from one VS Code window, the change is not reflected in the other windows.

This is an issue because the actions are "cached" in the view and this causes them to be out of sync with their actual state.

This PR fixes this by refreshing the actions whenever a change occur in the Code for i `actions` settings section. 

### How to test this PR
1. Open two VS Code windows and connectboth to IBM i
2. Expand the Environment view actions section in both window
3. Make a change to actions in one window (delete, rename, create, edit ...)
4. The change must be reflected in the other window as soon as the change is saved to the configuration 
<!-- 
Example:
1. Run the test cases
5. Expand view A and right click on the node
6. Run 'Execute Thing' from the command palette
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change