### PR TITLE
Test with ssh key

### DIFF
--- a/src/api/tests/.env.sample
+++ b/src/api/tests/.env.sample
@@ -4,3 +4,6 @@ VITE_DB_PASS=
 VITE_DB_PORT=22
 VITE_TEMP_LIB=
 #VITE_CONNECTION_TIMEOUT=25000
+# SSH Key authentication (optional - leave VITE_DB_PASS empty if using key)
+#VITE_PRIVATE_KEY_PATH=~/.ssh/id_rsa
+#VITE_PASSPHRASE=

--- a/src/api/tests/connection.ts
+++ b/src/api/tests/connection.ts
@@ -14,13 +14,13 @@ const testConfig = new JSONConfig();
 
 export const CONNECTION_TIMEOUT = process.env.VITE_CONNECTION_TIMEOUT ? parseInt(process.env.VITE_CONNECTION_TIMEOUT) : 25000;
 
-if (!process.env.VITE_SERVER || !process.env.VITE_DB_USER || !process.env.VITE_DB_PASS) {
+if (!process.env.VITE_SERVER || !process.env.VITE_DB_USER) {
   const messages = [
     ``,
     `Please set the environment variables:`,
     `\tVITE_SERVER`,
     `\tVITE_DB_USER`,
-    `\tVITE_DB_PASS`,
+    `\tVITE_DB_PASS (or VITE_PRIVATE_KEY_PATH for SSH key authentication)`,
     `\tVITE_DB_PORT`,
     ``,
     `If you're a developer, make a copy of .env.sample,`,
@@ -33,10 +33,28 @@ if (!process.env.VITE_SERVER || !process.env.VITE_DB_USER || !process.env.VITE_D
   process.exit(1);
 }
 
+// Validate that either password or private key is provided
+if (!process.env.VITE_DB_PASS && !process.env.VITE_PRIVATE_KEY_PATH) {
+  const messages = [
+    ``,
+    `Authentication error: You must provide either:`,
+    `\tVITE_DB_PASS (for password authentication)`,
+    `\tOR`,
+    `\tVITE_PRIVATE_KEY_PATH (for SSH key authentication)`,
+    ``,
+  ];
+
+  console.log(messages.join(`\n`));
+
+  process.exit(1);
+}
+
 const ENV_CREDS = {
   host: process.env.VITE_SERVER,
   username: process.env.VITE_DB_USER,
   password: process.env.VITE_DB_PASS,
+  privateKeyPath: process.env.VITE_PRIVATE_KEY_PATH,
+  passphrase: process.env.VITE_PASSPHRASE,
   port: parseInt(process.env.VITE_DB_PORT || `22`),
   tempLibrary: process.env.VITE_TEMP_LIB || 'ILEDITOR'
 }
@@ -108,7 +126,7 @@ export async function newConnection(reloadSettings?: boolean) {
 
 export async function disposeConnection(connection?: IBMi) {
   if (connection) {
-    await connection.dispose();
+    connection.disconnect();
     testStorage.save();
     testConfig.save();
   }


### PR DESCRIPTION
### Changes
This PR allows testing using ssh private key instead of user's password

### How to test this PR

1. add the **VITE_PRIVATE_KEY_PATH** directive that specifies your private key path inside your **.env** file (see **.env.sample**)
2. run `npm run test`

### Checklist
* [X] have tested my change

