### PR TITLE
feat: DedicatedJob API for companion extensions

### DIFF
--- a/src/api/DedicatedJob.ts
+++ b/src/api/DedicatedJob.ts
@@ -1,0 +1,131 @@
+import { BindingValue } from "@ibm/mapepire-js";
+import type IBMi from "./IBMi";
+import { Mapepire } from "./components/mapepire";
+import { sshSqlJob } from "./components/mapepire/sqlJob";
+import { Tools } from "./Tools";
+import { CommandResult } from "./types";
+
+/**
+ * Public interface for companion extensions to interact with a dedicated SQL job.
+ * Created via `connection.createDedicatedJob()`, this provides an isolated SQL job
+ * that preserves job-scoped IBM i state (locks, library list, temporary tables, etc.)
+ * across multiple calls.
+ *
+ * The job is automatically cleaned up on disconnect, but should be explicitly closed
+ * when no longer needed to free IBM i resources.
+ *
+ * Companion extensions can also register a DedicatedJob as the "save job" via
+ * `connection.setDedicatedSaveJob(job)`, so that member saves go through the same
+ * job that holds locks or context.
+ */
+export interface DedicatedJob {
+  /** Execute one or more SQL statements on this dedicated job. */
+  runSQL(statements: string | string[], options?: { bindings?: BindingValue[] }): Promise<Tools.DB2Row[]>;
+  /** Run a CL command on this dedicated job and return a CommandResult. */
+  runCommand(command: string): Promise<CommandResult>;
+  /** Close the dedicated job and release its IBM i resources. */
+  close(): Promise<void>;
+  /** The IBM i job identifier (e.g. "123456/USER/JOBNAME"), if available. */
+  readonly jobId?: string;
+}
+
+/**
+ * Creates a new dedicated SQL job for use by companion extensions.
+ * Wraps a Mapepire sshSqlJob with a simple public interface.
+ */
+export async function createDedicatedJob(connection: IBMi): Promise<DedicatedJob> {
+  const mapepire = connection.getComponent<Mapepire>(Mapepire.ID);
+  if (!mapepire) {
+    throw new Error(`Mapepire component not available. Cannot create dedicated job.`);
+  }
+
+  const sqlJob = await mapepire.newJob(connection);
+
+  return {
+    get jobId() {
+      return sqlJob.id;
+    },
+
+    async runSQL(statements: string | string[], options: { bindings?: BindingValue[] } = {}) {
+      return runSQLOnJob(connection, sqlJob, statements, options);
+    },
+
+    async runCommand(command: string): Promise<CommandResult> {
+      try {
+        await runSQLOnJob(connection, sqlJob, [`@${command}`]);
+        return { code: 0, stdout: '', stderr: '' };
+      } catch (error: any) {
+        return { code: 1, stdout: '', stderr: error.message || String(error) };
+      }
+    },
+
+    async close() {
+      await sqlJob.close();
+    }
+  };
+}
+
+/**
+ * Executes SQL statements and CL commands (prefixed with @) on a given SQL job.
+ * Shared execution logic between the main connection runSQL and DedicatedJob.runSQL.
+ */
+async function runSQLOnJob(connection: IBMi, sqlJob: sshSqlJob, statements: string | string[], options: { bindings?: BindingValue[] } = {}): Promise<Tools.DB2Row[]> {
+  const list = Array.isArray(statements) ? statements : statements.split(`;`).filter(x => x.trim().length > 0);
+  const lastResultSet: Tools.DB2Row[] = [];
+
+  for (const statement of list) {
+    if (statement.startsWith(`@`)) {
+      const command = statement.substring(1);
+      const log = `Running CL through SQL: ${command}\n\t`;
+      try {
+        const result = await sqlJob.execute<{ MESSAGE_ID: string, MESSAGE_TEXT: string }>(command, { isClCommand: true });
+        connection.appendOutput(`${log}-> OK${result.data.length ? "\n" + result.data.map(message => `\t[${message.MESSAGE_ID}] ${message.MESSAGE_TEXT}`).join("\n") : ''}`);
+      } catch (e: any) {
+        const error = new Tools.SqlError(e.message);
+        connection.appendOutput(`${log}-> Failed: ${error.message}`);
+
+        const jobLog = await runSQLOnJob(connection, sqlJob, `select ORDINAL_POSITION, message_id, message_text from table(qsys2.joblog_info('*')) order by ORDINAL_POSITION desc limit 5`);
+        let logs = `${log}Job log:\n`;
+        for (const row of jobLog) {
+          logs += `\t\t${row.MESSAGE_ID}: ${row.MESSAGE_TEXT}\n`;
+        }
+        connection.appendOutput(logs);
+
+        error.cause = { command, jobLog };
+        throw error;
+      }
+    } else {
+      let query;
+      let error: Tools.SqlError | undefined;
+      const log = `Running SQL query: ${statement}\n`;
+      try {
+        query = sqlJob.query<Tools.DB2Row>(statement, { parameters: options.bindings });
+        const rs = await query.execute(99999);
+        if (rs.has_results) {
+          lastResultSet.push(...rs.data);
+          connection.appendOutput(`${log}-> ${lastResultSet.length ? `${lastResultSet.length} row(s) returned` : 'no rows returned'}`);
+        } else {
+          connection.appendOutput(`${log}-> ${rs.update_count} row(s) impacted`);
+        }
+      } catch (e: any) {
+        error = new Tools.SqlError(e.message);
+        error.cause = statement;
+
+        const parts: string[] = e.message.split(`,`);
+        if (parts.length > 3) {
+          error.sqlstate = parts[parts.length - 2].trim();
+        }
+        connection.appendOutput(`${log}-> Failed: ${error.sqlstate ? `[${error.sqlstate}] ` : ''}${error.message}`);
+      } finally {
+        query?.close();
+      }
+
+      if (error) {
+        throw error;
+      }
+    }
+  }
+
+  connection.appendOutput("\n\n");
+  return lastResultSet;
+}

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -4,6 +4,7 @@ import path, { parse as parsePath } from 'path';
 import { ClientErrorExtensions } from "ssh2";
 import { EventEmitter } from 'stream';
 import { CompileTools } from "./CompileTools";
+import { createDedicatedJob, DedicatedJob } from "./DedicatedJob";
 import IBMiContent from "./IBMiContent";
 import { Tools } from './Tools';
 import { IBMiComponent } from "./components/component";
@@ -108,6 +109,9 @@ export default class IBMi {
 
   private sqlJob: sshSqlJob | undefined;
   splfUserData: string | undefined;
+
+  private dedicatedJobs: DedicatedJob[] = [];
+  private dedicatedSaveJob: DedicatedJob | undefined;
 
   /**
    * Used to store ASP numbers and their names
@@ -1171,10 +1175,47 @@ export default class IBMi {
     }
   }
 
+  /**
+   * Creates a new dedicated SQL job for use by companion extensions.
+   * The returned DedicatedJob provides an isolated IBM i job with its own
+   * job-scoped state (locks, library list, temporary tables, etc.).
+   * The job is automatically cleaned up on disconnect, but should be explicitly
+   * closed when no longer needed to free IBM i resources.
+   */
+  async createDedicatedJob(): Promise<DedicatedJob> {
+    const job = await createDedicatedJob(this);
+    this.dedicatedJobs.push(job);
+    return job;
+  }
+
+  /**
+   * Sets a dedicated job to be used for member save operations.
+   * When set, QSysFs will route member saves through this job instead of the
+   * shared connection job. Pass `undefined` to clear and revert to normal saves.
+   *
+   * This allows companion extensions to lock a member in a dedicated job and
+   * ensure saves go through the same job that holds the lock.
+   */
+  setDedicatedSaveJob(job: DedicatedJob | undefined) {
+    this.dedicatedSaveJob = job;
+  }
+
+  /**
+   * Returns the dedicated save job, if one is set.
+   */
+  getDedicatedSaveJob(): DedicatedJob | undefined {
+    return this.dedicatedSaveJob;
+  }
+
   private async dispose() {
     CompileTools.reset();
 
-    //Clear connected resources
+    for (const job of this.dedicatedJobs) {
+      try { await job.close(); } catch { }
+    }
+    this.dedicatedJobs = [];
+    this.dedicatedSaveJob = undefined;
+
     if (this.sqlJob) {
       delete this.sqlJob;
       delete this.splfUserData;

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -6,6 +6,7 @@ import tmp from 'tmp';
 import util from 'util';
 import { FilterType, parseFilter, singleGenericName } from './Filter';
 import { default as IBMi } from './IBMi';
+import { DedicatedJob } from './DedicatedJob';
 import { Tools } from './Tools';
 import { GetMemberInfo } from './components/getMemberInfo';
 import { ObjectTypes } from './import/Objects';
@@ -209,7 +210,7 @@ export default class IBMiContent {
    * @param member
    * @param content
    */
-  async uploadMemberContent(library: string, sourceFile: string, member: string, content: string | Uint8Array): Promise<boolean> {
+  async uploadMemberContent(library: string, sourceFile: string, member: string, content: string | Uint8Array, dedicatedJob?: DedicatedJob): Promise<boolean> {
     library = this.ibmi.upperCaseName(library);
     sourceFile = this.ibmi.upperCaseName(sourceFile);
     member = this.ibmi.upperCaseName(member);
@@ -233,22 +234,31 @@ export default class IBMiContent {
       if (this.ibmi.dangerousVariants && new RegExp(`[${this.ibmi.variantChars.local}]`).test(path)) {
         copyResult = { code: 0, stdout: '', stderr: '' };
         try {
-          await this.ibmi.runSQL([
+          const sqlStatements = [
             `Drop table if exists QTEMP.QTEMPSRC`,
             `@QSYS/CPYF FROMFILE(${library}/${sourceFile}) FROMMBR(${member}) TOFILE(QTEMP/QTEMPSRC) TOMBR(TEMPMEMBER) MBROPT(*REPLACE) CRTFILE(*YES)`,
             `@QSYS/CPYFRMSTMF FROMSTMF('${tempRmt}') TOMBR('${Tools.qualifyPath("QTEMP", "QTEMPSRC", "TEMPMEMBER", undefined)}') MBROPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`,
             `@QSYS/CPYF FROMFILE(QTEMP/QTEMPSRC) FROMMBR(TEMPMEMBER) TOFILE(${library}/${sourceFile}) TOMBR(${member}) MBROPT(*REPLACE)`
-          ]);
+          ];
+          if (dedicatedJob) {
+            await dedicatedJob.runSQL(sqlStatements);
+          } else {
+            await this.ibmi.runSQL(sqlStatements);
+          }
         } catch (error: any) {
           copyResult.code = -1;
           copyResult.stderr = String(error);
         }
       }
       else {
-        copyResult = await this.ibmi.runCommand({
-          command: `QSYS/CPYFRMSTMF FROMSTMF('${tempRmt}') TOMBR('${path}') MBROPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`,
-          noLibList: true
-        });
+        if (dedicatedJob) {
+          copyResult = await dedicatedJob.runCommand(`QSYS/CPYFRMSTMF FROMSTMF('${tempRmt}') TOMBR('${path}') MBROPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`);
+        } else {
+          copyResult = await this.ibmi.runCommand({
+            command: `QSYS/CPYFRMSTMF FROMSTMF('${tempRmt}') TOMBR('${path}') MBROPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`,
+            noLibList: true
+          });
+        }
       }
 
       if (copyResult.code === 0) {

--- a/src/filesystems/qsys/QSysFs.ts
+++ b/src/filesystems/qsys/QSysFs.ts
@@ -218,11 +218,12 @@ export class QSysFS implements vscode.FileSystemProvider {
             }
             else {
                 this.savedAsMembers.delete(uri.path);
+                const dedicatedSaveJob = connection.getDedicatedSaveJob();
                 if (this.extendedMemberSupport) {
-                    await this.extendedContent.uploadMemberContentWithDates(uri, content.toString());
+                    await this.extendedContent.uploadMemberContentWithDates(uri, content.toString(), dedicatedSaveJob);
                 } else {
                     await warnAboutSourceDates();
-                    await contentApi.uploadMemberContent(library, file, member, content);
+                    await contentApi.uploadMemberContent(library, file, member, content, dedicatedSaveJob);
                 }
             }
         }

--- a/src/filesystems/qsys/extendedContent.ts
+++ b/src/filesystems/qsys/extendedContent.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import tmp from "tmp";
 import util from "util";
 import vscode from "vscode";
+import { DedicatedJob } from "../../api/DedicatedJob";
 import { instance } from "../../instantiate";
 import { getAliasName, SourceDateHandler } from "./sourceDateHandler";
 
@@ -99,7 +100,7 @@ export class ExtendedIBMiContent {
    * @param {vscode.Uri} uri
    * @param {string} body 
    */
-  async uploadMemberContentWithDates(uri: vscode.Uri, body: string) {
+  async uploadMemberContentWithDates(uri: vscode.Uri, body: string, dedicatedJob?: DedicatedJob) {
     const connection = instance.getConnection();
     if (connection) {
       const config = connection.getConfig();
@@ -171,13 +172,20 @@ export class ExtendedIBMiContent {
           await connection.sendCommand({ command: `${setccsid} 1208 ${tempRmt}` });
         }
 
-        const insertResult = await connection.runCommand({
-          command: `QSYS/RUNSQLSTM SRCSTMF('${tempRmt}') COMMIT(*NONE) NAMING(*SQL)`,
-          noLibList: true
-        });
+        if (dedicatedJob) {
+          const insertResult = await dedicatedJob.runCommand(`QSYS/RUNSQLSTM SRCSTMF('${tempRmt}') COMMIT(*NONE) NAMING(*SQL)`);
+          if (insertResult.code !== 0) {
+            throw new Error(`Failed to save member: ` + insertResult.stderr);
+          }
+        } else {
+          const insertResult = await connection.runCommand({
+            command: `QSYS/RUNSQLSTM SRCSTMF('${tempRmt}') COMMIT(*NONE) NAMING(*SQL)`,
+            noLibList: true
+          });
 
-        if (insertResult.code !== 0) {
-          throw new Error(`Failed to save member: ` + insertResult.stderr);
+          if (insertResult.code !== 0) {
+            throw new Error(`Failed to save member: ` + insertResult.stderr);
+          }
         }
 
         this.sourceDateHandler.baseSource.set(alias, body);

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -31,4 +31,5 @@ export interface DeploymentParameters {
 
 export * from "./api/types";
 export * from "./ui/types";
+export type { DedicatedJob } from "./api/DedicatedJob";
 


### PR DESCRIPTION
### Changes

Adds a public `DedicatedJob` API that allows companion extensions to create persistent, isolated IBM i jobs through Mapepire.

#### Context

This addresses a recurring need discussed in:
- [discussions/2468](https://github.com/codefori/vscode-ibmi/discussions/2468) — Member Lock
- [discussions/3132](https://github.com/orgs/codefori/discussions/3132) — A way to lock member after opening

In both discussions, @sebjulliand identified the core limitation: _"ALCOBJ would not even be an option since commands executed from SSH are run in non-persistent jobs"_ ([#2468](https://github.com/orgs/codefori/discussions/2468#discussioncomment-11875855)) and _"Since the jobs running commands and queries are not persisted, members can't be locked. But when Mapepire will be integrated (starting with v3), this may become possible."_ ([#3132](https://github.com/orgs/codefori/discussions/3132)).

Mapepire is now integrated. This PR leverages it to provide exactly that capability — persistent jobs that companion extensions can use through the public API.

#### Why a generic DedicatedJob API instead of a built-in lock mechanism

Rather than implementing a specific lock policy inside Code for IBM i, this provides the underlying execution model that makes locking (and many other workflows) possible. A dedicated job persists for the lifetime of the connection, so:

- **Member locking** — `ALCOBJ`/`DLCOBJ` work because the lock lives in the job that holds it, and saves go through that same job
- **SEU-style validation programs** — open/close programs can run in the same job context
- **Job-scoped state** — library lists, temporary tables in QTEMP, open cursors, and other job-level resources are preserved across operations
- **Stateful workflows** — sequences of dependent CL commands that must share execution context

This means anyone who needs a custom locking or validation workflow can build a companion extension on top of this API, without requiring changes to Code for IBM i itself. The extension doesn't impose any policy — it only provides the persistent job capability that IBM i workflows depend on.

#### What changed

**New file:**
- `src/api/DedicatedJob.ts` — `DedicatedJob` interface (`runSQL`, `runCommand`, `close`, `jobId`) and `createDedicatedJob()` factory

**Modified files:**
- `src/api/IBMi.ts` — `createDedicatedJob()`, `setDedicatedSaveJob()`, `getDedicatedSaveJob()`, cleanup in `dispose()`
- `src/api/IBMiContent.ts` — `uploadMemberContent()` accepts optional `DedicatedJob` to route saves through the dedicated job
- `src/filesystems/qsys/extendedContent.ts` — `uploadMemberContentWithDates()` accepts optional `DedicatedJob`
- `src/filesystems/qsys/QSysFs.ts` — `writeFile()` passes the dedicated save job to content methods
- `src/typings.ts` — exports `DedicatedJob` type

**Design decisions:**
- No UI changes, no new settings, no schema changes — purely a programmatic API for extensions
- When no `DedicatedJob` is set, behavior is identical to current code (zero impact on existing users)
- All dedicated jobs are automatically cleaned up on disconnect
- The `runCommand()` method routes CL through the Mapepire SQL job (same pattern as `CompileTools.runCommand` for ILE), keeping everything in the same persistent job
- `setDedicatedSaveJob()` allows a companion extension to route member saves through its job, which is essential for lock-based workflows where the save must happen in the same job that holds the lock

#### API usage by companion extensions

```ts
const connection = instance.getConnection();

// Create an isolated persistent job
const job = await connection.createDedicatedJob();

// Run CL in the persistent job — the lock stays alive because the job persists
await job.runCommand('ALCOBJ OBJ((LIB/FILE *FILE *EXCLRD MBR1))');

// Route member saves through this job so saves respect the lock
connection.setDedicatedSaveJob(job);

// ... user edits and saves members normally in VS Code ...

// When done, release and clean up
await job.runCommand('DLCOBJ OBJ((LIB/FILE *FILE *EXCLRD MBR1))');
connection.setDedicatedSaveJob(undefined);
await job.close();
```

### How to test this PR

1. Build the extension (`npm run webpack-dev`)
2. Verify existing member save functionality works unchanged (no `DedicatedJob` set = same behavior as before)
3. For full testing with a companion extension, create a dedicated job via the API and verify:
   - `job.runSQL()` executes SQL in its own isolated job
   - `job.runCommand()` executes CL commands in the same job
   - `connection.setDedicatedSaveJob(job)` routes member saves through the dedicated job
   - `job.close()` properly ends the IBM i job
   - Disconnecting cleans up all dedicated jobs automatically

### Checklist

* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
