### PR TITLE
Update PARM_REGEX to match at the start or whitespace

### DIFF
--- a/src/ui/actions.ts
+++ b/src/ui/actions.ts
@@ -35,7 +35,7 @@ export type ActionTarget = {
 }
 
 const actionUsed: Map<string, number> = new Map;
-const PARM_REGEX = / (PNLGRP|OBJ|PGM|MODULE|FILE|MENU)\((?<object>.+?)\)/;
+const PARM_REGEX = /(^|\s+)(PNLGRP|OBJ|PGM|MODULE|FILE|MENU)\((?<object>.+?)\)/;
 
 export function registerActionTools(context: vscode.ExtensionContext) {
   context.subscriptions.push(


### PR DESCRIPTION
Now keywords are detected when they appear in column 1 or later. Previously they always required a blank in front of them, but now they can also appear in position/column 1 of the line.

### Changes
<!-- Describe your change here. -->

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [ ] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
