### PR TITLE
Added the ability to deploy selected files from the explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1318,6 +1318,13 @@
 				"enablement": "code-for-ibmi:connected && !code-for-ibmi:isReadonly && workspaceFolderCount >= 1"
 			},
 			{
+				"command": "code-for-ibmi.deploySelected",
+				"title": "Deploy Selected Files",
+				"category": "IBM i",
+				"icon": "$(cloud-upload)",
+				"enablement": "code-for-ibmi:connected && !code-for-ibmi:isReadonly"
+			},
+			{
 				"command": "code-for-ibmi.setDeployLocation",
 				"enablement": "code-for-ibmi:connected && !code-for-ibmi:isReadonly",
 				"title": "Set Deploy Workspace Location",
@@ -3216,6 +3223,11 @@
 					"command": "code-for-ibmi.runAction",
 					"when": "code-for-ibmi:connected && !explorerResourceIsFolder && code-for-ibmi:hasLocalActions",
 					"group": "1_localactions@01"
+				},
+				{
+					"command": "code-for-ibmi.deploySelected",
+					"when": "code-for-ibmi:connected && resource",
+					"group": "1_localactions@02"
 				}
 			]
 		},

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,6 +1,6 @@
 import { Variables } from "./variables";
 
-export type DeploymentMethod = "all" | "staged" | "unstaged" | "changed" | "compare";
+export type DeploymentMethod = "all" | "staged" | "unstaged" | "changed" | "compare" | "selected";
 
 export interface StandardIO {
   onStdout?: (data: Buffer) => void;

--- a/src/filesystems/local/deployTools.ts
+++ b/src/filesystems/local/deployTools.ts
@@ -81,9 +81,10 @@ export namespace DeployTools {
    * @param workspaceIndex if no index is provided, a prompt will be shown to pick one if there are multiple workspaces,
    * otherwise the current workspace will be used.
    * @param method if no method is provided, a prompt will be shown to pick the deployment method.
+   * @param selectedFiles if the "selected" deployment method is used, these files will be deployed.
    * @returns the index of the deployed workspace or `undefined` if the deployment failed
    */
-  export async function launchDeploy(workspaceIndex?: number, method?: DeploymentMethod): Promise<{ remoteDirectory: string, workspaceId: number } | undefined> {
+  export async function launchDeploy(workspaceIndex?: number, method?: DeploymentMethod, selectedFiles?: Uri[]): Promise<{ remoteDirectory: string, workspaceId: number } | undefined> {
     const folder = await Deployment.getWorkspaceFolder(workspaceIndex);
     if (folder) {
       const remotePath = getRemoteDeployDirectory(folder);
@@ -127,7 +128,8 @@ export namespace DeployTools {
           const parameters: DeploymentParameters = {
             workspaceFolder: folder,
             remotePath,
-            method
+            method,
+            selectedFiles
           };
 
           if (await deploy(parameters)) {
@@ -140,7 +142,7 @@ export namespace DeployTools {
         }
       } else {
         if (await vscode.window.showErrorMessage(`Chosen location (${folder.uri.fsPath}) is not configured for deployment.`, 'Set deploy location')) {
-          setDeployLocation(undefined, folder, buildPossibleDeploymentDirectory(folder));
+          setDeployLocation(undefined, folder, buildPossibleDeploymentDirectory(folder), method, selectedFiles);
         }
       }
     }
@@ -185,6 +187,10 @@ export namespace DeployTools {
               const { uploads, relativeRemoteDeletes } = await getDeployCompareFiles(parameters, progress)
               files.push(...uploads);
               deletes.push(...relativeRemoteDeletes);
+              break;
+
+            case "selected":
+              files.push(...parameters.selectedFiles || []);
               break;
 
             case "all":
@@ -333,7 +339,7 @@ export namespace DeployTools {
     return (await Deployment.findFiles(parameters, "**/*", "**/.git*"));
   }
 
-  export async function setDeployLocation(node: any, workspaceFolder?: WorkspaceFolder, value?: string) {
+  export async function setDeployLocation(node: any, workspaceFolder?: WorkspaceFolder, value?: string, method?: DeploymentMethod, selectedFiles?: Uri[]) {
     const path = node?.path || await vscode.window.showInputBox({
       prompt: `Enter IFS directory to deploy to`,
       value
@@ -353,7 +359,7 @@ export namespace DeployTools {
         instance.fire(`deployLocation`);
 
         if (await vscode.window.showInformationMessage(`Deployment location set to ${path}`, `Deploy now`)) {
-          vscode.commands.executeCommand(`code-for-ibmi.launchDeploy`, chosenWorkspaceFolder.index);
+          vscode.commands.executeCommand(`code-for-ibmi.launchDeploy`, chosenWorkspaceFolder.index, method, selectedFiles);
         }
       }
     }

--- a/src/filesystems/local/deployment.ts
+++ b/src/filesystems/local/deployment.ts
@@ -2,7 +2,7 @@
 import path from 'path';
 import { create as tarCreate, t as tarT } from 'tar';
 import tmp from 'tmp';
-import vscode from 'vscode';
+import vscode, { Uri } from 'vscode';
 import { getActions, getLocalActionsFiles } from '../../api/actions';
 import IBMi from '../../api/IBMi';
 import IBMiContent from '../../api/IBMiContent';
@@ -38,6 +38,27 @@ export namespace Deployment {
       deploymentLog,
       vscode.commands.registerCommand(`code-for-ibmi.launchActionsSetup`, DeployTools.launchActionsSetup),
       vscode.commands.registerCommand(`code-for-ibmi.launchDeploy`, DeployTools.launchDeploy),
+      vscode.commands.registerCommand(`code-for-ibmi.deploySelected`, async (item?: Uri, items?: Uri[]) => {
+        if(!(item instanceof Uri)) {
+          vscode.window.showErrorMessage(`No files selected for deployment.`);
+          return;
+        }
+        const selectedItems = Array.isArray(items) && items.length > 0 ? items : [item];
+        const itemsByWorkspace: Uri[][] = [];
+        selectedItems.forEach(uri => {
+          const workspace = vscode.workspace.getWorkspaceFolder(uri);
+          if (workspace) {
+            let uris = itemsByWorkspace[workspace.index];
+            if (!uris) uris = [];
+            uris.push(uri);
+            itemsByWorkspace[workspace.index] = uris;
+          }
+        });
+
+        await Promise.all(
+          itemsByWorkspace.map((workspaceItems, workspaceIndex) => DeployTools.launchDeploy(workspaceIndex, "selected", workspaceItems))
+        );
+      }),
       vscode.commands.registerCommand(`code-for-ibmi.setDeployLocation`, DeployTools.setDeployLocation)
     );
 

--- a/src/testing/deployTools.ts
+++ b/src/testing/deployTools.ts
@@ -148,6 +148,19 @@ export const DeployToolsSuite: TestSuite = {
             }
         },
         {
+            name: `Test 'Selected' deployment`, test: async () => {
+                const filesToDeploy = [
+                    fakeProject.files![1].localPath!,
+                    fakeProject.folders![0].localPath!,
+                ]
+
+                const locals = await getLocalFilesInfoForSelected(filesToDeploy);
+                const remotes = await deploy("selected", filesToDeploy);
+                assert.strictEqual(remotes.size, 4, "Expected 1 root file and 3 files from the folder to be deployed");
+                assertFilesInfoEquals(locals, remotes);
+            }
+        },
+        {
             name: `postDownload test`, test: async () => {
                 const action: Action = {
                     "name": "postDownload test",
@@ -215,7 +228,7 @@ export const DeployToolsSuite: TestSuite = {
     },
 }
 
-async function deploy(method: DeploymentMethod) {
+async function deploy(method: DeploymentMethod, selectedFiles?: vscode.Uri[]) {
     assert.ok(fakeProject.localPath, "No local path");
     assert.ok(fakeProject.remotePath, "No remote path");
     const workspaceFolder = vscode.workspace.getWorkspaceFolder(fakeProject.localPath);
@@ -227,7 +240,7 @@ async function deploy(method: DeploymentMethod) {
         `!${basename(fakeProject.localPath.path)}/**` //Allow content
     ]);
 
-    assert.ok(await DeployTools.deploy({ method, remotePath: fakeProject.remotePath, workspaceFolder, ignoreRules }), `"${method}" deployment failed`);
+    assert.ok(await DeployTools.deploy({ method, remotePath: fakeProject.remotePath, workspaceFolder, ignoreRules, selectedFiles }), `"${method}" deployment failed`);
     return await getRemoteFilesInfo();
 }
 
@@ -261,6 +274,17 @@ async function getLocalFilesInfo() {
     for await (const file of await vscode.workspace.findFiles(new vscode.RelativePattern(fakeProject.localPath!, "**/*"))) {
         const path = posix.join(basename(fakeProject.localPath!.path), posix.relative(fakeProject.localPath!.path, file.path));
         localFiles.set(path, { date: "unused", md5: VscodeTools.md5Hash(file) });
+    }
+    return localFiles;
+}
+
+async function getLocalFilesInfoForSelected(selectedFiles: vscode.Uri[]) {
+    const localFiles = await getLocalFilesInfo();
+    const selectedPaths = selectedFiles.map(file => posix.join(basename(fakeProject.localPath!.path), posix.relative(fakeProject.localPath!.path, file.path)));
+    for (const path of localFiles.keys()) {
+        if (!selectedPaths.some(selected => selected === path || path.startsWith(selected+'/'))) {
+            localFiles.delete(path);
+        }
     }
     return localFiles;
 }

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -1,5 +1,5 @@
 import { Ignore } from "ignore";
-import { WorkspaceFolder } from "vscode";
+import { Uri, WorkspaceFolder } from "vscode";
 import Instance from "./Instance";
 import { ComponentRegistry } from './api/components/manager';
 import { ConnectionManager } from "./api/configuration/config/ConnectionManager";
@@ -27,6 +27,7 @@ export interface DeploymentParameters {
   workspaceFolder: WorkspaceFolder
   remotePath: string
   ignoreRules?: Ignore
+  selectedFiles?: Uri[]
 }
 
 export * from "./api/types";


### PR DESCRIPTION
### Changes
This adds the ability to deploy selected files via the explorer context menu as suggested here #3082 

When files are selected from multiple base folders (workspaces?) it will deploy them In multiple goes. 
https://github.com/user-attachments/assets/72cead44-c242-44fb-9fed-e4903a85a4aa

If a deployment location hasn't been configured yet it prompts like normal for a location then when clicking the deploy now button it'll continue to deploy the files to the selected location.
https://github.com/user-attachments/assets/951f8c6e-8172-4446-a19f-69b7ae38c1f9

### How to test this PR
1. Add a folder to the workspace
2. Connect to the IBM i 
3. Select 1 or more files from the explorer pane
4. Right click and select "Deploy Selected Files"
5. Check the IFS browser only the selected files were uploaded

### Checklist
* [x] have tested my change
* [x] have created one or more test cases
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added