### PR TITLE
Always clear mapepire spooled files if not generated by an action

### DIFF
--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -25,7 +25,7 @@ export namespace CompileTools {
     updateProgress?: (message: string) => void
   }
 
-  export function reset(){
+  export function reset() {
     ileQueue.clear();
     jobLogOrdinal = 0;
   }
@@ -159,11 +159,9 @@ export namespace CompileTools {
                   commandResult.code = 2;
                   callbacks.onStderr?.(Buffer.from(`Failed to get spool output: ${JSON.stringify(e, undefined, 2)}`));
                 }
-                finally {
-                  if (!connection.getConfig().keepActionSpooledFiles) {
-                    await connection.runSQL(`@DLTSPLF FILE(*SELECT) SELECT(*CURRENT *ALL *ALL ${connection.splfUserData})`);
-                  }
-                }
+              }
+              if (!start || !connection.getConfig().keepActionSpooledFiles) {
+                await connection.runSQL(`@DLTSPLF FILE(*SELECT) SELECT(*CURRENT *ALL *ALL ${connection.splfUserData})`);
               }
             });
 


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Initially reported by Ricky Thompson on Zulip.

Some commands run internally by Code for i may generate a spooled file that will not be deleted after the command has run.

For example, if source date support is enabled, since saving a source member is performed using `RUNSQLTM`, it will leave a spooled file:
<img width="637" height="98" alt="image" src="https://github.com/user-attachments/assets/c56b26b0-8d7d-4588-9eb2-bd28efc46fb9" />

This PR forces the spooled file generated from Mapepire to always be deleted, unless the command the spooled file must be kept (i.e. "Keep actions splooed file" is enabled in the settings)

### How to test this PR
#### Before the PR
1. Make sure source date support is enabled
2. Open a member
3. Save it
4. Open your spooled files list (either from WRKSPLF or using an extension)
5. There must be a `VSCODETEMP` spooled file

#### After the PR
Saving a member with source date support enabled will not leave a `VSCODETEMP` spooled file.


### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change