### PR TITLE
Set to bash prompt will fallback to SQL, if chsh is not installed

### DIFF
--- a/src/ui/connection.ts
+++ b/src/ui/connection.ts
@@ -116,14 +116,24 @@ export async function handleConnectionResults(connection: IBMi, error: Connectio
       window.showInformationMessage(`IBM recommends using bash as your default shell.`, `Set shell to bash`, `Read More`,).then(async choice => {
         switch (choice) {
           case `Set shell to bash`:
-            const commandSetBashResult = await connection.sendCommand({
-              command: `/QOpenSys/pkgs/bin/chsh -s /QOpenSys/pkgs/bin/bash`
-            });
-
-            if (!commandSetBashResult.stderr) {
-              window.showInformationMessage(`Shell is now bash! Reconnect for change to take effect.`);
-            } else {
-              window.showInformationMessage(`Default shell WAS NOT changed to bash.`);
+            if (connection.remoteFeatures[`chsh`]){
+              const commandSetBashResult = await connection.sendCommand({
+                command: `/QOpenSys/pkgs/bin/chsh -s /QOpenSys/pkgs/bin/bash`
+              });
+              if (!commandSetBashResult.stderr) {
+                window.showInformationMessage(`Shell is now bash! Reconnect for change to take effect.`);
+              } else {
+                window.showInformationMessage(`Default shell WAS NOT changed to bash.`);
+              }
+            }
+            else {
+              try {
+                await connection.runSQL(`CALL QSYS2.SET_PASE_SHELL_INFO('*CURRENT', '/QOpenSys/pkgs/bin/bash')`);
+                window.showInformationMessage(`Shell is now bash! Reconnect for change to take effect.`);
+              }
+              catch (e: any){
+                window.showInformationMessage(e.message);
+              }
             }
             break;
 


### PR DESCRIPTION
### Set to bash prompt will fallback to SQL, if chsh is not installed.
#2349 


### How to test this PR
Set your pase shell info to not bash. I updated my pase shell info by running this SQL statement:
`call qsys2.set_pase_shell_info('*CURRENT', '/QOpenSys/usr/bin/ksh');`

I ran the connection in the debugger and updated the `remoteFeatures['chsh']` to be undefined. I stepped through the code and saw this code run
`` await connection.runSQL(`CALL QSYS2.SET_PASE_SHELL_INFO('*CURRENT', '/QOpenSys/pkgs/bin/bash')`);``

I did not test to see what would happen if the sql statement failed.


### Checklist
<!-- Put an `x` in the relevant boxes -->
* [X] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
