### PR TITLE
Plugin extended to support &GRANDPARENT as a variable in local actions.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,3 +71,4 @@ Thanks so much to everyone [who has contributed](https://github.com/codefori/vsc
 * [@jman116](https://github.com/jman116)
 * [@Mohammed-Yaseen-Ali-2081](https://github.com/Mohammed-Yaseen-Ali-2081)
 * [@SamJessep](https://github.com/SamJessep)
+* [@LuGe00](https://github.com/LuGe00)

--- a/src/editors/actionEditor.ts
+++ b/src/editors/actionEditor.ts
@@ -175,6 +175,7 @@ export function getVariablesInfo(): VariableInfoList {
       { name: `&amp;FULLPATH`, text: vscode.l10n.t(`Full path of the file on the remote system`) },
       { name: `&amp;FILEDIR`, text: vscode.l10n.t(`Directory of the file on the remote system`) },
       { name: `&amp;RELATIVEPATH`, text: vscode.l10n.t(`Relative path of the streamfile from the working directory or workspace`) },
+      { name: `&amp;GRANDPARENT`, text: vscode.l10n.t(`Name of the grandparent directory (two levels up from the file)`) },
       { name: `&amp;PARENT`, text: vscode.l10n.t(`Name of the parent directory or source file`) },
       { name: `&amp;BASENAME`, text: vscode.l10n.t(`Name of the file, including the extension`) },
       { name: `&amp;NAME`, text: vscode.l10n.t(`Name of the file (<code>&amp;NAMEL</code> for lowercase)`) },

--- a/src/testing/action.ts
+++ b/src/testing/action.ts
@@ -275,6 +275,53 @@ export const ActionSuite: TestSuite = {
         const success = await runAction(instance, uris, action, `compare`);
         assert.ok(success);
       }
+    },
+    {
+      name: "Grandparent variable expansion for local file action", test: async () => {
+        const localRoot = helloWorldProject.localPath!;
+        const grandparent = `gp${Tools.makeid(4).toLowerCase()}`;
+        const parent = `pa${Tools.makeid(4).toLowerCase()}`;
+
+        const parentFolder = vscode.Uri.joinPath(localRoot, grandparent, parent);
+        const nestedFile = vscode.Uri.joinPath(parentFolder, `grandparent_local.txt`);
+
+        await vscode.workspace.fs.createDirectory(parentFolder);
+        await vscode.workspace.fs.writeFile(nestedFile, Buffer.from("grandparent test", "utf8"));
+
+        const success = await runAction(instance, nestedFile, {
+          name: "Check local &GRANDPARENT",
+          command: `test "&GRANDPARENT" = "${grandparent}"`,
+          type: "file",
+          environment: "pase"
+        }, "all");
+
+        assert.ok(success);
+      }
+    },
+    {
+      name: "Grandparent variable expansion for streamfile action", test: async () => {
+        const connection = instance.getConnection()!;
+        const content = connection.getContent();
+
+        await connection.withTempDirectory(async directory => {
+          const grandparent = `gp${Tools.makeid(4).toLowerCase()}`;
+          const parent = `pa${Tools.makeid(4).toLowerCase()}`;
+          const remoteFolder = `${directory}/${grandparent}/${parent}`;
+          const remoteFile = `${remoteFolder}/grandparent_stream.txt`;
+
+          await connection.sendCommand({ command: `mkdir -p ${remoteFolder}` });
+          await content.writeStreamfileRaw(remoteFile, "grandparent test");
+
+          const success = await runAction(instance, vscode.Uri.parse(`streamfile:${remoteFile}`), {
+            name: "Check streamfile &GRANDPARENT",
+            command: `test "&GRANDPARENT" = "${grandparent}"`,
+            type: "streamfile",
+            environment: "pase"
+          }, "all");
+
+          assert.ok(success);
+        });
+      }
     }
   ]
 };

--- a/src/ui/actions.ts
+++ b/src/ui/actions.ts
@@ -205,6 +205,7 @@ export async function runAction(instance: Instance, uris: vscode.Uri | vscode.Ur
                 const basename = pathData.base;
                 const ext = pathData.ext ? (pathData.ext.startsWith(`.`) ? pathData.ext.substring(1) : pathData.ext) : ``;
                 const parent = path.parse(pathData.dir).base;
+                const grandparent = path.parse(path.parse(pathData.dir).dir).base;
                 let name = pathData.name;
 
                 // Logic to handle second extension, caused by TOBi.
@@ -260,7 +261,8 @@ export async function runAction(instance: Instance, uris: vscode.Uri | vscode.Ur
                     break;
                 }
 
-                variables.set(`&PARENT`, parent)
+                variables.set(`&GRANDPARENT`, grandparent)
+                  .set(`&PARENT`, parent)
                   .set(`&BASENAME`, basename)
                   .set(`{filename}`, basename)
 


### PR DESCRIPTION
[### Changes
<!-- Describe your change here. -->
Plugin extended to support Grandparent as a variable in local actions
### How to test this PR
<!-- 
Example:
1. Insert &GRANDPARENT as a variable in local actions.json and check if after executing the action it gets correctly translated to the directory name of the parent of parent

Example:
Inside .vscode/actions.json i created this action
{
    "name": "Create RPGLE Program and update source member",
    "command": "CRTBNDRPG PGM(&CURLIB/&NAME) SRCSTMF('&RELATIVEPATH') OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTCCSID(*JOB) \n CPYFRMSTMF FROMSTMF('&FULLPATH') TOMBR('/QSYS.LIB/&GRANDPARENT.LIB/&PARENT.FILE/&NAME.MBR') MBROPT(*REPLACE) CVTDTA(*AUTO) DBFCCSID(273)",
    "deployFirst": true,
    "environment": "ile",
    "extensions": [
      "RPGLE"
    ]
  }
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [X] have tested my change
* [X] have created one or more test cases
* [X] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
]