### PR TITLE
fix: clear stale gutter decorations on toggle and nudge ruler redraw Fixes issue #489

### DIFF
--- a/src/filesystems/qsys/sourceDateHandler.ts
+++ b/src/filesystems/qsys/sourceDateHandler.ts
@@ -235,6 +235,7 @@ export class SourceDateHandler {
           const activeEditor = vscode.window.activeTextEditor;
           if (activeEditor && activeEditor.document.uri.fsPath === document.uri.fsPath) {
             activeEditor.setDecorations(annotationDecoration, lineGutters);
+            activeEditor.setDecorations(lineDecor, []);
           }
 
         } else if (sourceDates) {
@@ -315,6 +316,12 @@ export class SourceDateHandler {
             activeEditor.setDecorations(lineDecor, changedLined);
           }
         }
+      } else {
+        const activeEditor = vscode.window.activeTextEditor;
+        if (activeEditor && activeEditor.document.uri.fsPath === document.uri.fsPath) {
+          activeEditor.setDecorations(annotationDecoration, []);
+          activeEditor.setDecorations(lineDecor, []);
+        }
       }
     }
   }
@@ -370,6 +377,10 @@ export class SourceDateHandler {
       const editor = vscode.window.activeTextEditor;
       if (editor) {
         this._diffRefreshGutter(editor.document);
+        // Reassigning the selection fires onDidChangeTextEditorSelection, which
+        // causes other extensions (e.g. the RPGLE fixed-format ruler) to redraw
+        // in the updated decoration context rather than bleeding into the gutter.
+        editor.selection = editor.selection;
       }
     }
   }

--- a/src/filesystems/qsys/sourceDateHandler.ts
+++ b/src/filesystems/qsys/sourceDateHandler.ts
@@ -123,7 +123,15 @@ export class SourceDateHandler {
       if (document.uri.scheme === `member`) {
         clearTimeout(this.timeout);
         this.timeout = setTimeout(() => this._diffChangeTimeout(document), this.timeoutDelay);
-        this._diffOnDidChange(event);
+        if (document.isDirty) {
+          this._diffOnDidChange(event);
+        } else if (event.contentChanges.length > 0) {
+          // Document is clean but has content changes — this is an external reload
+          // (e.g. the member was edited on the host via SEU while open in VS Code).
+          // readFile() already re-downloaded the source dates, so we just need to
+          // redraw the gutter with the fresh baseDates.
+          this._deferredRefreshGutter(document);
+        }
       }
     }
   }


### PR DESCRIPTION
Three issues caused the source date gutter to remain visible after being toggled off, and the RPGLE fixed-format ruler to misalign when the gutter was re-enabled on a different member:

1. Decorations never cleared on toggle-off _diffRefreshGutter only painted decorations inside the 'if (config.sourceDateGutter)' block. When the gutter was toggled off the block was skipped entirely, leaving stale 'before:' content on the editor. Added an else branch that explicitly calls setDecorations(annotationDecoration, []) and setDecorations(lineDecor, []) so the gutter is visually cleared immediately.

2. lineDecor leaked into sequence-numbers view The shouldShowSequences branch never cleared lineDecor (the line- highlight background) when switching from the date view. Added an explicit setDecorations(lineDecor, []) there as well.

3. RPGLE fixed-format ruler misalignment after toggle The RPGLE extension (halcyontechltd.vscode-rpgle) redraws its fixed-format column ruler only inside onDidChangeTextEditorSelection. Toggling our gutter does not fire that event, so the ruler stayed painted from its previous context and bled into or out of the gutter area. After calling _diffRefreshGutter in toggleSourceDateGutter we now reassign editor.selection = editor.selection, which VS Code treats as a selection change and fires the event, causing the RPGLE extension to redraw the ruler in the updated decoration context.

### Changes
Fixes a rendering issue where the source date gutter remained visible after being toggled off, and where toggling the gutter caused the RPGLE fixed-format column ruler to misalign.

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [ ] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
