### PR TITLE
Remove chsh check around updating a users default shell to bash

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -704,11 +704,8 @@ export default class IBMi {
 
           if (!commandShellResult.stderr) {
             let usesBash = this.shell === IBMi.bashShellPath;
-            if (!usesBash) {
-              // make sure chsh is installed
-              if (this.remoteFeatures[`chsh`]) {
-                callbacks.uiErrorHandler(this, `default_not_bash`);
-              }
+            if (!usesBash) {              
+              callbacks.uiErrorHandler(this, `default_not_bash`);
             }
 
             if (usesBash) {


### PR DESCRIPTION
### Changes
Since pr #3131 allows us to fallback on SQL to set bash as default shell. We no longer need to check for chsh to be installed before throwing the `default_not_bash` connection error code

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [X] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
