### PR TITLE
Show debug button for ILE Cobol and C

### DIFF
--- a/package.json
+++ b/package.json
@@ -2671,7 +2671,7 @@
 			"editor/title": [
 				{
 					"submenu": "code-for-ibmi.debug.group",
-					"when": "code-for-ibmi:connected && editorLangId =~ /^rpgle$|^rpg$|^cobol$|^cl$/i",
+					"when": "code-for-ibmi:connected && editorLangId =~ /^rpg(le)?|cl(le)?|(ile)?cobol|c?$/i",
 					"group": "navigation@1"
 				},
 				{


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Resolves #3101 

This PR adds support for displaying the Debug button in the editor title for ILE Cobol and C language types.

### How to test this PR
1. Open a CBLLE streamfile or member
2. If the language type shows `ILECOBOL`, the green debug button must show in the editor title
3. Open a CLE or C streamfile or member
4. If the language type shows `C`, the green debug button must show in the editor title
<!-- 
Example:
1. Run the test cases
5. Expand view A and right click on the node
6. Run 'Execute Thing' from the command palette
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change